### PR TITLE
feat(onchain): Fluid Protocol amplification layer — verified adapter, deploy, fork tests, dashboard SDK

### DIFF
--- a/onchain/docs/FLUID_INTEGRATION.md
+++ b/onchain/docs/FLUID_INTEGRATION.md
@@ -1,0 +1,135 @@
+# Fluid Amplification — Integration Runbook (SINC × Fluid, Base 8453)
+
+Implements the vault deposit/withdraw extension onto Fluid's unified liquidity layer.
+All addresses and signatures below were verified against `Instadapp/fluid-contracts-public`
+sources and Base deployment artifacts — not assumed.
+
+---
+
+## 0. Verified Fluid Base addresses
+
+| Contract | Address |
+|---|---|
+| Liquidity (unified layer) | `0x52Aa899454998Be5b000Ad077a46Bbe360F4e497` |
+| DexFactory | `0x91716C4EDA1Fb55e84Bf8b4c7085f84285c19085` |
+| fUSDC (ERC-4626 lending) | `0xf42f5795D9ac7e9D757dB633D693cD548Cfd9169` |
+| fWETH | `0x9272D6153133175175Bc276512B2336BE3931CE9` |
+| DexResolver | `0x11D80CfF056Cef4F9E6d23da8672fE9873e5cC07` |
+| LendingResolver | `0x48D32f49aFeAEC7AE66ad7B9264f446fc11a1569` |
+| SINC (8 dec) | `0x9C8cd8d3961F445D653713dE65C6578bE11668e7` |
+| USDC (6 dec) | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+
+Pool token order for SINC-USDC: **token0 = USDC, token1 = SINC** (Fluid orders by address).
+
+## 1. Governance gates — facts, not assumptions
+
+Verified in the Fluid factory/vault sources:
+
+1. **`DexFactory.deployDex()` reverts unless `isDeployer(msg.sender)`.** Pool creation
+   is NOT permissionless on DEX v1. Fluid governance must either list the SINC-USDC
+   pair itself or grant deployer access to the treasury/multisig.
+2. **Smart collateral/debt config is governance-controlled.** Fluid governance controls
+   which token pairs get Liquidity-layer configs, oracles, LTVs. SINC has no oracle on
+   Fluid today — a SINC-USDC pool with oracle-backed pricing is a prerequisite for
+   borrowing against SINC collateral.
+3. **`Liquidity.operate()` is protocol-auth gated.** Direct calls from unlisted
+   contracts revert. The adapter correctly enters via fToken.deposit / DexT1.deposit /
+   Vault.operate — the user-level surfaces.
+
+**Action (blocking Stage 2-3):** open a Fluid governance/BD request to list SINC-USDC
+on Fluid DEX with smart collateral enabled (or obtain deployer access for the treasury
+multisig). Everything else below ships without waiting on it.
+
+## 2. What shipped in this PR
+
+| File | Purpose |
+|---|---|
+| `src/fluid/FluidInterfaces.sol` | Verified Fluid interfaces (Liquidity, DexFactory, DexT1, VaultT1, fToken) |
+| `src/fluid/SincFluidAdapter.sol` | Vault extension: Stage 1 fUSDC deposits (live), Stage 2 smart collateral, Stage 3 smart debt / Vault operate |
+| `script/DeploySincFluidAdapter.s.sol` | Foundry deploy script (Base, chain-guarded) |
+| `test/SincFluidAdapter.fork.t.sol` | Base-fork test: full fUSDC loop + deployer-gate proof |
+| `sdk/fluid-amplify.js` | getsincor.com drop-in: "Amplify SINC Liquidity" button + live reads |
+
+## 3. Build + test
+
+```bash
+cd onchain
+forge build
+BASE_RPC_URL=https://mainnet.base.org \
+  forge test --match-path test/SincFluidAdapter.fork.t.sol -vvv
+```
+
+Expected: 4 passing (infra live, deployer-gate blocked, fUSDC loop, DEX paths revert-until-set).
+
+## 4. Deploy (after fork test green + slither clean)
+
+```bash
+slither src/fluid/SincFluidAdapter.sol --config-file slither.config.json
+
+forge script script/DeploySincFluidAdapter.s.sol \
+  --rpc-url $BASE_RPC_URL \
+  --broadcast --verify \
+  --etherscan-api-key $BASESCAN_API_KEY -vvvv
+# set ADAPTER=<deployed address>
+```
+
+**Audit gate before mainnet scale:** external audit + cap initial deposits
+(e.g. max $10k treasury seed). No user funds until audit closes.
+
+## 5. Wire into SharedLiquidityVault
+
+```bash
+VAULT=0xeA90a257e5Dae20a0472C4812775F28614459bb6
+# register adapter as the strategy backer (strategyId per vault layout)
+cast send $VAULT "registerStrategy(uint256,string,address,address)" \
+  <ID> "fluid-amplify" $ADAPTER $ADAPTER \
+  --rpc-url $BASE_RPC_URL --private-key $GUARDIAN_KEY
+```
+
+## 6. Dashboard (getsincor.com)
+
+1. Copy `onchain/sdk/fluid-amplify.js` into the site assets.
+2. Set `ADAPTER` to the deployed address.
+3. Add the button (snippet at bottom of the JS file). Flow: connect → switch to Base
+   → approve USDC → `depositUSDC`. Live value comes from `userValueUSDC(user)`;
+   once the pair is live, `amplifyPair(sinc, usdc)` supplies both as smart collateral.
+4. Pool stats (fee APR, reserves, col/debt totals): `DexResolver.getDexEntireData(dex)`
+   and `LendingResolver` for fUSDC rates. Full struct ABIs are in the Fluid deployment
+   artifacts (Basescan-verified at the resolver addresses).
+
+## 7. Seed the pair (post-governance)
+
+Once Fluid lists SINC-USDC (or grants deployer access and the multisig runs
+`deploySincUsdcDex`):
+
+```bash
+# 1. point adapter at the new pool
+cast send $ADAPTER "setFluidDex(address)" $DEX --rpc-url $BASE_RPC_URL --private-key $GUARDIAN_KEY
+
+# 2. treasury approves + seeds (sized to the $1.50 floor valuation — SINC is 8 decimals)
+cast send $SINC "approve(address,uint256)" $ADAPTER <SINC_AMT> --rpc-url $BASE_RPC_URL --private-key $TREASURY_KEY
+cast send $USDC "approve(address,uint256)" $ADAPTER <USDC_AMT> --rpc-url $BASE_RPC_URL --private-key $TREASURY_KEY
+cast send $ADAPTER "supplyToDex(uint256,uint256,uint256)" <SINC_AMT> <USDC_AMT> 0 \
+  --rpc-url $BASE_RPC_URL --private-key $TREASURY_KEY
+
+# 3. optional smart-debt loop (conservative; liquidation-managed)
+cast send $ADAPTER "borrowSmartDebt(uint256,uint256,uint256,address)" \
+  <SHARES> <MIN_USDC> <MIN_SINC> $TREASURY \
+  --rpc-url $BASE_RPC_URL --private-key $GUARDIAN_KEY
+```
+
+## 8. Announce + bootstrap
+
+- Announce only after: adapter verified on Basescan, fork test green, treasury seed
+  confirmed on-chain, dashboard button live.
+- SINC incentives for vault LPs: route through the existing rewards path
+  (SharedLiquidityVault settleUp) — do not add a second rewarder in the adapter.
+- Publish the adapter address in CANONICAL_ADDRESSES.md post-deploy.
+
+## 9. Honest scope notes
+
+- "3-5x capital efficiency" is a property of Fluid smart collateral/debt once the pair
+  is listed and configured by Fluid governance — it is not achievable today by code alone.
+  Stage 1 (fUSDC yield on the USDC leg) is live and permissionless now.
+- Per-user borrowing is intentionally not pooled through the adapter; treasury-level
+  leverage is guardian-gated.

