### PR TITLE
Moebius v2: sealed-bid escrow replaces honor-system tax (10/10 tests)

### DIFF
--- a/onchain/MOEBIUS_V2_NOTES.md
+++ b/onchain/MOEBIUS_V2_NOTES.md
@@ -1,0 +1,56 @@
+# Moebius v2 — Sealed-Bid Rewrite (2026-07-17)
+
+## Why the rewrite
+
+v1's tax was levied on the searcher's **self-declared** `expectedProfit`, enforced
+only by sniffing the hook's own token balance before/after. Two fatal problems:
+
+1. **Honor system**: declare 1 wei, pay dust, keep the arb. No competition = no tax.
+2. **Griefable accounting**: anyone could dust the hook with the real asset and
+   distort `balanceBefore`, DoS-ing `executeMEV` or corrupting tax math.
+
+## What changed
+
+| Area | v1 | v2 |
+|---|---|---|
+| Tax basis | Declared `expectedProfit` | Hard **escrowed bid**, pulled upfront via transferFrom / msg.value |
+| Enforcement | Balance sniffing | Deterministic split of escrow: 80% LP donation / 20% treasury |
+| Under-declaration | Possible | Meaningless — the bid IS the tax; searchers compete on bid size |
+| Policy rate | None | `minBidBps` floor: bid >= flashAmount * rate (scales with capital used) |
+| Swap fee | N/A | `setPoolSwapFee` — hook owns dynamic-fee pMEV pools (lever #2) |
+| Pool config | Static fee | **Dynamic fee flag (0x800000) required** — zero-flag hooks are only valid with dynamic fee pools |
+| Deployment | Not specified | CREATE2 salt mining for zero lower-14 flag bits + nonce prediction for the pMEV/hook circular dependency |
+| Reentrancy | Transient guard on entry | Same + typed unlock actions (MEV / SEED), nested-unlock payload revalidation |
+| FoT tokens | Unhandled | Rejected at escrow (`FeeOnTransferNotSupported`) |
+
+Also new: `seedLiquidity` — the central-bank desk. The hook flash-mints pMEV
+inventory and pairs it with the owner's real asset into an LP position the hook
+owns. This is what gives pMEV a price and searchers a venue. Unabsorbed pMEV is
+burned; unspent real asset is refunded.
+
+## Test results (forge test, solc 0.8.26, cancun)
+
+10/10 passing, including:
+- full cycle: flash mint -> pool sell -> rebuy -> burn -> 20/80 bid split
+- bid below policy floor reverts
+- non-returning searcher: entire tx reverts, escrow returned (atomicity)
+- reentrant executeMEV blocked
+- only hook can mint/burn pMEV
+- admin gates on policy rate / rescue
+
+## Activation runbook
+
+1. `forge script script/DeployMoebius.s.sol --rpc-url $BASE_RPC --broadcast --verify`
+   (env: DEPLOYER_PRIVATE_KEY, POOL_MANAGER=0x498581fF718922c3f8e6A244956aF099B2652b2b,
+   TREASURY, MIN_BID_BPS)
+2. Initialize pMEV/<realAsset> pool: `fee = 0x800000`, `hooks = <hook>`, chosen tickSpacing.
+3. Owner: `setPoolSwapFee(key, fee)`.
+4. Owner: `seedLiquidity(key, tickLower, tickUpper, liquidity, maxReal, amountPmev)`.
+5. Ship a reference searcher (see test/mocks/MockSearcher.sol for the settlement pattern).
+
+## Still open before mainnet funds
+
+- External audit (this is a reserve-holding contract).
+- `owner` should be a multisig, not an EOA.
+- Native-asset (ETH) realAsset path is implemented but only ERC20 is covered in tests.
+- Donate reverts if the pool has no in-range liquidity at current tick — keep seed range wide.

--- a/onchain/script/DeployMoebius.s.sol
+++ b/onchain/script/DeployMoebius.s.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
+import {PhantomCreditToken} from "../src/hooks/PhantomCreditToken.sol";
+import {MoebiusMEVHook} from "../src/hooks/MoebiusMEVHook.sol";
+
+/// @title DeployMoebius
+/// @notice One-command activation of the Moebius central-bank stack.
+///
+///         Resolves two hard constraints at once:
+///         1. Circular dependency: pMEV immutably stores the hook address,
+///            the hook immutably stores the pMEV address.
+///         2. PoolManager requires a flag-less hook (zero callbacks) to sit at
+///            an address with ZERO set bits in the lower 14 hook-flag bits.
+///
+///         Solution: predict pMEV's CREATE address from the deployer nonce,
+///         then mine a CREATE2 salt for the hook (~16k iterations, seconds).
+///
+///         Env required:
+///           DEPLOYER_PRIVATE_KEY  uint
+///           POOL_MANAGER          address (Base: 0x498581fF718922c3f8e6A244956aF099B2652b2b)
+///           TREASURY              address
+///           MIN_BID_BPS           uint    (policy rate floor, e.g. 50 = 0.5%)
+///
+///         Run:
+///           forge script script/DeployMoebius.s.sol --rpc-url $BASE_RPC \
+///             --broadcast --verify --etherscan-api-key $BASESCAN_KEY
+contract DeployMoebius is Script {
+    uint160 internal constant ALL_HOOK_MASK = 0x3FFF;
+
+    function run() external returns (PhantomCreditToken pToken, MoebiusMEVHook hook, bytes32 salt) {
+        uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerKey);
+        address poolManager = vm.envAddress("POOL_MANAGER");
+        address treasury = vm.envAddress("TREASURY");
+        uint256 minBidBps = vm.envUint("MIN_BID_BPS");
+
+        // 1. pMEV will deploy via CREATE at the deployer's next nonce
+        address predictedPToken = vm.computeCreateAddress(deployer, vm.getNonce(deployer));
+
+        // 2. Mine a salt giving the hook a zero-flag address
+        bytes32 initHash = keccak256(
+            abi.encodePacked(
+                type(MoebiusMEVHook).creationCode, abi.encode(poolManager, predictedPToken, treasury, minBidBps)
+            )
+        );
+        address predictedHook;
+        for (uint256 i = 0;; i++) {
+            salt = bytes32(i);
+            predictedHook = vm.computeCreate2Address(salt, initHash, deployer);
+            if (uint160(predictedHook) & ALL_HOOK_MASK == 0) break;
+        }
+        console2.log("Mined salt:", vm.toString(salt));
+
+        // 3. Deploy
+        vm.startBroadcast(deployerKey);
+        pToken = new PhantomCreditToken(predictedHook);
+        require(address(pToken) == predictedPToken, "nonce drifted - aborting");
+        hook = new MoebiusMEVHook{salt: salt}(IPoolManager(poolManager), address(pToken), treasury, minBidBps);
+        require(address(hook) == predictedHook, "CREATE2 drifted - aborting");
+        vm.stopBroadcast();
+
+        console2.log("PhantomCreditToken (pMEV):", address(pToken));
+        console2.log("MoebiusMEVHook           :", address(hook));
+        console2.log("Policy rate (minBidBps)  :", minBidBps);
+        console2.log("NEXT STEPS:");
+        console2.log("  1. initialize pMEV/<realAsset> pool with fee=0x800000 (dynamic), hooks=hook");
+        console2.log("  2. owner: setPoolSwapFee(key, fee) then seedLiquidity(key, ...)");
+        console2.log("  3. point searcher bots at executeMEV()");
+    }
+}

--- a/onchain/script/InitializeMoebiusPool.s.sol
+++ b/onchain/script/InitializeMoebiusPool.s.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "v4-core/src/types/PoolKey.sol";
+import {Currency} from "v4-core/src/types/Currency.sol";
+import {IHooks} from "v4-core/src/interfaces/IHooks.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IMoebiusHook {
+    function pToken() external view returns (address);
+    function setPoolSwapFee(PoolKey calldata key, uint24 newFee) external;
+    function seedLiquidity(
+        PoolKey calldata key, int24 tickLower, int24 tickUpper, uint256 liquidity, uint256 maxReal, uint256 amountPmev
+    ) external payable;
+}
+
+/// @title InitializeMoebiusPool
+/// @notice Second (and final) activation step after DeployMoebius:
+///         initializes the pMEV/<realAsset> pool, sets the swap fee (policy
+///         lever #2), and seeds the redemption window (central bank balance sheet).
+///
+///         Env: DEPLOYER_PRIVATE_KEY, POOL_MANAGER, HOOK, REAL_ASSET (0x0 = native ETH),
+///         SQRT_PRICE_X96 (1:1 = 79228162514264337593543950336), TICK_SPACING, SWAP_FEE,
+///         TICK_LOWER, TICK_UPPER, LIQUIDITY, MAX_REAL, AMOUNT_PMEV
+///
+///         Run: forge script script/InitializeMoebiusPool.s.sol --rpc-url $BASE_RPC --broadcast
+contract InitializeMoebiusPool is Script {
+    uint24 internal constant DYNAMIC_FEE = 0x800000;
+
+    struct Cfg {
+        address poolManager;
+        address hook;
+        address realAsset;
+        uint160 sqrtPriceX96;
+        int24 tickSpacing;
+        uint24 swapFee;
+        int24 tickLower;
+        int24 tickUpper;
+        uint256 liquidity;
+        uint256 maxReal;
+        uint256 amountPmev;
+    }
+
+    function run() external returns (PoolKey memory key) {
+        uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        Cfg memory c = _loadCfg();
+
+        address pToken = IMoebiusHook(c.hook).pToken();
+
+        // Currency sorting: address(0) (native) sorts first
+        bool pTokenIs0 = pToken == address(0) || (c.realAsset != address(0) && pToken < c.realAsset);
+        key = PoolKey({
+            currency0: Currency.wrap(pTokenIs0 ? pToken : c.realAsset),
+            currency1: Currency.wrap(pTokenIs0 ? c.realAsset : pToken),
+            fee: DYNAMIC_FEE,
+            tickSpacing: c.tickSpacing,
+            hooks: IHooks(c.hook)
+        });
+
+        vm.startBroadcast(deployerKey);
+
+        IPoolManager(c.poolManager).initialize(key, c.sqrtPriceX96);
+        IMoebiusHook(c.hook).setPoolSwapFee(key, c.swapFee);
+
+        if (c.realAsset == address(0)) {
+            IMoebiusHook(c.hook).seedLiquidity{value: c.maxReal}(
+                key, c.tickLower, c.tickUpper, c.liquidity, c.maxReal, c.amountPmev
+            );
+        } else {
+            IERC20(c.realAsset).approve(c.hook, c.maxReal);
+            IMoebiusHook(c.hook).seedLiquidity(key, c.tickLower, c.tickUpper, c.liquidity, c.maxReal, c.amountPmev);
+        }
+
+        vm.stopBroadcast();
+
+        console2.log("Pool initialized. pMEV:", pToken, "realAsset:", c.realAsset);
+        console2.log("Swap fee:", c.swapFee, "| liquidity:", c.liquidity);
+        console2.log("ACTIVATED. Searchers can now call executeMEV().");
+    }
+
+    function _loadCfg() internal returns (Cfg memory c) {
+        c.poolManager = vm.envAddress("POOL_MANAGER");
+        c.hook = vm.envAddress("HOOK");
+        c.realAsset = vm.envAddress("REAL_ASSET");
+        c.sqrtPriceX96 = uint160(vm.envUint("SQRT_PRICE_X96"));
+        c.tickSpacing = int24(int256(vm.envInt("TICK_SPACING")));
+        c.swapFee = uint24(vm.envUint("SWAP_FEE"));
+        c.tickLower = int24(int256(vm.envInt("TICK_LOWER")));
+        c.tickUpper = int24(int256(vm.envInt("TICK_UPPER")));
+        c.liquidity = vm.envUint("LIQUIDITY");
+        c.maxReal = vm.envUint("MAX_REAL");
+        c.amountPmev = vm.envUint("AMOUNT_PMEV");
+    }
+}

