### PR TITLE
Uniform agent count: 42 → 45 (Enterprise) + orchestration clarity

### DIFF
--- a/src/sincor2/email_sender.py
+++ b/src/sincor2/email_sender.py
@@ -319,7 +319,7 @@ https://getsincor.com
     def _render_thank_you_email(self, customer_name: str, tier: str,
                                order_id: str, download_urls: Dict[str, str]) -> str:
         """Render thank-you email HTML."""
-        agent_counts = {'Starter': 10, 'Professional': 25, 'Enterprise': 42}
+        agent_counts = {'Starter': 10, 'Professional': 25, 'Enterprise': 45}
         agent_count = agent_counts.get(tier, 10)
 
         guide_url = download_urls.get(tier.lower(), f"/files/guides/sincor-{tier.lower()}-guide-{order_id}.pdf")
@@ -445,7 +445,7 @@ https://getsincor.com
 
             <h2 style="color: #667eea; margin-top: 30px;">Your {tier} Plan Includes</h2>
             <ul style="line-height: 2; color: #555;">
-                <li>{{'Scout, Synthesizer, Builder Agents' if tier == 'Starter' else 'All Scout/Synthesizer/Builder plus Negotiator, Caretaker Agents' if tier == 'Professional' else 'All 42 AI Agents with custom development'}} </li>
+                <li>{{'Scout, Synthesizer, Builder Agents' if tier == 'Starter' else 'All Scout/Synthesizer/Builder plus Negotiator, Caretaker Agents' if tier == 'Professional' else 'All 45 AI Agents with custom development'}} </li>
                 <li>{{'5 core integrations' if tier == 'Starter' else '15 enterprise integrations' if tier == 'Professional' else '25+ white-label integrations'}}</li>
                 <li>{{'Email support - 24 hour response' if tier == 'Starter' else 'Priority support - 4 hour response' if tier == 'Professional' else '24/7 dedicated success manager'}}</li>
                 <li>Full knowledge base access</li>

--- a/src/sincor2/order_fulfillment.py
+++ b/src/sincor2/order_fulfillment.py
@@ -263,7 +263,7 @@ class OrderFulfillmentSystem:
         agent_counts = {
             'Starter': 10,
             'Professional': 25,
-            'Enterprise': 42
+            'Enterprise': 45  # up to 45; orchestration decides dispatch
         }
         return agent_counts.get(plan_name, 0)
 

--- a/src/sincor2/platform_payments.py
+++ b/src/sincor2/platform_payments.py
@@ -72,7 +72,7 @@ PLATFORM_PLANS: dict[str, dict[str, Any]] = {
         "usd_reference": 2997,
         "token": "SINC",
         "billing": "month",
-        "agents": 42,
+        "agents": 45,  # up to 45; orchestration agent decides dispatch count
     },
 }
 
@@ -315,6 +315,7 @@ def list_plans() -> list[dict[str, Any]]:
                 "treasury": TREASURY,
                 "chain_id": CHAIN_ID,
                 "spot_available": display > 0,
+                "agents": plan.get("agents"),
             }
         )
     return out


### PR DESCRIPTION
## Summary
Uniform update of Enterprise agent count from the stale **42** to **45** across billing, fulfillment, emails, and key code paths.

### Why 45
- Actual specialized agent inventory in `/agents/` is ~46 (E-*.yaml from 01–46 including TOA, Strategist, Critic, etc.).
- Marketing/code was stuck on 42.
- Honest framing: **"up to 45 agents · full swarm access · orchestration agent decides how many to dispatch"** (never claim "all 45 always running").

### Changes already landed on this branch
- `src/sincor2/platform_payments.py` — PLATFORM_PLANS enterprise agents: 45
- `src/sincor2/order_fulfillment.py` — agent_counts Enterprise: 45
- `src/sincor2/email_sender.py` — agent_counts + thank-you email copy: 45

### Still needed (high visibility templates + catalogs)
These still contain 42 and will be cleaned in follow-up commits on this PR:
- `src/sincor2/mvp_app.py` (PRODUCT_CATALOG)
- `templates/home.html` (hero badge, stats, live panel)
- `templates/sales.html`
- `templates/product_enterprise.html` / products_enterprise.html
- `templates/product_starter.html` (upgrade path)
- `templates/sitemap.html`, `agent_selector.html`, `admin_*.html`, pitch, content_agent, app.py, docs

### Tier model (recommended)
- **Starter**: 10 agents
- **Professional**: 25 agents
- **Enterprise**: up to 45 agents + full swarm(1) access (orchestration decides dispatch count)
- Higher parallel tiers (future): x10 / x100 concurrency + gated Polyclaw / verticals

### Test plan
- [ ] Billing catalog returns agents=45 for enterprise
- [ ] Fulfillment activates 45 for Enterprise orders
- [ ] Thank-you email shows 45
- [ ] Homepage / sales / product pages show consistent 45 after remaining template updates
- [ ] Existing pytest suite still green (pure config change)

Ready for review once remaining public templates are updated.