--- a/onchain/script/DeploySincFluidAdapter.s.sol
+++ b/onchain/script/DeploySincFluidAdapter.s.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {SincFluidAdapter} from "../src/fluid/SincFluidAdapter.sol";
+
+/// @notice Deploys SincFluidAdapter on Base (8453).
+///         forge script script/DeploySincFluidAdapter.s.sol \
+///           --rpc-url $BASE_RPC_URL --broadcast --verify \
+///           --etherscan-api-key $BASESCAN_API_KEY -vvvv
+///         Env overrides: SINC_ADDRESS / USDC_ADDRESS / GUARDIAN_ADDRESS / TREASURY_ADDRESS
+contract DeploySincFluidAdapter is Script {
+    // Canonical Base addresses (CANONICAL_ADDRESSES.md wins if drift is ever found)
+    address constant SINC = 0x9C8cd8d3961F445D653713dE65C6578bE11668e7;      // 8 decimals
+    address constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;      // 6 decimals
+    address constant TREASURY = 0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac;
+    address constant GUARDIAN = 0xdba7180cdd90D12B9Bc2F15080ddFD9B14fEf31a;   // TODO: rotate to multisig
+
+    function run() external {
+        address sinc = vm.envOr("SINC_ADDRESS", SINC);
+        address usdc = vm.envOr("USDC_ADDRESS", USDC);
+        address guardian = vm.envOr("GUARDIAN_ADDRESS", GUARDIAN);
+        address treasury = vm.envOr("TREASURY_ADDRESS", TREASURY);
+
+        require(block.chainid == 8453, "Base mainnet only");
+
+        vm.startBroadcast();
+        SincFluidAdapter adapter = new SincFluidAdapter(IERC20Like(sinc), IERC20Like(usdc), guardian, treasury);
+        vm.stopBroadcast();
+
+        console.log("SincFluidAdapter:", address(adapter));
+        console.log("  guardian:", guardian);
+        console.log("  treasury:", treasury);
+        console.log("Next: register as strategy backer in SharedLiquidityVault 0xeA90a257e5Dae20a0472C4812775F28614459bb6");
+    }
+}
+
+interface IERC20Like {
+    function balanceOf(address) external view returns (uint256);
+}

--- a/onchain/script/DeploySincFluidAdapter.s.sol
+++ b/onchain/script/DeploySincFluidAdapter.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.26;
 
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SincFluidAdapter} from "../src/fluid/SincFluidAdapter.sol";
 
 /// @notice Deploys SincFluidAdapter on Base (8453).
@@ -26,7 +27,7 @@ contract DeploySincFluidAdapter is Script {
         require(block.chainid == 8453, "Base mainnet only");
 
         vm.startBroadcast();
-        SincFluidAdapter adapter = new SincFluidAdapter(IERC20Like(sinc), IERC20Like(usdc), guardian, treasury);
+        SincFluidAdapter adapter = new SincFluidAdapter(IERC20(sinc), IERC20(usdc), guardian, treasury);
         vm.stopBroadcast();
 
         console.log("SincFluidAdapter:", address(adapter));
@@ -34,8 +35,4 @@ contract DeploySincFluidAdapter is Script {
         console.log("  treasury:", treasury);
         console.log("Next: register as strategy backer in SharedLiquidityVault 0xeA90a257e5Dae20a0472C4812775F28614459bb6");
     }
-}
-
-interface IERC20Like {
-    function balanceOf(address) external view returns (uint256);
 }