--- a/onchain/src/hooks/AutoCapitalizeMonetizeHook.sol
+++ b/onchain/src/hooks/AutoCapitalizeMonetizeHook.sol
@@ -1,44 +1,252 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-// AutoCapitalizeMonetizeHook.sol
-// Fees from looped/yield pools auto-route to SINC treasury, buyback, LP deepen, agent rewards.
-// Closes the create->optimize->monetize->capitalize->market% loop onchain.
-// 24/7 accountability via events. Production: Timelock for fee splits, SINC burn on monetize.
-
- import {BaseLendingLoopHookContainer} from "./BaseLendingLoopHookContainer.sol";
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
-import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
-import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
+import {IHooks} from "v4-core/src/interfaces/IHooks.sol";
+import {Hooks} from "v4-core/src/libraries/Hooks.sol";
+import {PoolKey} from "v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/src/types/PoolId.sol";
+import {Currency, CurrencyLibrary} from "v4-core/src/types/Currency.sol";
+import {BalanceDelta} from "v4-core/src/types/BalanceDelta.sol";
+import {ModifyLiquidityParams, SwapParams} from "v4-core/src/types/PoolOperation.sol";
+import {BeforeSwapDelta} from "v4-core/src/types/BeforeSwapDelta.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-contract AutoCapitalizeMonetizeHook is BaseLendingLoopHookContainer {
+/// @title AutoCapitalizeMonetizeHook (v2, standalone)
+/// @notice Replaces the non-compiling v1 sketch. Captures a protocol fee on every
+///         swap via the afterSwap return-delta, banks it as real tokens held by
+///         this contract, and splits swept balances per configurable bps:
+///
+///           treasuryBps  -> protocol treasury (hard revenue)
+///           reserveBps   -> retained on-contract as the buyback / LP-deepen
+///                           reserve, accounted per currency for a keeper to act on
+///
+///         Fee base is the UNSPECIFIED side of the swap (output for exact-in,
+///         input for exact-out), the same convention as Uniswap's reference
+///         fee-taking hooks.
+///
+///         Permissions: afterSwap + afterSwapReturnDelta. Deploy address MUST
+///         carry exactly those flag bits (mine via CREATE2, see test).
+///         NOT a reserve-holding contract for user funds - fees only.
+contract AutoCapitalizeMonetizeHook is IHooks {
+    using PoolIdLibrary for PoolKey;
     using SafeERC20 for IERC20;
 
-    address public sincTreasury; // Your treasury or router
-    uint256 public feeToTreasuryBps = 3000; // 30% example
-    uint256 public feeToBuybackBps = 4000; // 40% SINC buyback/burn
-    uint256 public feeToLPDeepenBps = 3000; // 30% deepen SINC LP
+    IPoolManager public immutable poolManager;
 
-    constructor(IPoolManager _poolManager, address _guardian, address _sincTreasury) BaseLendingLoopHookContainer(_poolManager, _guardian) {
-        sincTreasury = _sincTreasury;
+    address public owner;
+    address public treasury;
+
+    uint256 public feeBps; // protocol fee on unspecified side, cap 10%
+    uint256 public treasuryBps; // share of swept fees -> treasury; rest -> reserve
+    uint256 public constant MAX_FEE_BPS = 1000;
+
+    /// @notice Fees banked per currency (lifetime accounting; reserve = balance - swept)
+    mapping(Currency => uint256) public totalCaptured;
+    mapping(Currency => uint256) public totalSwept;
+
+    event FeeCaptured(PoolId indexed poolId, Currency indexed currency, uint256 amount);
+    event Swept(Currency indexed currency, uint256 toTreasury, uint256 toReserve);
+    event FeeBpsUpdated(uint256 newFeeBps);
+    event TreasuryBpsUpdated(uint256 newTreasuryBps);
+    event TreasuryUpdated(address newTreasury);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    error Unauthorized();
+    error UnauthorizedCallback();
+    error FeeTooHigh();
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert Unauthorized();
+        _;
     }
 
-    function _afterSwap(...) internal override returns (bytes4, int128) {
-        // Production: Calculate protocol fees from delta or hook state
-        // uint256 feeAmount = ... ;
-        // IERC20(key.currency0).safeTransfer(sincTreasury, feeAmount * feeToTreasuryBps / 10000);
-        // Execute buyback or LP add for remaining (via router or internal swap)
-        // Emit monetize events for agent tracking and market% calc
-        return BaseLendingLoopHookContainer._afterSwap(sender, key, params, delta, hookData);
+    modifier onlyPoolManager() {
+        if (msg.sender != address(poolManager)) revert UnauthorizedCallback();
+        _;
     }
 
-    // Guardian can update splits (production: timelock)
-    function updateFeeSplits(uint256 t, uint256 b, uint256 l) external {
-        require(msg.sender == guardian, "Only guardian");
-        feeToTreasuryBps = t;
-        feeToBuybackBps = b;
-        feeToLPDeepenBps = l;
+    constructor(IPoolManager _poolManager, address _treasury, uint256 _feeBps, uint256 _treasuryBps) {
+        require(address(_poolManager) != address(0) && _treasury != address(0), "Zero address");
+        if (_feeBps > MAX_FEE_BPS || _treasuryBps > 10_000) revert FeeTooHigh();
+        poolManager = _poolManager;
+        treasury = _treasury;
+        feeBps = _feeBps;
+        treasuryBps = _treasuryBps;
+        owner = msg.sender;
+    }
+
+    // ==================== IHooks surface (only afterSwap is live) ====================
+
+    function getHookPermissions() public pure returns (Hooks.Permissions memory) {
+        return Hooks.Permissions({
+            beforeInitialize: false,
+            afterInitialize: false,
+            beforeAddLiquidity: false,
+            afterAddLiquidity: false,
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: false,
+            beforeSwap: false,
+            afterSwap: true,
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: false,
+            afterSwapReturnDelta: true,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+
+    function beforeSwap(address, PoolKey calldata, SwapParams calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        revert UnauthorizedCallback();
+    }
+
+    function afterSwap(
+        address,
+        PoolKey calldata key,
+        SwapParams calldata params,
+        BalanceDelta delta,
+        bytes calldata
+    ) external onlyPoolManager returns (bytes4, int128) {
+        if (feeBps == 0) return (this.afterSwap.selector, 0);
+
+        // Unspecified side: exact-in -> output currency, exact-out -> input currency
+        bool exactInput = params.amountSpecified < 0;
+        bool feeOnCurrency0 = exactInput ? !params.zeroForOne : params.zeroForOne;
+        int128 side = feeOnCurrency0 ? delta.amount0() : delta.amount1();
+        uint256 base = side < 0 ? uint256(uint128(-side)) : uint256(uint128(side));
+
+        uint256 feeAmount = (base * feeBps) / 10_000;
+        if (feeAmount == 0) return (this.afterSwap.selector, 0);
+
+        Currency feeCurrency = feeOnCurrency0 ? key.currency0 : key.currency1;
+        poolManager.take(feeCurrency, address(this), feeAmount);
+        totalCaptured[feeCurrency] += feeAmount;
+
+        emit FeeCaptured(key.toId(), feeCurrency, feeAmount);
+        return (this.afterSwap.selector, int128(int256(feeAmount)));
+    }
+
+    // ==================== Remaining IHooks stubs (never called: no flags) ====================
+
+    function beforeInitialize(address, PoolKey calldata, uint160) external pure returns (bytes4) {
+        revert UnauthorizedCallback();
+    }
+
+    function afterInitialize(address, PoolKey calldata, uint160, int24) external pure returns (bytes4) {
+        revert UnauthorizedCallback();
+    }
+
+    function beforeAddLiquidity(address, PoolKey calldata, ModifyLiquidityParams calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        revert UnauthorizedCallback();
+    }
+
+    function afterAddLiquidity(
+        address,
+        PoolKey calldata,
+        ModifyLiquidityParams calldata,
+        BalanceDelta,
+        BalanceDelta,
+        bytes calldata
+    ) external pure returns (bytes4, BalanceDelta) {
+        revert UnauthorizedCallback();
+    }
+
+    function beforeRemoveLiquidity(address, PoolKey calldata, ModifyLiquidityParams calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        revert UnauthorizedCallback();
+    }
+
+    function afterRemoveLiquidity(
+        address,
+        PoolKey calldata,
+        ModifyLiquidityParams calldata,
+        BalanceDelta,
+        BalanceDelta,
+        bytes calldata
+    ) external pure returns (bytes4, BalanceDelta) {
+        revert UnauthorizedCallback();
+    }
+
+    function beforeDonate(address, PoolKey calldata, uint256, uint256, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        revert UnauthorizedCallback();
+    }
+
+    function afterDonate(address, PoolKey calldata, uint256, uint256, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        revert UnauthorizedCallback();
+    }
+
+    // ==================== MONETIZATION ====================
+
+    /// @notice Sweep banked fees: treasuryBps to treasury, remainder stays as the
+    ///         on-contract buyback / LP-deepen reserve. Keeper-compoundable.
+    function sweep(Currency currency) external {
+        uint256 balance = IERC20(Currency.unwrap(currency)).balanceOf(address(this));
+        uint256 captured = totalCaptured[currency];
+        uint256 swept = totalSwept[currency];
+        uint256 available = balance < captured - swept ? balance : captured - swept;
+        if (available == 0) return;
+
+        uint256 toTreasury = (available * treasuryBps) / 10_000;
+        uint256 toReserve = available - toTreasury;
+
+        totalSwept[currency] = swept + available;
+        if (toTreasury > 0) IERC20(Currency.unwrap(currency)).safeTransfer(treasury, toTreasury);
+
+        emit Swept(currency, toTreasury, toReserve);
+    }
+
+    /// @notice Spend reserve on buyback / LP-deepen. Owner-gated; the keeper pattern.
+    ///         v2 keeps execution off-contract (owner routes via its own call) to
+    ///         avoid embedding a router dependency in a fee contract.
+    function releaseReserve(Currency currency, uint256 amount, address to) external onlyOwner {
+        require(to != address(0), "Zero address");
+        IERC20(Currency.unwrap(currency)).safeTransfer(to, amount);
+    }
+
+    // ==================== ADMIN ====================
+
+    function setFeeBps(uint256 newFeeBps) external onlyOwner {
+        if (newFeeBps > MAX_FEE_BPS) revert FeeTooHigh();
+        feeBps = newFeeBps;
+        emit FeeBpsUpdated(newFeeBps);
+    }
+
+    function setTreasuryBps(uint256 newTreasuryBps) external onlyOwner {
+        if (newTreasuryBps > 10_000) revert FeeTooHigh();
+        treasuryBps = newTreasuryBps;
+        emit TreasuryBpsUpdated(newTreasuryBps);
+    }
+
+    function setTreasury(address newTreasury) external onlyOwner {
+        require(newTreasury != address(0), "Zero address");
+        treasury = newTreasury;
+        emit TreasuryUpdated(newTreasury);
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        require(newOwner != address(0), "Zero address");
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
     }
 }

--- a/onchain/src/hooks/MoebiusMEVHook.sol
+++ b/onchain/src/hooks/MoebiusMEVHook.sol
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
-import {BaseHook} from "v4-periphery/src/base/hooks/BaseHook.sol";
 import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
-import {Hooks} from "v4-core/src/libraries/Hooks.sol";
+import {IUnlockCallback} from "v4-core/src/interfaces/callback/IUnlockCallback.sol";
 import {PoolKey} from "v4-core/src/types/PoolKey.sol";
 import {Currency, CurrencyLibrary} from "v4-core/src/types/Currency.sol";
+import {BalanceDelta} from "v4-core/src/types/BalanceDelta.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/src/types/PoolId.sol";
+import {ModifyLiquidityParams} from "v4-core/src/types/PoolOperation.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
 
 /// @notice Strict interface searchers must implement for typed, contained execution
@@ -18,136 +22,313 @@ interface IPhantomCreditToken {
     function burnEphemeral(address from, uint256 amount) external;
 }
 
-contract MoebiusMEVHook is BaseHook, ReentrancyGuardTransient {
+/// @title MoebiusMEVHook - "central bank" MEV capture for Uniswap v4
+/// @notice v2 rewrite. Replaces the v1 honor-system tax (levied on the searcher's
+///         SELF-DECLARED profit - gameable to dust) with a sealed-bid escrow:
+///
+///         1. Searcher escrows a hard bid in the pool's real asset UP FRONT
+///            (transferFrom / msg.value). No bid, no credit.
+///         2. Hook flash-mints pMEV working capital to the searcher.
+///         3. Searcher runs its loop; must return (burn) 100% of the pMEV.
+///         4. The escrowed bid is split deterministically:
+///            80% donated to in-range LPs, 20% to protocol treasury.
+///
+///         Enforcement no longer sniffs contract balances (griefable by dusting)
+///         and no longer trusts declared profit. The bid IS the tax. Competition
+///         between searchers for the same flow is what pushes bids toward the
+///         true arb value - a real auction.
+///
+///         minBidBps is the policy rate: a floor on bids proportional to the
+///         flash amount, so LP compensation scales with capital consumed.
+///
+///         The hook carries ZERO hook-permission flags: it intercepts no swaps
+///         and adds no gas to swappers. Its address must carry zero lower-14
+///         hook-flag bits (mined via CREATE2 - see DeployMoebius.s.sol), and
+///         pMEV pools must use the dynamic-fee flag, with the swap fee set
+///         through setPoolSwapFee (policy lever #2).
+contract MoebiusMEVHook is IUnlockCallback, ReentrancyGuardTransient {
     using CurrencyLibrary for Currency;
+    using PoolIdLibrary for PoolKey;
+    using SafeERC20 for IERC20;
 
+    IPoolManager public immutable poolManager;
     IPhantomCreditToken public immutable pToken;
-    address public immutable protocolTreasury;
 
-    uint256 public constant TREASURY_SHARE_BIPS = 2000; // 20%
-    uint256 public constant BASE_TAX_BIPS = 1000;       // 10%
+    address public owner;
+    address public protocolTreasury;
+
+    /// @notice Policy rate floor: bid >= flashAmount * minBidBps / 10_000
+    uint256 public minBidBps;
+
+    uint256 public constant TREASURY_SHARE_BIPS = 2000; // 20% of escrowed bid
+    uint256 public constant MAX_MIN_BID_BPS = 1000; // floor itself capped at 10%
+
+    bytes32 internal constant ACTION_MEV = keccak256("MOEBIUS_MEV");
+    bytes32 internal constant ACTION_SEED = keccak256("MOEBIUS_SEED");
 
     event MEVLoopExecuted(
-        address indexed searcher,
-        uint256 flashAmount,
-        uint256 expectedProfit,
-        uint256 actualTaxPaid,
-        uint256 lpShare,
-        uint256 protocolShare
+        address indexed searcher, uint256 flashAmount, uint256 bid, uint256 lpShare, uint256 protocolShare
     );
+    event LiquiditySeeded(PoolId indexed poolId, uint256 pMevSeeded, uint256 realSeeded, uint256 liquidity);
+    event PolicyRateUpdated(uint256 newMinBidBps);
+    event PoolSwapFeeUpdated(PoolId indexed poolId, uint24 newFee);
+    event TreasuryUpdated(address newTreasury);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
+    error Unauthorized();
     error UnauthorizedCallback();
     error InvalidPoolKey();
-    error ExecutionFailed();
-    error TaxEvasionDetected();
-    error ZeroProfitDeclared();
+    error BidBelowFloor(uint256 bid, uint256 floor);
+    error BadEscrow();
+    error ZeroAmount();
+    error FeeOnTransferNotSupported();
+    error RateTooHigh();
 
-    constructor(
-        IPoolManager _poolManager,
-        address _pToken,
-        address _treasury
-    ) BaseHook(_poolManager) {
-        require(_pToken != address(0) && _treasury != address(0), "Zero address");
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert Unauthorized();
+        _;
+    }
+
+    constructor(IPoolManager _poolManager, address _pToken, address _treasury, uint256 _minBidBps) {
+        require(address(_poolManager) != address(0) && _pToken != address(0) && _treasury != address(0), "Zero address");
+        if (_minBidBps > MAX_MIN_BID_BPS) revert RateTooHigh();
+        poolManager = _poolManager;
         pToken = IPhantomCreditToken(_pToken);
         protocolTreasury = _treasury;
+        minBidBps = _minBidBps;
+        owner = msg.sender;
     }
 
-    function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
-        return Hooks.Permissions({
-            beforeInitialize: false, afterInitialize: false,
-            beforeAddLiquidity: false, afterAddLiquidity: false,
-            beforeRemoveLiquidity: false, afterRemoveLiquidity: false,
-            beforeSwap: false, afterSwap: false,
-            beforeDonate: false, afterDonate: false,
-            beforeSwapReturnDelta: false, afterSwapReturnDelta: false,
-            afterAddLiquidityReturnDelta: false, afterRemoveLiquidityReturnDelta: false
-        });
+    // ==================== SEARCHER ENTRY ====================
+
+    /// @notice Execute a MEV loop with flash-minted pMEV working capital.
+    /// @param key         PoolKey of the pMEV/realAsset pool (hooks must be THIS contract)
+    /// @param flashAmount Amount of pMEV to flash-mint (must be fully returned)
+    /// @param bid         Escrowed tax bid, paid in the pool's real asset
+    /// @param payload     Opaque searcher payload forwarded to moebiusExecute
+    function executeMEV(PoolKey calldata key, uint256 flashAmount, uint256 bid, bytes calldata payload)
+        external
+        payable
+        nonReentrant
+    {
+        if (flashAmount == 0) revert ZeroAmount();
+        Currency realAsset = _validateKeyAndGetRealAsset(key);
+
+        uint256 floor = (flashAmount * minBidBps) / 10_000;
+        if (bid < floor) revert BidBelowFloor(bid, floor);
+
+        _escrow(realAsset, msg.sender, bid);
+
+        poolManager.unlock(abi.encode(ACTION_MEV, msg.sender, key, flashAmount, bid, payload));
+
+        // Loop succeeded (else the whole tx reverted, escrow included).
+        uint256 protocolShare = (bid * TREASURY_SHARE_BIPS) / 10_000;
+        uint256 lpShare = bid - protocolShare;
+        if (protocolShare > 0) _payout(realAsset, protocolTreasury, protocolShare);
+
+        emit MEVLoopExecuted(msg.sender, flashAmount, bid, lpShare, protocolShare);
     }
 
-    /// @notice Entry point. Searcher declares expected profit upfront. Full validation.
-    function executeMEV(
+    // ==================== CENTRAL BANK DESK ====================
+
+    /// @notice Owner seeds the pMEV/realAsset pool: hook flash-mints pMEV inventory
+    ///         and pairs it with the owner's real asset into an LP position owned
+    ///         by the hook. This is the balance sheet that gives pMEV a price.
+    /// @param liquidity  v4 liquidity delta (compute off-chain via LiquidityAmounts)
+    /// @param maxReal    Max real asset to escrow (leftover is refunded)
+    /// @param amountPmev pMEV to mint for seeding (unneeded remainder is burned)
+    function seedLiquidity(
         PoolKey calldata key,
-        uint256 flashAmount,
-        uint256 expectedProfit,
-        bytes calldata searcherPayload
-    ) external nonReentrant {
-        if (key.hooks != address(this)) revert InvalidPoolKey();
-        
-        address c0 = Currency.unwrap(key.currency0);
-        address c1 = Currency.unwrap(key.currency1);
-        if (c0 != address(pToken) && c1 != address(pToken)) revert InvalidPoolKey();
-        if (c0 == c1) revert InvalidPoolKey(); // Sanity against malformed keys
-        
-        if (expectedProfit == 0) revert ZeroProfitDeclared();
+        int24 tickLower,
+        int24 tickUpper,
+        uint256 liquidity,
+        uint256 maxReal,
+        uint256 amountPmev
+    ) external payable onlyOwner nonReentrant {
+        if (liquidity == 0 || amountPmev == 0) revert ZeroAmount();
+        Currency realAsset = _validateKeyAndGetRealAsset(key);
 
-        bytes memory data = abi.encode(msg.sender, key, flashAmount, expectedProfit, searcherPayload);
-        poolManager.unlock(data);
+        _escrow(realAsset, msg.sender, maxReal);
+
+        uint256 realBefore = _selfBalance(realAsset);
+        poolManager.unlock(abi.encode(ACTION_SEED, key, tickLower, tickUpper, liquidity, amountPmev));
+        uint256 realSpent = realBefore - _selfBalance(realAsset);
+
+        // Refund unspent escrow
+        uint256 leftover = _selfBalance(realAsset);
+        if (leftover > 0) _payout(realAsset, msg.sender, leftover);
+
+        emit LiquiditySeeded(key.toId(), amountPmev, realSpent, liquidity);
     }
 
-    /// @notice The V4 callback - perfected with defense-in-depth, typed execution, V4 compliant settlement, safe tax math
+    // ==================== V4 CALLBACK ====================
+
     function unlockCallback(bytes calldata data) external override returns (bytes memory) {
         if (msg.sender != address(poolManager)) revert UnauthorizedCallback();
 
-        (
-            address searcher,
-            PoolKey memory key,
-            uint256 flashAmount,
-            uint256 expectedProfit,
-            bytes memory payload
-        ) = abi.decode(data, (address, PoolKey, uint256, uint256, bytes));
+        bytes32 action = abi.decode(data, (bytes32));
 
-        // Defense in depth: ensure we don't process garbage data from a rogue nested unlock
-        if (key.hooks != address(this)) revert InvalidPoolKey();
-
-        // 1. Dynamic Sorting for real asset
-        bool isZeroPToken = Currency.unwrap(key.currency0) == address(pToken);
-        Currency realAsset = isZeroPToken ? key.currency1 : key.currency0;
-
-        uint256 requiredTax = (expectedProfit * BASE_TAX_BIPS) / 10000;
-        uint256 balanceBefore = realAsset.balanceOfSelf();
-
-        // 2. Flash Issue & Typed Execution (searcher responsible for any nested V4 frames)
-        pToken.mintEphemeral(searcher, flashAmount);
-        IMoebiusSearcher(searcher).moebiusExecute(payload);
-        pToken.burnEphemeral(searcher, flashAmount);
-
-        // 3. Tax Enforcement with safe math (prevents underflow if balance decreased)
-        uint256 balanceAfter = realAsset.balanceOfSelf();
-        if (balanceAfter <= balanceBefore) revert TaxEvasionDetected();
-        uint256 actualTaxPaid = balanceAfter - balanceBefore;
-        if (actualTaxPaid < requiredTax) revert TaxEvasionDetected();
-
-        uint256 protocolShare = 0;
-        uint256 lpShare = 0;
-
-        if (actualTaxPaid > 0) {
-            protocolShare = (actualTaxPaid * TREASURY_SHARE_BIPS) / 10000;
-            lpShare = actualTaxPaid - protocolShare;
-
-            if (protocolShare > 0) {
-                realAsset.transfer(protocolTreasury, protocolShare);
-            }
-
-            if (lpShare > 0) {
-                uint256 amount0 = isZeroPToken ? 0 : lpShare;
-                uint256 amount1 = isZeroPToken ? lpShare : 0;
-                
-                poolManager.donate(key, amount0, amount1, "");
-
-                // 4. V4 Core compliant settlement (no-arg settle after sync/transfer for ERC20; payable no-arg for native)
-                if (realAsset.isNative()) {
-                    poolManager.settle{value: lpShare}();
-                } else {
-                    poolManager.sync(realAsset);
-                    realAsset.transfer(address(poolManager), lpShare);
-                    poolManager.settle();
-                }
-            }
+        if (action == ACTION_MEV) {
+            (, address searcher, PoolKey memory key, uint256 flashAmount, uint256 bid, bytes memory payload) =
+                abi.decode(data, (bytes32, address, PoolKey, uint256, uint256, bytes));
+            _runMevLoop(searcher, key, flashAmount, bid, payload);
+        } else if (action == ACTION_SEED) {
+            (, PoolKey memory key, int24 tickLower, int24 tickUpper, uint256 liquidity, uint256 amountPmev) =
+                abi.decode(data, (bytes32, PoolKey, int24, int24, uint256, uint256));
+            _runSeed(key, tickLower, tickUpper, liquidity, amountPmev);
+        } else {
+            revert UnauthorizedCallback();
         }
 
-        // 5. Always emit for verifiable auction mechanics (includes actualTaxPaid for overbids)
-        emit MEVLoopExecuted(searcher, flashAmount, expectedProfit, actualTaxPaid, lpShare, protocolShare);
-
         return "";
+    }
+
+    function _runMevLoop(address searcher, PoolKey memory key, uint256 flashAmount, uint256 bid, bytes memory payload)
+        internal
+    {
+        // Defense in depth: never act on a malformed nested-unlock payload
+        Currency realAsset = _validateKeyAndGetRealAsset(key);
+        bool isZeroPToken = Currency.unwrap(key.currency0) == address(pToken);
+
+        // 1. Flash-issue working capital
+        pToken.mintEphemeral(searcher, flashAmount);
+
+        // 2. Typed searcher execution (searcher settles its own deltas inside this frame)
+        IMoebiusSearcher(searcher).moebiusExecute(payload);
+
+        // 3. Full repayment enforced by the token itself: reverts on shortfall,
+        //    which reverts the entire transaction INCLUDING the escrow.
+        pToken.burnEphemeral(searcher, flashAmount);
+
+        // 4. LP share of the escrowed bid goes to in-range LPs, settled from escrow
+        uint256 protocolShare = (bid * TREASURY_SHARE_BIPS) / 10_000;
+        uint256 lpShare = bid - protocolShare;
+        if (lpShare > 0) {
+            (uint256 amount0, uint256 amount1) = isZeroPToken ? (uint256(0), lpShare) : (lpShare, uint256(0));
+            poolManager.donate(key, amount0, amount1, "");
+            _settleFromSelf(realAsset, lpShare);
+        }
+    }
+
+    function _runSeed(PoolKey memory key, int24 tickLower, int24 tickUpper, uint256 liquidity, uint256 amountPmev)
+        internal
+    {
+        pToken.mintEphemeral(address(this), amountPmev);
+
+        (BalanceDelta delta,) = poolManager.modifyLiquidity(
+            key,
+            ModifyLiquidityParams({
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                liquidityDelta: int256(liquidity),
+                salt: bytes32(0)
+            }),
+            ""
+        );
+
+        // Settle what the position actually consumed
+        _settleDeltaCurrency(key.currency0, delta.amount0());
+        _settleDeltaCurrency(key.currency1, delta.amount1());
+
+        // Burn any pMEV the position didn't absorb
+        uint256 pMevLeft = IERC20(address(pToken)).balanceOf(address(this));
+        if (pMevLeft > 0) pToken.burnEphemeral(address(this), pMevLeft);
+    }
+
+    // ==================== INTERNALS ====================
+
+    function _validateKeyAndGetRealAsset(PoolKey memory key) internal view returns (Currency realAsset) {
+        if (address(key.hooks) != address(this)) revert InvalidPoolKey();
+        address c0 = Currency.unwrap(key.currency0);
+        address c1 = Currency.unwrap(key.currency1);
+        if (c0 == c1) revert InvalidPoolKey();
+        if (c0 == address(pToken)) return key.currency1;
+        if (c1 == address(pToken)) return key.currency0;
+        revert InvalidPoolKey();
+    }
+
+    /// @dev Pull the bid/seed escrow into this contract. Native = msg.value, else transferFrom.
+    function _escrow(Currency realAsset, address from, uint256 amount) internal {
+        if (amount == 0) {
+            if (msg.value != 0) revert BadEscrow();
+            return;
+        }
+        if (realAsset.isAddressZero()) {
+            if (msg.value != amount) revert BadEscrow();
+        } else {
+            if (msg.value != 0) revert BadEscrow();
+            uint256 before = IERC20(Currency.unwrap(realAsset)).balanceOf(address(this));
+            IERC20(Currency.unwrap(realAsset)).safeTransferFrom(from, address(this), amount);
+            // Reject fee-on-transfer assets outright: escrow math must be exact
+            if (IERC20(Currency.unwrap(realAsset)).balanceOf(address(this)) - before != amount) {
+                revert FeeOnTransferNotSupported();
+            }
+        }
+    }
+
+    /// @dev Pay out tokens this contract holds (outside the PoolManager lock).
+    function _payout(Currency realAsset, address to, uint256 amount) internal {
+        if (realAsset.isAddressZero()) {
+            (bool ok,) = to.call{value: amount}("");
+            require(ok, "Native payout failed");
+        } else {
+            IERC20(Currency.unwrap(realAsset)).safeTransfer(to, amount);
+        }
+    }
+
+    /// @dev Settle a PoolManager debt using tokens this contract holds (inside the lock).
+    function _settleFromSelf(Currency currency, uint256 amount) internal {
+        if (currency.isAddressZero()) {
+            poolManager.settle{value: amount}();
+        } else {
+            poolManager.sync(currency);
+            IERC20(Currency.unwrap(currency)).safeTransfer(address(poolManager), amount);
+            poolManager.settle();
+        }
+    }
+
+    function _settleDeltaCurrency(Currency currency, int128 deltaAmount) internal {
+        if (deltaAmount >= 0) return; // positive delta = PoolManager owes us; leave as claim
+        _settleFromSelf(currency, uint256(uint128(-deltaAmount)));
+    }
+
+    function _selfBalance(Currency currency) internal view returns (uint256) {
+        return currency.isAddressZero() ? address(this).balance : IERC20(Currency.unwrap(currency)).balanceOf(address(this));
+    }
+
+    // ==================== ADMIN (monetary policy) ====================
+
+    function setMinBidBps(uint256 newMinBidBps) external onlyOwner {
+        if (newMinBidBps > MAX_MIN_BID_BPS) revert RateTooHigh();
+        minBidBps = newMinBidBps;
+        emit PolicyRateUpdated(newMinBidBps);
+    }
+
+    /// @notice Policy lever #2: set the swap fee of a hook-owned dynamic-fee pool.
+    ///         pMEV pools must be initialized with the dynamic fee flag (0x800000)
+    ///         because this hook carries zero permission flags.
+    function setPoolSwapFee(PoolKey calldata key, uint24 newFee) external onlyOwner {
+        _validateKeyAndGetRealAsset(key);
+        poolManager.updateDynamicLPFee(key, newFee);
+        emit PoolSwapFeeUpdated(key.toId(), newFee);
+    }
+
+    function setTreasury(address newTreasury) external onlyOwner {
+        require(newTreasury != address(0), "Zero address");
+        protocolTreasury = newTreasury;
+        emit TreasuryUpdated(newTreasury);
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        require(newOwner != address(0), "Zero address");
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
+    }
+
+    /// @notice Recover stray tokens force-sent to the hook. Cannot touch an active
+    ///         unlock frame (this is only callable outside one by definition).
+    function rescue(Currency currency, uint256 amount, address to) external onlyOwner {
+        require(to != address(0), "Zero address");
+        _payout(currency, to, amount);
     }
 }

--- a/onchain/src/hooks/PhantomCreditToken.sol
+++ b/onchain/src/hooks/PhantomCreditToken.sol
@@ -3,6 +3,13 @@ pragma solidity ^0.8.24;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
+/// @title PhantomCreditToken (pMEV)
+/// @notice Ephemeral working-capital credit for the Moebius MEV loop.
+///         Mintable/burnable ONLY by the MoebiusMEVHook. Net supply outside
+///         the pool is zero at every transaction boundary: searchers must
+///         return (burn) the full flash amount within the same unlock frame.
+///         Supply resting in the pMEV/realAsset pool is hook-seeded inventory
+///         (the central bank's balance sheet), backed by the hook's LP position.
 contract PhantomCreditToken is ERC20 {
     address public immutable hook;
 

--- a/onchain/test/AutoCapitalizeMonetizeHook.t.sol
+++ b/onchain/test/AutoCapitalizeMonetizeHook.t.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {PoolManager} from "v4-core/src/PoolManager.sol";
+import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "v4-core/src/types/PoolKey.sol";
+import {Currency, CurrencyLibrary} from "v4-core/src/types/Currency.sol";
+import {TickMath} from "v4-core/src/libraries/TickMath.sol";
+import {IHooks} from "v4-core/src/interfaces/IHooks.sol";
+import {Hooks} from "v4-core/src/libraries/Hooks.sol";
+import {LiquidityAmounts} from "v4-periphery/src/libraries/LiquidityAmounts.sol";
+
+import {AutoCapitalizeMonetizeHook} from "../src/hooks/AutoCapitalizeMonetizeHook.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockSwapRouter} from "./mocks/MockSwapRouter.sol";
+
+contract AutoCapitalizeMonetizeHookTest is Test {
+    PoolManager manager;
+    AutoCapitalizeMonetizeHook hook;
+    MockERC20 token0;
+    MockERC20 token1;
+    MockSwapRouter router;
+
+    address treasury = makeAddr("treasury");
+    address stranger = makeAddr("stranger");
+
+    PoolKey key;
+
+    uint24 constant POOL_FEE = 3000;
+    int24 constant TICK_SPACING = 60;
+    uint160 constant SQRT_PRICE_1_1 = 79228162514264337593543950336;
+
+    uint256 constant FEE_BPS = 25; // 0.25% protocol fee on unspecified side
+    uint256 constant TREASURY_BPS = 3000; // 30% of swept -> treasury
+
+    uint160 constant REQUIRED_FLAGS =
+        uint160(Hooks.AFTER_SWAP_FLAG) | uint160(Hooks.AFTER_SWAP_RETURNS_DELTA_FLAG);
+    uint160 constant ALL_HOOK_MASK = 0x3FFF;
+
+    function setUp() public {
+        manager = new PoolManager(address(this));
+
+        // Mine hook address carrying exactly AFTER_SWAP | AFTER_SWAP_RETURNS_DELTA
+        bytes32 initHash = keccak256(
+            abi.encodePacked(
+                type(AutoCapitalizeMonetizeHook).creationCode,
+                abi.encode(address(manager), treasury, FEE_BPS, TREASURY_BPS)
+            )
+        );
+        bytes32 salt;
+        address predicted;
+        for (uint256 i = 0;; i++) {
+            salt = bytes32(i);
+            predicted = vm.computeCreate2Address(salt, initHash, address(this));
+            if (uint160(predicted) & ALL_HOOK_MASK == REQUIRED_FLAGS) break;
+        }
+        hook = new AutoCapitalizeMonetizeHook{salt: salt}(
+            IPoolManager(address(manager)), treasury, FEE_BPS, TREASURY_BPS
+        );
+        assertEq(address(hook), predicted, "CREATE2 prediction");
+
+        MockERC20 a = new MockERC20("Token A", "TKA");
+        MockERC20 b = new MockERC20("Token B", "TKB");
+        (token0, token1) = address(a) < address(b) ? (a, b) : (b, a);
+
+        key = PoolKey({
+            currency0: Currency.wrap(address(token0)),
+            currency1: Currency.wrap(address(token1)),
+            fee: POOL_FEE,
+            tickSpacing: TICK_SPACING,
+            hooks: IHooks(address(hook))
+        });
+
+        manager.initialize(key, SQRT_PRICE_1_1);
+
+        router = new MockSwapRouter(address(manager));
+        token0.mint(address(this), 1000 ether);
+        token1.mint(address(this), 1000 ether);
+        token0.approve(address(router), type(uint256).max);
+        token1.approve(address(router), type(uint256).max);
+
+        uint256 liquidity = LiquidityAmounts.getLiquidityForAmounts(
+            SQRT_PRICE_1_1,
+            TickMath.getSqrtPriceAtTick(-600),
+            TickMath.getSqrtPriceAtTick(600),
+            100 ether,
+            100 ether
+        );
+        router.addLiquidity(key, -600, 600, liquidity);
+    }
+
+    function test_capturesFeeOnSwap_unspecifiedSide() public {
+        uint256 amountIn = 10 ether;
+        uint256 myToken1Before = token1.balanceOf(address(this));
+
+        uint256 out = router.swapExactIn(key, true, amountIn); // token0 -> token1, exact-in
+
+        // Fee taken on the output (unspecified) side
+        uint256 expectedFee = (out * FEE_BPS) / (10_000 - FEE_BPS); // gross = net + fee
+        uint256 hookBal = token1.balanceOf(address(hook));
+
+        assertGt(hookBal, 0, "hook captured fees");
+        assertEq(hook.totalCaptured(Currency.wrap(address(token1))), hookBal, "accounting matches balance");
+        // Swapper received gross output minus hook fee
+        assertEq(token1.balanceOf(address(this)) - myToken1Before, out, "router output realized");
+        assertApproxEqAbs(hookBal, expectedFee, 2, "fee ~= bps of gross output");
+    }
+
+    function test_sweep_splitsTreasuryAndReserve() public {
+        router.swapExactIn(key, true, 10 ether);
+
+        Currency c1 = Currency.wrap(address(token1));
+        uint256 captured = hook.totalCaptured(c1);
+        uint256 expectedTreasury = (captured * TREASURY_BPS) / 10_000;
+
+        hook.sweep(c1);
+
+        assertEq(token1.balanceOf(treasury), expectedTreasury, "treasury got its split");
+        assertEq(token1.balanceOf(address(hook)), captured - expectedTreasury, "reserve retained");
+        assertEq(hook.totalSwept(c1), captured, "sweep accounted");
+    }
+
+    function test_releaseReserve_ownerOnly() public {
+        router.swapExactIn(key, true, 10 ether);
+        Currency c1 = Currency.wrap(address(token1));
+        hook.sweep(c1);
+        uint256 reserve = token1.balanceOf(address(hook));
+
+        vm.prank(stranger);
+        vm.expectRevert(AutoCapitalizeMonetizeHook.Unauthorized.selector);
+        hook.releaseReserve(c1, reserve, stranger);
+
+        hook.releaseReserve(c1, reserve, treasury);
+        assertEq(token1.balanceOf(address(hook)), 0, "reserve released");
+    }
+
+    function test_adminGates() public {
+        vm.prank(stranger);
+        vm.expectRevert(AutoCapitalizeMonetizeHook.Unauthorized.selector);
+        hook.setFeeBps(50);
+
+        vm.expectRevert(AutoCapitalizeMonetizeHook.FeeTooHigh.selector);
+        hook.setFeeBps(1001);
+
+        hook.setFeeBps(50);
+        assertEq(hook.feeBps(), 50);
+    }
+}

--- a/onchain/test/MoebiusMEVHook.fork.t.sol
+++ b/onchain/test/MoebiusMEVHook.fork.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "v4-core/src/types/PoolKey.sol";
+import {Currency, CurrencyLibrary} from "v4-core/src/types/Currency.sol";
+import {TickMath} from "v4-core/src/libraries/TickMath.sol";
+import {IHooks} from "v4-core/src/interfaces/IHooks.sol";
+import {LiquidityAmounts} from "v4-periphery/src/libraries/LiquidityAmounts.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {MoebiusMEVHook} from "../src/hooks/MoebiusMEVHook.sol";
+import {PhantomCreditToken} from "../src/hooks/PhantomCreditToken.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockSearcher} from "./mocks/MockSearcher.sol";
+
+/// @notice Base mainnet fork test against the REAL canonical PoolManager.
+///         Run: forge test --match-contract MoebiusMEVHookFork --fork-url https://mainnet.base.org -vvv
+contract MoebiusMEVHookForkTest is Test {
+    using CurrencyLibrary for Currency;
+
+    address constant PM_BASE = 0x498581fF718922c3f8e6A244956aF099B2652b2b;
+
+    IPoolManager manager = IPoolManager(PM_BASE);
+    PhantomCreditToken pToken;
+    MoebiusMEVHook hook;
+    MockERC20 real;
+    MockSearcher searcher;
+
+    address treasury = makeAddr("treasury");
+
+    PoolKey key;
+    bool zeroIsPToken;
+
+    uint24 constant DYNAMIC_FEE = 0x800000;
+    uint24 constant POOL_FEE = 3000;
+    int24 constant TICK_SPACING = 60;
+    uint160 constant SQRT_PRICE_1_1 = 79228162514264337593543950336;
+
+    uint256 constant SEED_REAL = 100 ether;
+    uint256 constant SEED_PMEV = 100 ether;
+    uint256 constant FLASH = 10 ether;
+    uint256 constant POLICY_BPS = 100;
+
+    uint160 constant ALL_HOOK_MASK = 0x3FFF;
+
+    function setUp() public {
+        vm.createSelectFork("https://mainnet.base.org");
+        require(PM_BASE.code.length > 0, "PoolManager not found on fork");
+
+        // Same CREATE2-mined deploy pattern as production
+        address predictedPToken = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        bytes32 initHash = keccak256(
+            abi.encodePacked(
+                type(MoebiusMEVHook).creationCode, abi.encode(PM_BASE, predictedPToken, treasury, POLICY_BPS)
+            )
+        );
+        bytes32 salt;
+        address predictedHook;
+        for (uint256 i = 0;; i++) {
+            salt = bytes32(i);
+            predictedHook = vm.computeCreate2Address(salt, initHash, address(this));
+            if (uint160(predictedHook) & ALL_HOOK_MASK == 0) break;
+        }
+
+        pToken = new PhantomCreditToken(predictedHook);
+        hook = new MoebiusMEVHook{salt: salt}(manager, address(pToken), treasury, POLICY_BPS);
+        assertEq(address(hook), predictedHook, "CREATE2 prediction");
+
+        real = new MockERC20("Real Asset", "REAL");
+
+        zeroIsPToken = address(pToken) < address(real);
+        key = PoolKey({
+            currency0: Currency.wrap(zeroIsPToken ? address(pToken) : address(real)),
+            currency1: Currency.wrap(zeroIsPToken ? address(real) : address(pToken)),
+            fee: DYNAMIC_FEE,
+            tickSpacing: TICK_SPACING,
+            hooks: IHooks(address(hook))
+        });
+
+        manager.initialize(key, SQRT_PRICE_1_1);
+        hook.setPoolSwapFee(key, POOL_FEE);
+
+        real.mint(address(this), SEED_REAL * 10);
+        real.approve(address(hook), type(uint256).max);
+
+        uint160 sqrtA = TickMath.getSqrtPriceAtTick(-600);
+        uint160 sqrtB = TickMath.getSqrtPriceAtTick(600);
+        uint256 liquidity = LiquidityAmounts.getLiquidityForAmounts(
+            SQRT_PRICE_1_1,
+            sqrtA,
+            sqrtB,
+            zeroIsPToken ? SEED_PMEV : SEED_REAL,
+            zeroIsPToken ? SEED_REAL : SEED_PMEV
+        );
+        hook.seedLiquidity(key, -600, 600, liquidity, SEED_REAL * 2, SEED_PMEV * 2);
+
+        searcher = new MockSearcher(address(manager), address(hook));
+        real.mint(address(searcher), 10 ether);
+        vm.prank(address(searcher));
+        real.approve(address(hook), type(uint256).max);
+    }
+
+    function test_fork_fullCycle_onCanonicalPoolManager() public {
+        uint256 bid = 1 ether;
+        uint256 protocolShare = bid / 5;
+        uint256 lpShare = bid - protocolShare;
+
+        uint256 treasuryBefore = real.balanceOf(treasury);
+        uint256 pmBefore = real.balanceOf(PM_BASE);
+        uint256 searcherBefore = real.balanceOf(address(searcher));
+        uint256 supplyBefore = pToken.totalSupply();
+
+        vm.prank(address(searcher));
+        hook.executeMEV(key, FLASH, bid, abi.encode(uint8(1), key, FLASH, zeroIsPToken));
+
+        uint256 searcherSwapCost = (searcherBefore - real.balanceOf(address(searcher))) - bid;
+        assertEq(real.balanceOf(treasury) - treasuryBefore, protocolShare, "treasury 20%");
+        assertEq(real.balanceOf(PM_BASE) - pmBefore, lpShare + searcherSwapCost, "LPs 80% + fees");
+        assertEq(pToken.totalSupply(), supplyBefore, "supply restored");
+        assertEq(real.balanceOf(address(hook)), 0, "hook retains nothing");
+    }
+
+    function test_fork_bidBelowFloor_reverts() public {
+        uint256 floor = (FLASH * POLICY_BPS) / 10_000;
+        vm.prank(address(searcher));
+        vm.expectRevert(abi.encodeWithSelector(MoebiusMEVHook.BidBelowFloor.selector, floor - 1, floor));
+        hook.executeMEV(key, FLASH, floor - 1, abi.encode(uint8(0), key, FLASH, zeroIsPToken));
+    }
+
+    function test_fork_nonReturningSearcher_atomicRevert() public {
+        uint256 searcherBefore = real.balanceOf(address(searcher));
+        vm.prank(address(searcher));
+        vm.expectRevert();
+        hook.executeMEV(key, FLASH, 1 ether, abi.encode(uint8(3), key, FLASH, zeroIsPToken));
+        assertEq(real.balanceOf(address(searcher)), searcherBefore, "escrow safe");
+    }
+}

--- a/onchain/test/MoebiusMEVHook.t.sol
+++ b/onchain/test/MoebiusMEVHook.t.sol
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {PoolManager} from "v4-core/src/PoolManager.sol";
+import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "v4-core/src/types/PoolKey.sol";
+import {Currency, CurrencyLibrary} from "v4-core/src/types/Currency.sol";
+import {TickMath} from "v4-core/src/libraries/TickMath.sol";
+import {IHooks} from "v4-core/src/interfaces/IHooks.sol";
+import {LiquidityAmounts} from "v4-periphery/src/libraries/LiquidityAmounts.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {MoebiusMEVHook} from "../src/hooks/MoebiusMEVHook.sol";
+import {PhantomCreditToken} from "../src/hooks/PhantomCreditToken.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockSearcher} from "./mocks/MockSearcher.sol";
+
+contract MoebiusMEVHookTest is Test {
+    using CurrencyLibrary for Currency;
+
+    PoolManager manager;
+    PhantomCreditToken pToken;
+    MoebiusMEVHook hook;
+    MockERC20 real;
+    MockSearcher searcher;
+
+    address treasury = makeAddr("treasury");
+    address stranger = makeAddr("stranger");
+
+    PoolKey key;
+    bool zeroIsPToken;
+
+    uint24 constant DYNAMIC_FEE = 0x800000;
+    uint24 constant POOL_FEE = 3000;
+    int24 constant TICK_SPACING = 60;
+    uint160 constant SQRT_PRICE_1_1 = 79228162514264337593543950336; // 2**96
+
+    uint256 constant SEED_REAL = 100 ether;
+    uint256 constant SEED_PMEV = 100 ether;
+    uint256 constant FLASH = 10 ether;
+    uint256 constant POLICY_BPS = 100; // 1% floor
+
+    uint160 constant ALL_HOOK_MASK = 0x3FFF;
+
+    function setUp() public {
+        manager = new PoolManager(address(this));
+
+        // Circular dependency, production pattern:
+        // 1. predict pToken's CREATE address (next nonce of this deployer)
+        // 2. mine a CREATE2 salt for the hook whose address has ZERO lower-14
+        //    hook-flag bits (required by PoolManager for flag-less hooks)
+        // 3. deploy pToken with the mined hook address, then the hook via CREATE2
+        address predictedPToken = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        bytes32 initHash = keccak256(
+            abi.encodePacked(
+                type(MoebiusMEVHook).creationCode, abi.encode(address(manager), predictedPToken, treasury, POLICY_BPS)
+            )
+        );
+        bytes32 salt;
+        address predictedHook;
+        for (uint256 i = 0;; i++) {
+            salt = bytes32(i);
+            predictedHook = vm.computeCreate2Address(salt, initHash, address(this));
+            if (uint160(predictedHook) & ALL_HOOK_MASK == 0) break;
+        }
+
+        pToken = new PhantomCreditToken(predictedHook);
+        assertEq(address(pToken), predictedPToken, "nonce prediction");
+        hook = new MoebiusMEVHook{salt: salt}(IPoolManager(address(manager)), address(pToken), treasury, POLICY_BPS);
+        assertEq(address(hook), predictedHook, "CREATE2 prediction");
+
+        real = new MockERC20("Real Asset", "REAL");
+
+        // Sort currencies
+        zeroIsPToken = address(pToken) < address(real);
+        key = PoolKey({
+            currency0: Currency.wrap(zeroIsPToken ? address(pToken) : address(real)),
+            currency1: Currency.wrap(zeroIsPToken ? address(real) : address(pToken)),
+            fee: DYNAMIC_FEE,
+            tickSpacing: TICK_SPACING,
+            hooks: IHooks(address(hook))
+        });
+
+        manager.initialize(key, SQRT_PRICE_1_1);
+        hook.setPoolSwapFee(key, POOL_FEE);
+
+        // Seed the redemption window (central bank balance sheet)
+        real.mint(address(this), SEED_REAL * 10);
+        real.approve(address(hook), type(uint256).max);
+
+        uint160 sqrtA = TickMath.getSqrtPriceAtTick(-600);
+        uint160 sqrtB = TickMath.getSqrtPriceAtTick(600);
+        uint256 liquidity = LiquidityAmounts.getLiquidityForAmounts(
+            SQRT_PRICE_1_1,
+            sqrtA,
+            sqrtB,
+            zeroIsPToken ? SEED_PMEV : SEED_REAL,
+            zeroIsPToken ? SEED_REAL : SEED_PMEV
+        );
+        hook.seedLiquidity(key, -600, 600, liquidity, SEED_REAL * 2, SEED_PMEV * 2);
+
+        // Reference searcher, pre-funded with "external venue" real-asset profit
+        searcher = new MockSearcher(address(manager), address(hook));
+        real.mint(address(searcher), 10 ether);
+        vm.prank(address(searcher));
+        real.approve(address(hook), type(uint256).max);
+    }
+
+    function _payload(uint8 mode, uint256 flashAmount) internal view returns (bytes memory) {
+        return abi.encode(mode, key, flashAmount, zeroIsPToken);
+    }
+
+    // ==================== HAPPY PATH ====================
+
+    function test_fullCycle_bidSplitDeterministically() public {
+        uint256 bid = 1 ether;
+        uint256 protocolShare = bid / 5; // 20%
+        uint256 lpShare = bid - protocolShare;
+
+        uint256 treasuryBefore = real.balanceOf(treasury);
+        uint256 pmBefore = real.balanceOf(address(manager));
+        uint256 searcherBefore = real.balanceOf(address(searcher));
+        uint256 supplyBefore = pToken.totalSupply();
+
+        vm.prank(address(searcher));
+        hook.executeMEV(key, FLASH, bid, _payload(1, FLASH));
+
+        // PM gain = LP donation share + the searcher's net swap contribution (fees/impact)
+        uint256 searcherSwapCost = (searcherBefore - real.balanceOf(address(searcher))) - bid;
+        assertEq(real.balanceOf(treasury) - treasuryBefore, protocolShare, "treasury got 20%");
+        assertEq(real.balanceOf(address(manager)) - pmBefore, lpShare + searcherSwapCost, "LPs got 80% + cycle fees");
+        assertEq(pToken.totalSupply(), supplyBefore, "pMEV supply back to seeded level");
+        assertEq(pToken.balanceOf(address(searcher)), 0, "searcher holds no leftover pMEV");
+        assertEq(real.balanceOf(address(hook)), 0, "hook retains nothing");
+    }
+
+    function test_holdMode_escrowAndReturn() public {
+        uint256 bid = 0.5 ether;
+        uint256 pmBefore = real.balanceOf(address(manager));
+
+        vm.prank(address(searcher));
+        hook.executeMEV(key, FLASH, bid, _payload(0, FLASH));
+
+        assertEq(real.balanceOf(treasury), bid / 5, "treasury share");
+        assertEq(real.balanceOf(address(manager)) - pmBefore, bid - bid / 5, "donation share");
+    }
+
+    // ==================== POLICY RATE FLOOR ====================
+
+    function test_bidBelowFloor_reverts() public {
+        uint256 floor = (FLASH * POLICY_BPS) / 10_000; // 0.1 ether
+        vm.prank(address(searcher));
+        vm.expectRevert(abi.encodeWithSelector(MoebiusMEVHook.BidBelowFloor.selector, floor - 1, floor));
+        hook.executeMEV(key, FLASH, floor - 1, _payload(0, FLASH));
+    }
+
+    function test_policyRate_adminOnly() public {
+        vm.prank(stranger);
+        vm.expectRevert(MoebiusMEVHook.Unauthorized.selector);
+        hook.setMinBidBps(200);
+
+        hook.setMinBidBps(200);
+        assertEq(hook.minBidBps(), 200);
+
+        vm.expectRevert(MoebiusMEVHook.RateTooHigh.selector);
+        hook.setMinBidBps(1001);
+    }
+
+    // ==================== SAFETY ====================
+
+    function test_nonReturningSearcher_entireTxReverts_escrowSafe() public {
+        uint256 searcherRealBefore = real.balanceOf(address(searcher));
+
+        vm.prank(address(searcher));
+        vm.expectRevert(); // ERC20 burn underflow on repayment
+        hook.executeMEV(key, FLASH, 1 ether, _payload(3, FLASH));
+
+        assertEq(real.balanceOf(address(searcher)), searcherRealBefore, "escrow reverted back");
+    }
+
+    function test_reentrancy_blocked() public {
+        vm.prank(address(searcher));
+        vm.expectRevert(); // ReentrancyGuardReentrantCall bubbles up
+        hook.executeMEV(key, FLASH, 1 ether, _payload(2, FLASH));
+    }
+
+    function test_onlyHookCanMintBurn() public {
+        vm.expectRevert(PhantomCreditToken.OnlyHook.selector);
+        pToken.mintEphemeral(stranger, 1);
+        vm.expectRevert(PhantomCreditToken.OnlyHook.selector);
+        pToken.burnEphemeral(stranger, 1);
+    }
+
+    function test_wrongPoolKey_reverts() public {
+        PoolKey memory badKey = key;
+        badKey.hooks = IHooks(stranger);
+        vm.prank(address(searcher));
+        vm.expectRevert(MoebiusMEVHook.InvalidPoolKey.selector);
+        hook.executeMEV(badKey, FLASH, 1 ether, _payload(0, FLASH));
+    }
+
+    function test_seededPoolState() public view {
+        // Seeded inventory sits in the PoolManager; supply equals absorbed pMEV
+        assertGt(pToken.totalSupply(), 0, "pMEV inventory exists");
+        assertGt(real.balanceOf(address(manager)), 0, "real asset in pool");
+        assertEq(pToken.balanceOf(address(hook)), 0, "hook burned unabsorbed pMEV");
+    }
+
+    function test_rescue_ownerOnly() public {
+        real.mint(address(hook), 1 ether);
+        vm.prank(stranger);
+        vm.expectRevert(MoebiusMEVHook.Unauthorized.selector);
+        hook.rescue(Currency.wrap(address(real)), 1 ether, stranger);
+
+        hook.rescue(Currency.wrap(address(real)), 1 ether, treasury);
+        assertEq(real.balanceOf(treasury), 1 ether);
+    }
+}

--- a/onchain/test/mocks/MockERC20.sol
+++ b/onchain/test/mocks/MockERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/onchain/test/mocks/MockSearcher.sol
+++ b/onchain/test/mocks/MockSearcher.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
+import {SwapParams} from "v4-core/src/types/PoolOperation.sol";
+import {PoolKey} from "v4-core/src/types/PoolKey.sol";
+import {Currency, CurrencyLibrary} from "v4-core/src/types/Currency.sol";
+import {BalanceDelta} from "v4-core/src/types/BalanceDelta.sol";
+import {TickMath} from "v4-core/src/libraries/TickMath.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IMoebiusHook {
+    function executeMEV(PoolKey calldata key, uint256 flashAmount, uint256 bid, bytes calldata payload) external payable;
+}
+
+/// @notice Reference searcher. Modes (payload[0]):
+///   0 = HOLD:   keep the pMEV, return it intact (tests pure mint/burn/escrow)
+///   1 = CYCLE:  sell all pMEV into the pool, take real asset, rebuy exact pMEV
+///   2 = EVIL:   attempt reentrant executeMEV (must be blocked)
+///   3 = BURN:   send pMEV to a dead address so repayment fails
+contract MockSearcher {
+    using CurrencyLibrary for Currency;
+
+    IPoolManager public immutable poolManager;
+    IMoebiusHook public immutable hook;
+
+    constructor(address _poolManager, address _hook) {
+        poolManager = IPoolManager(_poolManager);
+        hook = IMoebiusHook(_hook);
+    }
+
+    function moebiusExecute(bytes calldata payload) external {
+        (uint8 mode, PoolKey memory key, uint256 flashAmount, bool zeroIsPToken) =
+            abi.decode(payload, (uint8, PoolKey, uint256, bool));
+
+        if (mode == 0) return;
+
+        if (mode == 2) {
+            // Reentrancy attempt - should revert the whole call chain
+            hook.executeMEV(key, flashAmount, 0, payload);
+            return;
+        }
+
+        Currency pmev = zeroIsPToken ? key.currency0 : key.currency1;
+
+        if (mode == 3) {
+            // Send the flash credit to a dead end - repayment must fail
+            IERC20(Currency.unwrap(pmev)).transfer(address(0xdead), flashAmount);
+            return;
+        }
+
+        // mode == 1: full cycle
+        // Sell all pMEV -> real
+        _swapExactIn(key, zeroIsPToken, flashAmount);
+        // Rebuy exactly flashAmount pMEV (uses own pre-funded real asset as "external arb profit")
+        _swapExactOut(key, !zeroIsPToken, flashAmount);
+    }
+
+    function _swapExactIn(PoolKey memory key, bool zeroForOne, uint256 amountIn) internal {
+        Currency input = zeroForOne ? key.currency0 : key.currency1;
+        Currency output = zeroForOne ? key.currency1 : key.currency0;
+
+        BalanceDelta delta = poolManager.swap(
+            key,
+            SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: -int256(amountIn),
+                sqrtPriceLimitX96: zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1
+            }),
+            ""
+        );
+
+        // settle input
+        poolManager.sync(input);
+        IERC20(Currency.unwrap(input)).transfer(address(poolManager), amountIn);
+        poolManager.settle();
+
+        // take output
+        int128 outAmt = zeroForOne ? delta.amount1() : delta.amount0();
+        require(outAmt > 0, "no output");
+        poolManager.take(output, address(this), uint256(uint128(outAmt)));
+    }
+
+    function _swapExactOut(PoolKey memory key, bool zeroForOne, uint256 amountOut) internal {
+        // zeroForOne=true: pay currency0, receive currency1; false: pay currency1, receive currency0
+        Currency input = zeroForOne ? key.currency0 : key.currency1;
+        Currency output = zeroForOne ? key.currency1 : key.currency0;
+
+        BalanceDelta delta = poolManager.swap(
+            key,
+            SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: int256(amountOut),
+                sqrtPriceLimitX96: zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1
+            }),
+            ""
+        );
+
+        int128 inAmt = zeroForOne ? delta.amount0() : delta.amount1();
+        require(inAmt < 0, "no input owed");
+        uint256 owed = uint256(uint128(-inAmt));
+
+        poolManager.sync(input);
+        IERC20(Currency.unwrap(input)).transfer(address(poolManager), owed);
+        poolManager.settle();
+
+        poolManager.take(output, address(this), amountOut);
+    }
+}

--- a/onchain/test/mocks/MockSwapRouter.sol
+++ b/onchain/test/mocks/MockSwapRouter.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
+import {IUnlockCallback} from "v4-core/src/interfaces/callback/IUnlockCallback.sol";
+import {PoolKey} from "v4-core/src/types/PoolKey.sol";
+import {Currency, CurrencyLibrary} from "v4-core/src/types/Currency.sol";
+import {BalanceDelta} from "v4-core/src/types/BalanceDelta.sol";
+import {ModifyLiquidityParams, SwapParams} from "v4-core/src/types/PoolOperation.sol";
+import {TickMath} from "v4-core/src/libraries/TickMath.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @notice Minimal unlock router for tests: add liquidity and swap through a PoolManager.
+contract MockSwapRouter is IUnlockCallback {
+    using CurrencyLibrary for Currency;
+
+    IPoolManager public immutable poolManager;
+
+    bytes32 constant ACTION_LIQ = keccak256("LIQ");
+    bytes32 constant ACTION_SWAP = keccak256("SWAP");
+
+    constructor(address _poolManager) {
+        poolManager = IPoolManager(_poolManager);
+    }
+
+    function addLiquidity(PoolKey calldata key, int24 tickLower, int24 tickUpper, uint256 liquidity) external {
+        poolManager.unlock(abi.encode(ACTION_LIQ, key, tickLower, tickUpper, liquidity, msg.sender));
+    }
+
+    function swapExactIn(PoolKey calldata key, bool zeroForOne, uint256 amountIn) external returns (uint256 amountOut) {
+        bytes memory result =
+            poolManager.unlock(abi.encode(ACTION_SWAP, key, zeroForOne, amountIn, msg.sender));
+        return abi.decode(result, (uint256));
+    }
+
+    function unlockCallback(bytes calldata data) external returns (bytes memory) {
+        require(msg.sender == address(poolManager), "only PM");
+        bytes32 action = abi.decode(data, (bytes32));
+
+        if (action == ACTION_LIQ) {
+            (, PoolKey memory key, int24 tickLower, int24 tickUpper, uint256 liquidity, address payer) =
+                abi.decode(data, (bytes32, PoolKey, int24, int24, uint256, address));
+            (BalanceDelta delta,) = poolManager.modifyLiquidity(
+                key,
+                ModifyLiquidityParams({
+                    tickLower: tickLower, tickUpper: tickUpper, liquidityDelta: int256(liquidity), salt: bytes32(0)
+                }),
+                ""
+            );
+            _settleDelta(key.currency0, delta.amount0(), payer);
+            _settleDelta(key.currency1, delta.amount1(), payer);
+            return "";
+        }
+
+        // SWAP
+        (, PoolKey memory key, bool zeroForOne, uint256 amountIn, address payer) =
+            abi.decode(data, (bytes32, PoolKey, bool, uint256, address));
+        BalanceDelta delta = poolManager.swap(
+            key,
+            SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: -int256(amountIn),
+                sqrtPriceLimitX96: zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1
+            }),
+            ""
+        );
+        Currency input = zeroForOne ? key.currency0 : key.currency1;
+        Currency output = zeroForOne ? key.currency1 : key.currency0;
+        int128 outAmt = zeroForOne ? delta.amount1() : delta.amount0();
+
+        _pay(input, uint256(uint128(zeroForOne ? -delta.amount0() : -delta.amount1())), payer);
+        poolManager.take(output, payer, uint256(uint128(outAmt)));
+
+        return abi.encode(uint256(uint128(outAmt)));
+    }
+
+    function _settleDelta(Currency currency, int128 deltaAmount, address payer) internal {
+        if (deltaAmount >= 0) return;
+        _pay(currency, uint256(uint128(-deltaAmount)), payer);
+    }
+
+    function _pay(Currency currency, uint256 amount, address payer) internal {
+        poolManager.sync(currency);
+        IERC20(Currency.unwrap(currency)).transferFrom(payer, address(poolManager), amount);
+        poolManager.settle();
+    }
+}


### PR DESCRIPTION
## Summary

Review of the MoebiusMEVHook v1 found the central mechanism was economically unenforceable: the 10% tax was computed on the searcher's **self-declared** `expectedProfit` and "enforced" by sniffing the hook's own balance — a rational searcher declares 1 wei and pays dust, and anyone can dust the hook to corrupt the accounting. This PR rewrites the mechanism around an **escrowed sealed bid** and adds the missing deployment path. Full test suite: **10/10 passing** (solc 0.8.26, cancun).

## Changes

- **`src/hooks/MoebiusMEVHook.sol` (rewritten)**
  - Bid escrowed upfront in the pool's real asset (`transferFrom` / `msg.value`). The bid IS the tax — under-declaration is no longer possible.
  - Deterministic split: 80% donated to in-range LPs inside the unlock frame, 20% to treasury after successful completion. Any failure reverts the entire tx including escrow.
  - `minBidBps` policy-rate floor: bid must scale with flash amount.
  - `setPoolSwapFee`: hook-owned dynamic-fee pools (policy lever #2).
  - `seedLiquidity`: central-bank desk — hook flash-mints pMEV inventory and LPs it with owner real asset, giving pMEV a price and searchers a venue.
  - Drops `BaseHook` (removed in current v4-periphery); implements `IUnlockCallback` directly. Typed unlock actions + nested-unlock payload revalidation. Fee-on-transfer assets rejected at escrow.
- **`script/DeployMoebius.s.sol` (new)** — one-command activation: predicts pMEV's CREATE address from deployer nonce, mines a CREATE2 salt so the hook lands on a zero-flag address (required by `Hooks.isValidHookAddress`), deploys both, asserts no drift.
- **`test/MoebiusMEVHook.t.sol` + mocks (new)** — full cycle (mint → sell → rebuy → burn → 20/80 split), policy floor, atomicity on non-repayment, reentrancy block, access control.
- **`MOEBIUS_V2_NOTES.md`** — rationale, migration table, activation runbook.

## Important deployment notes

- Zero-flag hooks are only valid on **dynamic-fee pools** — initialize pMEV pools with `fee = 0x800000`, then `setPoolSwapFee`.
- Before mainnet funds: external audit, multisig owner, native-ETH test coverage, wide seed range (donate reverts with no in-range liquidity).

## Test plan

`forge test` → 10/10 passing, including the deterministic bid split (treasury 20%, LPs 80% + cycle fees) and full atomicity on searcher default.