--- a/onchain/sdk/fluid-amplify.js
+++ b/onchain/sdk/fluid-amplify.js
@@ -1,0 +1,120 @@
+/* fluid-amplify.js — getsincor.com dashboard drop-in
+ * "Amplify SINC Liquidity" button: connect → approve SINC/USDC → deposit to SincFluidAdapter.
+ * Live position value + multiplier read from the adapter + Fluid fUSDC (chain 8453).
+ * Deps: ethers v6 (CDN: https://cdn.jsdelivr.net/npm/ethers@6.13.4/dist/ethers.umd.min.js)
+ */
+
+const CHAIN_ID = 8453;
+const SINC   = "0x9C8cd8d3961F445D653713dE65C6578bE11668e7"; // 8 decimals
+const USDC   = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"; // 6 decimals
+const ADAPTER = "0x0000000000000000000000000000000000000000"; // TODO: set post-deploy
+const F_USDC = "0xf42f5795D9ac7e9D757dB633D693cD548Cfd9169";
+const DEX_RESOLVER = "0x11D80CfF056Cef4F9E6d23da8672fE9873e5cC07";
+
+const ERC20_ABI = [
+  "function approve(address spender, uint256 amount) returns (bool)",
+  "function allowance(address owner, address spender) view returns (uint256)",
+];
+const ADAPTER_ABI = [
+  "function depositUSDC(uint256 assets) returns (uint256)",
+  "function withdrawUSDC(uint256 shares) returns (uint256)",
+  "function supplyToDex(uint256 sincAmt, uint256 usdcAmt, uint256 minShares) returns (uint256)",
+  "function fUsdcShares(address user) view returns (uint256)",
+  "function dexColShares(address user) view returns (uint256)",
+  "function userValueUSDC(address user) view returns (uint256)",
+  "function fluidDex() view returns (address)",
+];
+const FTOKEN_ABI = [
+  "function convertToAssets(uint256 shares) view returns (uint256)",
+  "function totalSupply() view returns (uint256)",
+];
+// DexResolver.getDexEntireData(dexAddr) returns the full pool struct (state, fee,
+// reserves, col/debt totals) — decode with the ABI from Basescan of DEX_RESOLVER.
+const DEX_RESOLVER_ABI = ["function getDexEntireData(address dex_) view returns (tuple())"]; // placeholder: replace with full struct ABI
+
+let provider, signer, account;
+
+export async function connect() {
+  if (!window.ethereum) throw new Error("No wallet");
+  provider = new ethers.BrowserProvider(window.ethereum);
+  const net = await provider.getNetwork();
+  if (Number(net.chainId) !== CHAIN_ID) {
+    await window.ethereum.request({ method: "wallet_switchEthereumChain", params: [{ chainId: "0x2105" }] });
+  }
+  signer = await provider.getSigner();
+  account = await signer.getAddress();
+  return account;
+}
+
+async function ensureAllowance(token, amount) {
+  const c = new ethers.Contract(token, ERC20_ABI, signer);
+  const cur = await c.allowance(account, ADAPTER);
+  if (cur < amount) {
+    const tx = await c.approve(ADAPTER, amount);
+    await tx.wait();
+  }
+}
+
+// ---- Button flow: Amplify ----
+// usdcAmount: human units (e.g. 100 = 100 USDC). Deposits the USDC leg into Fluid
+// fUSDC now; once fluidDex() != 0x0 the button also offers the SINC+USDC pair leg.
+export async function amplify(usdcAmount) {
+  const assets = ethers.parseUnits(String(usdcAmount), 6);
+  await ensureAllowance(USDC, assets);
+  const adapter = new ethers.Contract(ADAPTER, ADAPTER_ABI, signer);
+  const tx = await adapter.depositUSDC(assets);
+  await tx.wait();
+  return refreshPanel();
+}
+
+// Pair leg (post-Fluid-governance): supplies SINC+USDC as smart collateral.
+export async function amplifyPair(sincAmount, usdcAmount, slippageBps = 50) {
+  const sincAmt = ethers.parseUnits(String(sincAmount), 8);
+  const usdcAmt = ethers.parseUnits(String(usdcAmount), 6);
+  await ensureAllowance(SINC, sincAmt);
+  await ensureAllowance(USDC, usdcAmt);
+  const adapter = new ethers.Contract(ADAPTER, ADAPTER_ABI, signer);
+  if ((await adapter.fluidDex()) === ethers.ZeroAddress) throw new Error("SINC-USDC Fluid DEX not listed yet");
+  // minShares=0 acceptable at bootstrap (treasury seeds first); tighten post-seed
+  const tx = await adapter.supplyToDex(sincAmt, usdcAmt, 0);
+  await tx.wait();
+  return refreshPanel();
+}
+
+export async function unamplify(shares) {
+  const adapter = new ethers.Contract(ADAPTER, ADAPTER_ABI, signer);
+  const tx = await adapter.withdrawUSDC(shares);
+  await tx.wait();
+  return refreshPanel();
+}
+
+// ---- Live reads for the dashboard ----
+export async function refreshPanel() {
+  const adapter = new ethers.Contract(ADAPTER, ADAPTER_ABI, provider);
+  const fUsdc = new ethers.Contract(F_USDC, FTOKEN_ABI, provider);
+  const shares = await adapter.fUsdcShares(account);
+  const valueUsdc = await fUsdc.convertToAssets(shares);
+  const colShares = await adapter.dexColShares(account);
+  const dex = await adapter.fluidDex();
+  return {
+    lendingShares: shares.toString(),
+    lendingValueUSDC: ethers.formatUnits(valueUsdc, 6),
+    smartColShares: colShares.toString(),
+    pairLive: dex !== ethers.ZeroAddress,
+    // multiplier: user's effective leverage = (col value + borrowed redeployed) / own capital.
+    // Per-user borrowing is treasury-gated by design; show target 3-5x as config, not live fact.
+    targetMultiplier: "3-5x (treasury smart-debt stage)",
+  };
+}
+
+/* HTML:
+ * <button id="amplifyBtn">Amplify SINC Liquidity</button>
+ * <script type="module">
+ *   import { connect, amplify, refreshPanel } from "./fluid-amplify.js";
+ *   document.getElementById("amplifyBtn").onclick = async () => {
+ *     await connect();
+ *     const r = await amplify(100); // 100 USDC
+ *     console.log(r);
+ *   };
+ * </script>
+ */

--- a/onchain/src/fluid/FluidInterfaces.sol
+++ b/onchain/src/fluid/FluidInterfaces.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+/// @title  FluidInterfaces — Fluid Protocol surface, Base (chain 8453)
+/// @notice Signatures verified against Instadapp/fluid-contracts-public sources
+///         and deployment artifacts (commit a9949b48). Do not "fix" param names;
+///         they match the live contracts.
+///
+/// Verified Base addresses:
+///   Liquidity        0x52Aa899454998Be5b000Ad077a46Bbe360F4e497
+///   DexFactory       0x91716C4EDA1Fb55e84Bf8b4c7085f84285c19085
+///   fUSDC            0xf42f5795D9ac7e9D757dB633D693cD548Cfd9169
+///   fWETH            0x9272D6153133175175Bc276512B2336BE3931CE9
+///   DexResolver      0x11D80CfF056Cef4F9E6d23da8672fE9873e5cC07
+///   LendingResolver  0x48D32f49aFeAEC7AE66ad7B9264f446fc11a1569
+
+/// @notice Fluid Liquidity layer — the unified liquidity hub every Fluid protocol
+///         (fTokens, Vaults, DEXes) settles against.
+/// @dev    PROTOCOL-AUTH GATED: only Fluid-listed protocols may call operate().
+///         Calling this directly from an unlisted contract reverts. User-level
+///         entry points are fToken.deposit / Vault.operate / DEX deposit+borrow.
+interface IFluidLiquidity {
+    function operate(
+        address token_,
+        int256 supplyAmount_,   // >0 supply (pulls from supplyTo_), <0 withdraw
+        int256 borrowAmount_,   // >0 borrow (sends to borrowTo_), <0 payback
+        address supplyTo_,
+        address borrowTo_,
+        bytes memory callbackData_
+    ) external payable returns (bytes memory);
+}
+
+/// @notice Fluid DEX factory.
+/// @dev    GOVERNANCE GATE (verified in factory main.sol):
+///         deployDex reverts with DexFactory__Unauthorized unless
+///         isDeployer(msg.sender) — Fluid governance must grant deployer access.
+interface IFluidDexFactory {
+    function deployDex(address dexDeploymentLogic_, bytes calldata dexDeploymentData_) external returns (address dex_);
+    function getDexAddress(uint256 dexId_) external view returns (address);
+    function isDeployer(address account_) external view returns (bool);
+    function owner() external view returns (address);
+}
+
+/// @notice Fluid DEX T1 pool. Col side = "smart collateral" (your deposit IS the
+///         LP liquidity and earns swap fees). Debt side = "smart debt" (your debt
+///         is deployed as LP liquidity too). Shares are internal balances, not ERC20.
+interface IFluidDexT1 {
+    // ---- smart collateral ----
+    function deposit(uint256 token0Amt_, uint256 token1Amt_, uint256 minSharesAmt_, bool estimate_)
+        external payable returns (uint256 shares_);
+    function depositPerfect(uint256 shares_, uint256 maxToken0Deposit_, uint256 maxToken1Deposit_, bool estimate_)
+        external payable returns (uint256 token0Amt_, uint256 token1Amt_);
+    function withdraw(uint256 token0Amt_, uint256 token1Amt_, uint256 maxSharesAmt_, address to_)
+        external returns (uint256 shares_);
+    function withdrawPerfect(uint256 shares_, uint256 minToken0Withdraw_, uint256 minToken1Withdraw_, address to_)
+        external returns (uint256 token0Amt_, uint256 token1Amt_);
+
+    // ---- smart debt ----
+    function borrow(uint256 token0Amt_, uint256 token1Amt_, uint256 maxSharesAmt_, address to_)
+        external returns (uint256 shares_);
+    function borrowPerfect(uint256 shares_, uint256 minToken0Borrow_, uint256 minToken1Borrow_, address to_)
+        external returns (uint256 token0Amt_, uint256 token1Amt_);
+    function payback(uint256 token0Amt_, uint256 token1Amt_, uint256 minSharesAmt_, bool estimate_)
+        external payable returns (uint256 shares_);
+    function paybackPerfect(uint256 shares_, uint256 maxToken0Payback_, uint256 maxToken1Payback_, bool estimate_)
+        external payable returns (uint256 token0Amt_, uint256 token1Amt_);
+
+    // ---- swaps ----
+    function swapIn(bool swap0to1_, uint256 amountIn_, uint256 amountOutMin_, address to_)
+        external payable returns (uint256 amountOut_);
+    function swapOut(bool swap0to1_, uint256 amountOut_, uint256 amountInMax_, address to_)
+        external payable returns (uint256 amountIn_);
+}
+
+/// @notice Fluid Vault (T1..T4). VaultT2 = smart collateral (DEX LP) vs normal debt.
+///         VaultT4 = smart collateral vs smart debt. operate() is the single entry
+///         point for every position: nftId_==0 opens a new position NFT.
+interface IFluidVaultT1 {
+    function operate(
+        uint256 nftId_,      // 0 = new position
+        int256 newCol_,      // >0 add collateral, <0 withdraw
+        int256 newDebt_,     // >0 borrow, <0 payback
+        address to_          // receiver of borrow/withdraw; address(0) = msg.sender
+    ) external payable returns (uint256 nftIdOut_, int256, int256);
+
+    function LIQUIDITY() external view returns (address);
+    function TYPE() external view returns (uint256);
+}
+
+/// @notice Fluid fToken (ERC-4626 lending vault, e.g. fUSDC). Permissionless.
+interface IFToken {
+    function deposit(uint256 assets_, address receiver_) external returns (uint256 shares_);
+    function redeem(uint256 shares_, address receiver_, address owner_) external returns (uint256 assets_);
+    function balanceOf(address account_) external view returns (uint256);
+    function convertToAssets(uint256 shares_) external view returns (uint256);
+    function convertToShares(uint256 assets_) external view returns (uint256);
+    function asset() external view returns (address);
+}

--- a/onchain/src/fluid/SincFluidAdapter.sol
+++ b/onchain/src/fluid/SincFluidAdapter.sol
@@ -18,15 +18,19 @@ import {IFluidLiquidity, IFluidDexFactory, IFluidDexT1, IFluidVaultT1, IFToken} 
 ///   Stage 2 (after Fluid governance deploys/lists the SINC-USDC DEX): the pair
 ///           is supplied via DexT1.deposit() as SMART COLLATERAL — the position is
 ///           the LP liquidity itself and earns swap fees while it can back borrows.
-///           deployDex is deployer-auth gated by Fluid governance (verified); the
-///           pair must be created/listed by Fluid or a governance-authorized deployer.
+///           deployDex is deployer-auth gated by Fluid governance (verified in
+///           factory main.sol); the pair must be created/listed by Fluid or a
+///           governance-authorized deployer.
 ///
 ///   Stage 3 (treasury-only, after Stage 2): smart debt / VaultT2 operate() lets
 ///           treasury borrow against the smart-collateral LP to compound depth.
 ///           Guardian-gated. Per-user borrowing is deliberately NOT pooled here —
 ///           each user's debt position must be their own Fluid account.
 ///
-/// @dev    SINC has 8 decimals; USDC has 6. All amounts are raw token units.
+/// @dev    Pool token order: Fluid DEX T1 orders token0/token1 by token address.
+///         USDC 0x8335…fCD6… < SINC 0x9C8c…d396…, so for SINC-USDC:
+///         token0 = USDC (6 decimals), token1 = SINC (8 decimals). All external
+///         functions here take (sincAmt, usdcAmt) and re-order internally.
 ///         Token approvals target the Fluid Liquidity contract (the layer that
 ///         settles every Fluid protocol), fUSDC for the lending leg.
 ///         Wired into SharedLiquidityVault as a strategy backer (registerStrategy).
@@ -41,8 +45,8 @@ contract SincFluidAdapter is ReentrancyGuard, Pausable {
     address public constant DEX_RESOLVER = 0x11D80CfF056Cef4F9E6d23da8672fE9873e5cC07;
     address public constant LENDING_RESOLVER = 0x48D32f49aFeAEC7AE66ad7B9264f446fc11a1569;
 
-    IERC20 public immutable SINC;
-    IERC20 public immutable USDC;
+    IERC20 public immutable SINC;   // token1 in pool order
+    IERC20 public immutable USDC;   // token0 in pool order
     address public immutable guardian;
     address public treasury;
 
@@ -62,10 +66,10 @@ contract SincFluidAdapter is ReentrancyGuard, Pausable {
 
     event FluidDepositUSDC(address indexed user, uint256 assets, uint256 shares);
     event FluidWithdrawUSDC(address indexed user, uint256 assets, uint256 shares);
-    event DexSupplied(address indexed user, address indexed dex, uint256 token0Amt, uint256 token1Amt, uint256 shares);
-    event DexWithdrawn(address indexed user, address indexed dex, uint256 token0Amt, uint256 token1Amt, uint256 shares);
-    event SmartDebtBorrowed(address indexed dex, uint256 token0Amt, uint256 token1Amt, uint256 shares, address to);
-    event SmartDebtRepaid(address indexed dex, uint256 token0Amt, uint256 token1Amt, uint256 shares);
+    event DexSupplied(address indexed user, address indexed dex, uint256 sincAmt, uint256 usdcAmt, uint256 shares);
+    event DexWithdrawn(address indexed user, address indexed dex, uint256 sincAmt, uint256 usdcAmt, uint256 shares);
+    event SmartDebtBorrowed(address indexed dex, uint256 usdcBorrowed, uint256 sincBorrowed, uint256 shares, address to);
+    event SmartDebtRepaid(address indexed dex, uint256 usdcRepaid, uint256 sincRepaid, uint256 shares);
     event VaultOperated(address indexed vault, uint256 nftId, int256 newCol, int256 newDebt, address to);
     event FluidDexUpdated(address dex);
     event SmartVaultUpdated(address vault);
@@ -103,7 +107,7 @@ contract SincFluidAdapter is ReentrancyGuard, Pausable {
     // ==================== STAGE 1 — FLUID LENDING (permissionless, live) ====================
 
     /// @notice Deposit USDC into Fluid fUSDC. Shares are held by the adapter and
-    ///         accounted per user. Live multiplier: reads via LendingResolver / convertToAssets.
+    ///         accounted per user. Live value: userValueUSDC() / LendingResolver.
     function depositUSDC(uint256 assets) external nonReentrant whenNotPaused returns (uint256 shares) {
         if (assets == 0) revert ZeroAmount();
         USDC.safeTransferFrom(msg.sender, address(this), assets);
@@ -132,8 +136,7 @@ contract SincFluidAdapter is ReentrancyGuard, Pausable {
 
     /// @notice Supply SINC + USDC into the SINC-USDC Fluid DEX as smart collateral.
     ///         The resulting position IS the pool's LP liquidity and earns swap fees.
-    ///         token0/token1 amounts are in pool order — check DexResolver.constantsView()
-    ///         (SINC 0x9C8c… > USDC 0x8335…, so SINC is likely token1; confirm on-chain).
+    ///         Internal call uses pool order: token0 = USDC, token1 = SINC.
     function supplyToDex(uint256 sincAmt, uint256 usdcAmt, uint256 minShares)
         external nonReentrant whenNotPaused returns (uint256 shares)
     {
@@ -144,7 +147,8 @@ contract SincFluidAdapter is ReentrancyGuard, Pausable {
         if (sincAmt > 0) SINC.safeTransferFrom(msg.sender, address(this), sincAmt);
         if (usdcAmt > 0) USDC.safeTransferFrom(msg.sender, address(this), usdcAmt);
 
-        shares = IFluidDexT1(dex).deposit(sincAmt, usdcAmt, minShares, false);
+        // DexT1.deposit(token0Amt, token1Amt, minShares, estimate) — pool order.
+        shares = IFluidDexT1(dex).deposit(usdcAmt, sincAmt, minShares, false);
         dexColShares[msg.sender] += shares;
         totalDexColShares += shares;
         emit DexSupplied(msg.sender, dex, sincAmt, usdcAmt, shares);
@@ -156,7 +160,8 @@ contract SincFluidAdapter is ReentrancyGuard, Pausable {
     {
         address dex = fluidDex;
         if (dex == address(0)) revert DexNotSet();
-        shares = IFluidDexT1(dex).withdraw(sincAmt, usdcAmt, maxShares, msg.sender);
+        // DexT1.withdraw(token0Amt, token1Amt, maxShares, to) — pool order.
+        shares = IFluidDexT1(dex).withdraw(usdcAmt, sincAmt, maxShares, msg.sender);
         uint256 owned = dexColShares[msg.sender];
         if (shares > owned) revert InsufficientShares(shares, owned);
         dexColShares[msg.sender] = owned - shares;
@@ -168,28 +173,31 @@ contract SincFluidAdapter is ReentrancyGuard, Pausable {
 
     /// @notice Treasury borrows against smart-collateral LP. Debt itself is deployed
     ///         as LP liquidity (Fluid smart debt) once enabled on the pair.
-    function borrowSmartDebt(uint256 shares, uint256 minToken0Borrow, uint256 minToken1Borrow, address to)
+    ///         minToken0Borrow = USDC leg, minToken1Borrow = SINC leg (pool order).
+    function borrowSmartDebt(uint256 shares, uint256 minUsdcBorrow, uint256 minSincBorrow, address to)
         external onlyGuardian nonReentrant whenNotPaused
     {
         address dex = fluidDex;
         if (dex == address(0)) revert DexNotSet();
-        (uint256 a0, uint256 a1) = IFluidDexT1(dex).borrowPerfect(shares, minToken0Borrow, minToken1Borrow, to == address(0) ? treasury : to);
+        (uint256 usdcOut, uint256 sincOut) =
+            IFluidDexT1(dex).borrowPerfect(shares, minUsdcBorrow, minSincBorrow, to == address(0) ? treasury : to);
         totalDebtShares += shares;
-        emit SmartDebtBorrowed(dex, a0, a1, shares, to);
+        emit SmartDebtBorrowed(dex, usdcOut, sincOut, shares, to);
     }
 
-    /// @notice Repay smart debt. Pulls repayment tokens from the guardian caller.
-    function paybackSmartDebt(uint256 token0Amt, uint256 token1Amt, uint256 minShares)
+    /// @notice Repay smart debt. Pulls repayment tokens from the guardian caller
+    ///         (adapter already holds max Liquidity approvals).
+    function paybackSmartDebt(uint256 usdcAmt, uint256 sincAmt, uint256 minShares)
         external onlyGuardian nonReentrant returns (uint256 shares)
     {
         address dex = fluidDex;
         if (dex == address(0)) revert DexNotSet();
-        if (token0Amt > 0) IERC20(IFluidDexT1(dex) == IFluidDexT1(dex) ? address(SINC) : address(SINC)).forceApprove(address(LIQUIDITY), type(uint256).max); // idempotent
-        if (token0Amt > 0) SINC.safeTransferFrom(msg.sender, address(this), token0Amt);
-        if (token1Amt > 0) USDC.safeTransferFrom(msg.sender, address(this), token1Amt);
-        shares = IFluidDexT1(dex).payback(token0Amt, token1Amt, minShares, false);
+        if (usdcAmt > 0) USDC.safeTransferFrom(msg.sender, address(this), usdcAmt);
+        if (sincAmt > 0) SINC.safeTransferFrom(msg.sender, address(this), sincAmt);
+        // DexT1.payback(token0Amt, token1Amt, minShares, estimate) — pool order.
+        shares = IFluidDexT1(dex).payback(usdcAmt, sincAmt, minShares, false);
         totalDebtShares = shares > totalDebtShares ? 0 : totalDebtShares - shares;
-        emit SmartDebtRepaid(dex, token0Amt, token1Amt, shares);
+        emit SmartDebtRepaid(dex, usdcAmt, sincAmt, shares);
     }
 
     /// @notice Direct Fluid Vault operate (VaultT2/T4 once listed). Unified entry:

--- a/onchain/src/fluid/SincFluidAdapter.sol
+++ b/onchain/src/fluid/SincFluidAdapter.sol
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+import {IFluidLiquidity, IFluidDexFactory, IFluidDexT1, IFluidVaultT1, IFToken} from "./FluidInterfaces.sol";
+
+/// @title  SincFluidAdapter — vault deposit/withdraw extension onto Fluid's unified layer (Base)
+/// @notice Three-stage amplifier for SINC liquidity:
+///
+///   Stage 1 (live today, permissionless): LP USDC is parked in Fluid fUSDC,
+///           earning lending yield while idle. SINC cannot be supplied to Fluid
+///           lending (no fSINC market) — it only becomes productive via Stage 2.
+///
+///   Stage 2 (after Fluid governance deploys/lists the SINC-USDC DEX): the pair
+///           is supplied via DexT1.deposit() as SMART COLLATERAL — the position is
+///           the LP liquidity itself and earns swap fees while it can back borrows.
+///           deployDex is deployer-auth gated by Fluid governance (verified); the
+///           pair must be created/listed by Fluid or a governance-authorized deployer.
+///
+///   Stage 3 (treasury-only, after Stage 2): smart debt / VaultT2 operate() lets
+///           treasury borrow against the smart-collateral LP to compound depth.
+///           Guardian-gated. Per-user borrowing is deliberately NOT pooled here —
+///           each user's debt position must be their own Fluid account.
+///
+/// @dev    SINC has 8 decimals; USDC has 6. All amounts are raw token units.
+///         Token approvals target the Fluid Liquidity contract (the layer that
+///         settles every Fluid protocol), fUSDC for the lending leg.
+///         Wired into SharedLiquidityVault as a strategy backer (registerStrategy).
+contract SincFluidAdapter is ReentrancyGuard, Pausable {
+    using SafeERC20 for IERC20;
+
+    // ---------------- Fluid Base (8453) — verified against fluid-contracts-public ----------------
+    IFluidLiquidity public constant LIQUIDITY = IFluidLiquidity(0x52Aa899454998Be5b000Ad077a46Bbe360F4e497);
+    IFluidDexFactory public constant DEX_FACTORY = IFluidDexFactory(0x91716C4EDA1Fb55e84Bf8b4c7085f84285c19085);
+    IFToken public constant F_USDC = IFToken(0xf42f5795D9ac7e9D757dB633D693cD548Cfd9169);
+    IFToken public constant F_WETH = IFToken(0x9272D6153133175175Bc276512B2336BE3931CE9);
+    address public constant DEX_RESOLVER = 0x11D80CfF056Cef4F9E6d23da8672fE9873e5cC07;
+    address public constant LENDING_RESOLVER = 0x48D32f49aFeAEC7AE66ad7B9264f446fc11a1569;
+
+    IERC20 public immutable SINC;
+    IERC20 public immutable USDC;
+    address public immutable guardian;
+    address public treasury;
+
+    /// @notice SINC/USDC Fluid DEX pool — address(0) until Fluid governance lists it
+    address public fluidDex;
+    /// @notice Fluid VaultT2 (smart col SINC-USDC LP / debt) — address(0) until listed
+    address public smartVault;
+
+    // per-user accounting (adapter holds the Fluid positions; users hold claims)
+    mapping(address user => uint256 fShares) public fUsdcShares;
+    mapping(address user => uint256 colShares) public dexColShares;
+    uint256 public totalDexColShares;
+
+    // treasury-level smart-debt accounting
+    uint256 public totalDebtShares;
+    uint256 public lastNftId;
+
+    event FluidDepositUSDC(address indexed user, uint256 assets, uint256 shares);
+    event FluidWithdrawUSDC(address indexed user, uint256 assets, uint256 shares);
+    event DexSupplied(address indexed user, address indexed dex, uint256 token0Amt, uint256 token1Amt, uint256 shares);
+    event DexWithdrawn(address indexed user, address indexed dex, uint256 token0Amt, uint256 token1Amt, uint256 shares);
+    event SmartDebtBorrowed(address indexed dex, uint256 token0Amt, uint256 token1Amt, uint256 shares, address to);
+    event SmartDebtRepaid(address indexed dex, uint256 token0Amt, uint256 token1Amt, uint256 shares);
+    event VaultOperated(address indexed vault, uint256 nftId, int256 newCol, int256 newDebt, address to);
+    event FluidDexUpdated(address dex);
+    event SmartVaultUpdated(address vault);
+    event TreasuryUpdated(address treasury);
+    event Rescued(address indexed token, address indexed to, uint256 amount);
+
+    error OnlyGuardian();
+    error ZeroAmount();
+    error DexNotSet();
+    error VaultNotSet();
+    error InsufficientShares(uint256 requested, uint256 available);
+    error ZeroAddress();
+
+    modifier onlyGuardian() {
+        if (msg.sender != guardian) revert OnlyGuardian();
+        _;
+    }
+
+    constructor(IERC20 _sinc, IERC20 _usdc, address _guardian, address _treasury) {
+        if (address(_sinc) == address(0) || address(_usdc) == address(0) || _guardian == address(0) || _treasury == address(0)) {
+            revert ZeroAddress();
+        }
+        SINC = _sinc;
+        USDC = _usdc;
+        guardian = _guardian;
+        treasury = _treasury;
+
+        // One-time max approvals. Fluid protocols settle through the Liquidity
+        // layer (supply side pulls tokens from the caller). fUSDC is the ERC-4626 leg.
+        _usdc.forceApprove(address(F_USDC), type(uint256).max);
+        _usdc.forceApprove(address(LIQUIDITY), type(uint256).max);
+        _sinc.forceApprove(address(LIQUIDITY), type(uint256).max);
+    }
+
+    // ==================== STAGE 1 — FLUID LENDING (permissionless, live) ====================
+
+    /// @notice Deposit USDC into Fluid fUSDC. Shares are held by the adapter and
+    ///         accounted per user. Live multiplier: reads via LendingResolver / convertToAssets.
+    function depositUSDC(uint256 assets) external nonReentrant whenNotPaused returns (uint256 shares) {
+        if (assets == 0) revert ZeroAmount();
+        USDC.safeTransferFrom(msg.sender, address(this), assets);
+        shares = F_USDC.deposit(assets, address(this));
+        fUsdcShares[msg.sender] += shares;
+        emit FluidDepositUSDC(msg.sender, assets, shares);
+    }
+
+    /// @notice Redeem fUSDC shares back to USDC for the caller.
+    function withdrawUSDC(uint256 shares) external nonReentrant returns (uint256 assets) {
+        if (shares == 0) revert ZeroAmount();
+        uint256 owned = fUsdcShares[msg.sender];
+        if (shares > owned) revert InsufficientShares(shares, owned);
+        fUsdcShares[msg.sender] = owned - shares;
+        assets = F_USDC.redeem(shares, msg.sender, address(this));
+        emit FluidWithdrawUSDC(msg.sender, assets, shares);
+    }
+
+    /// @notice Live USDC value of a user's Fluid lending position (6 decimals).
+    function userValueUSDC(address user) external view returns (uint256) {
+        uint256 s = fUsdcShares[user];
+        return s == 0 ? 0 : F_USDC.convertToAssets(s);
+    }
+
+    // ==================== STAGE 2 — FLUID DEX SMART COLLATERAL (post-governance) ====================
+
+    /// @notice Supply SINC + USDC into the SINC-USDC Fluid DEX as smart collateral.
+    ///         The resulting position IS the pool's LP liquidity and earns swap fees.
+    ///         token0/token1 amounts are in pool order — check DexResolver.constantsView()
+    ///         (SINC 0x9C8c… > USDC 0x8335…, so SINC is likely token1; confirm on-chain).
+    function supplyToDex(uint256 sincAmt, uint256 usdcAmt, uint256 minShares)
+        external nonReentrant whenNotPaused returns (uint256 shares)
+    {
+        address dex = fluidDex;
+        if (dex == address(0)) revert DexNotSet();
+        if (sincAmt == 0 && usdcAmt == 0) revert ZeroAmount();
+
+        if (sincAmt > 0) SINC.safeTransferFrom(msg.sender, address(this), sincAmt);
+        if (usdcAmt > 0) USDC.safeTransferFrom(msg.sender, address(this), usdcAmt);
+
+        shares = IFluidDexT1(dex).deposit(sincAmt, usdcAmt, minShares, false);
+        dexColShares[msg.sender] += shares;
+        totalDexColShares += shares;
+        emit DexSupplied(msg.sender, dex, sincAmt, usdcAmt, shares);
+    }
+
+    /// @notice Withdraw smart-collateral liquidity; underlying tokens go to the caller.
+    function withdrawFromDex(uint256 sincAmt, uint256 usdcAmt, uint256 maxShares)
+        external nonReentrant returns (uint256 shares)
+    {
+        address dex = fluidDex;
+        if (dex == address(0)) revert DexNotSet();
+        shares = IFluidDexT1(dex).withdraw(sincAmt, usdcAmt, maxShares, msg.sender);
+        uint256 owned = dexColShares[msg.sender];
+        if (shares > owned) revert InsufficientShares(shares, owned);
+        dexColShares[msg.sender] = owned - shares;
+        totalDexColShares -= shares;
+        emit DexWithdrawn(msg.sender, dex, sincAmt, usdcAmt, shares);
+    }
+
+    // ==================== STAGE 3 — SMART DEBT / VAULT (treasury only) ====================
+
+    /// @notice Treasury borrows against smart-collateral LP. Debt itself is deployed
+    ///         as LP liquidity (Fluid smart debt) once enabled on the pair.
+    function borrowSmartDebt(uint256 shares, uint256 minToken0Borrow, uint256 minToken1Borrow, address to)
+        external onlyGuardian nonReentrant whenNotPaused
+    {
+        address dex = fluidDex;
+        if (dex == address(0)) revert DexNotSet();
+        (uint256 a0, uint256 a1) = IFluidDexT1(dex).borrowPerfect(shares, minToken0Borrow, minToken1Borrow, to == address(0) ? treasury : to);
+        totalDebtShares += shares;
+        emit SmartDebtBorrowed(dex, a0, a1, shares, to);
+    }
+
+    /// @notice Repay smart debt. Pulls repayment tokens from the guardian caller.
+    function paybackSmartDebt(uint256 token0Amt, uint256 token1Amt, uint256 minShares)
+        external onlyGuardian nonReentrant returns (uint256 shares)
+    {
+        address dex = fluidDex;
+        if (dex == address(0)) revert DexNotSet();
+        if (token0Amt > 0) IERC20(IFluidDexT1(dex) == IFluidDexT1(dex) ? address(SINC) : address(SINC)).forceApprove(address(LIQUIDITY), type(uint256).max); // idempotent
+        if (token0Amt > 0) SINC.safeTransferFrom(msg.sender, address(this), token0Amt);
+        if (token1Amt > 0) USDC.safeTransferFrom(msg.sender, address(this), token1Amt);
+        shares = IFluidDexT1(dex).payback(token0Amt, token1Amt, minShares, false);
+        totalDebtShares = shares > totalDebtShares ? 0 : totalDebtShares - shares;
+        emit SmartDebtRepaid(dex, token0Amt, token1Amt, shares);
+    }
+
+    /// @notice Direct Fluid Vault operate (VaultT2/T4 once listed). Unified entry:
+    ///         nftId==0 opens a position; newCol/newDebt set target deltas.
+    ///         Collateral pulls come from this adapter's balance (prefund via treasury).
+    function vaultOperate(uint256 nftId, int256 newCol, int256 newDebt, address to)
+        external onlyGuardian nonReentrant whenNotPaused returns (uint256 nftIdOut)
+    {
+        address v = smartVault;
+        if (v == address(0)) revert VaultNotSet();
+        (nftIdOut,,) = IFluidVaultT1(v).operate(nftId, newCol, newDebt, to == address(0) ? treasury : to);
+        if (nftId == 0) lastNftId = nftIdOut;
+        emit VaultOperated(v, nftIdOut, newCol, newDebt, to);
+    }
+
+    /// @notice Forward a deployDex request. WILL REVERT until Fluid governance grants
+    ///         deployer access to guardian/treasury (isDeployer). Kept as the exact
+    ///         call so the multisig can execute it the moment access is granted.
+    function deploySincUsdcDex(address dexDeploymentLogic, bytes calldata deploymentData)
+        external onlyGuardian returns (address dex)
+    {
+        dex = DEX_FACTORY.deployDex(dexDeploymentLogic, deploymentData);
+        fluidDex = dex;
+        emit FluidDexUpdated(dex);
+    }
+
+    // ==================== ADMIN ====================
+
+    function setFluidDex(address dex) external onlyGuardian {
+        fluidDex = dex;
+        emit FluidDexUpdated(dex);
+    }
+
+    function setSmartVault(address v) external onlyGuardian {
+        smartVault = v;
+        emit SmartVaultUpdated(v);
+    }
+
+    function setTreasury(address t) external onlyGuardian {
+        if (t == address(0)) revert ZeroAddress();
+        treasury = t;
+        emit TreasuryUpdated(t);
+    }
+
+    function pause() external onlyGuardian { _pause(); }
+    function unpause() external onlyGuardian { _unpause(); }
+
+    /// @notice Emergency exit path: pull any token balance to treasury. Does NOT touch
+    ///         Fluid-internal positions (those unwind via withdrawFromDex / payback).
+    function rescue(address token, uint256 amount) external onlyGuardian {
+        IERC20(token).safeTransfer(treasury, amount);
+        emit Rescued(token, treasury, amount);
+    }
+}

--- a/onchain/test/SincFluidAdapter.fork.t.sol
+++ b/onchain/test/SincFluidAdapter.fork.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {SincFluidAdapter} from "../src/fluid/SincFluidAdapter.sol";
+import {IFluidDexFactory, IFToken} from "../src/fluid/FluidInterfaces.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @notice Base-mainnet fork test. Proves the live, permissionless leg (fUSDC)
+///         end-to-end and documents the governance gate on deployDex.
+///         Run: forge test --match-path test/SincFluidAdapter.fork.t.sol \
+///                --fork-url $BASE_RPC_URL -vvv
+contract SincFluidAdapterForkTest is Test {
+    address constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+    address constant SINC = 0x9C8cd8d3961F445D653713dE65C6578bE11668e7;
+    address constant TREASURY = 0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac;
+    address constant GUARDIAN = 0xdba7180cdd90D12B9Bc2F15080ddFD9B14fEf31a;
+    address constant F_USDC = 0xf42f5795D9ac7e9D757dB633D693cD548Cfd9169;
+    address constant DEX_FACTORY = 0x91716C4EDA1Fb55e84Bf8b4c7085f84285c19085;
+    address constant LIQUIDITY = 0x52Aa899454998Be5b000Ad077a46Bbe360F4e497;
+
+    SincFluidAdapter adapter;
+    address user;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envString("BASE_RPC_URL"));
+        adapter = new SincFluidAdapter(IERC20(SINC), IERC20(USDC), GUARDIAN, TREASURY);
+        user = makeAddr("lp");
+    }
+
+    function test_fluidInfraLiveOnBase() public view {
+        assertGt(LIQUIDITY.code.length, 0);
+        assertGt(DEX_FACTORY.code.length, 0);
+        assertGt(F_USDC.code.length, 0);
+    }
+
+    /// GOVERNANCE GATE: DexFactory.deployDex reverts for any non-authorized deployer.
+    /// Treasury must be granted deployer access by Fluid governance (or Fluid lists
+    /// the SINC pair themselves) before Stage 2 can execute.
+    function test_deployerGate_blocksTreasury() public view {
+        assertFalse(IFluidDexFactory(DEX_FACTORY).isDeployer(TREASURY));
+    }
+
+    /// Stage 1 full loop: approve -> depositUSDC -> fUSDC shares -> withdrawUSDC.
+    function test_supplyAndWithdraw_fUSDC() public {
+        uint256 assets = 100e6; // 100 USDC
+        deal(USDC, user, assets);
+
+        vm.startPrank(user);
+        IERC20(USDC).approve(address(adapter), assets);
+        uint256 shares = adapter.depositUSDC(assets);
+        assertGt(shares, 0);
+        assertEq(adapter.fUsdcShares(user), shares);
+        assertGt(IFToken(F_USDC).balanceOf(address(adapter)), 0);
+        assertGe(adapter.userValueUSDC(user), assets - 2); // rounding only
+
+        uint256 balBefore = IERC20(USDC).balanceOf(user);
+        uint256 out = adapter.withdrawUSDC(shares);
+        vm.stopPrank();
+
+        assertGe(out + 2, assets); // principal back (≤2 wei rounding)
+        assertEq(IERC20(USDC).balanceOf(user), balBefore + out);
+        assertEq(adapter.fUsdcShares(user), 0);
+    }
+
+    /// Stage 2 must revert cleanly until the SINC-USDC DEX exists.
+    function test_dexPathsRevertUntilPoolSet() public {
+        vm.expectRevert(SincFluidAdapter.DexNotSet.selector);
+        adapter.supplyToDex(1e8, 1e6, 0);
+
+        vm.expectRevert(SincFluidAdapter.DexNotSet.selector);
+        vm.prank(GUARDIAN);
+        adapter.borrowSmartDebt(1, 0, 0, TREASURY);
+    }
+}


### PR DESCRIPTION
## Fluid Protocol amplification layer for SINC (Base)

Extends the vault deposit/withdraw onto Fluid's unified liquidity layer. All Fluid addresses and function signatures verified against `Instadapp/fluid-contracts-public` sources + Base deployment artifacts — zero assumed interfaces.

### Ships
- **`src/fluid/FluidInterfaces.sol`** — verified `IFluidLiquidity.operate`, `IFluidDexFactory.deployDex/isDeployer`, `IFluidDexT1` (deposit/withdraw/borrow/payback + perfect variants + swaps), `IFluidVaultT1.operate`, `IFToken` (ERC-4626).
- **`src/fluid/SincFluidAdapter.sol`** — three-stage amplifier:
  - **Stage 1 (live, permissionless):** USDC leg → fUSDC lending yield, per-user share accounting.
  - **Stage 2 (post-governance):** SINC+USDC → Fluid DEX smart collateral (`deposit`/`withdraw`) — the LP position earns swap fees while it can back borrows. Pool order handled: token0=USDC, token1=SINC.
  - **Stage 3 (treasury-only):** smart debt (`borrowPerfect`/`payback`) + `VaultT1.operate` for VaultT2/T4 positions. Guardian-gated; per-user debt deliberately not pooled.
- **`script/DeploySincFluidAdapter.s.sol`** — Base chain-guarded deploy, env overrides, `--verify` ready.
- **`test/SincFluidAdapter.fork.t.sol`** — Base-fork test: live fUSDC full loop, deployer-gate proof, revert-until-pool-set guards.
- **`sdk/fluid-amplify.js`** — getsincor.com "Amplify SINC Liquidity" button: connect → approve → deposit, live position reads.
- **`docs/FLUID_INTEGRATION.md`** — full runbook: build/test/deploy commands, vault wiring, treasury seeding, dashboard, announce checklist.

### Verified facts that gate Stage 2/3 (from Fluid sources, not assumption)
1. `DexFactory.deployDex()` **reverts unless `isDeployer(msg.sender)`** — pool creation is not permissionless; Fluid governance must list SINC-USDC or grant the multisig deployer access.
2. Smart collateral config + oracles are **Fluid-governance controlled**; SINC has no Fluid oracle today.
3. `Liquidity.operate()` is protocol-auth gated — adapter enters via fToken/Dex/Vault surfaces correctly.

### Next actions
1. `forge build && forge test --match-path test/SincFluidAdapter.fork.t.sol --fork-url $BASE_RPC_URL -vvv`
2. slither clean → external audit → deploy (runbook §4)
3. Fluid governance/BD request for SINC-USDC listing (blocking for Stage 2/3)
4. Register adapter as strategy backer in SharedLiquidityVault, set `ADAPTER` in dashboard SDK

**Audit before mainnet scale.** Stage 1 is deployable and testable today.