### PR TITLE
CEO 2026-08-11: Treasury inflow push — execution log + scheduler fee projection + TOA feedback

### DIFF
--- a/docs/CEO_EXECUTION_2026-08-11.md
+++ b/docs/CEO_EXECUTION_2026-08-11.md
@@ -1,0 +1,84 @@
+# CEO Execution Log — 2026-08-11
+
+**Owner:** CEO (Autonomous Swarm Oversight)  
+**Branch:** `ceo/2026-08-11-treasury-inflow-push`  
+**KPI:** Treasury inflow to `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac` (realized preferred; projected tracked)
+
+## Status at 13:30 CDT
+
+### Live infrastructure confirmed
+- SINC Phase 1 mainnet: `0x9C8cd8d3961F445D653713dE65C6578bE11668e7` | $1.50 floor path | CertiK 97/100
+- Yield Aggregator (`src/sincor2/defi/yield_aggregator.py`): multi-strategy, risk caps, fee_to_treasury_bps=10, dry-run default, live intents only under `EXECUTE_LIVE=1`
+- Treasury ledger (`src/sincor2/treasury_inflow.py`): append-only JSONL, 24h realized vs projected, optional Base RPC snapshot of treasury balances
+- DeFi Swarm Scheduler (`scripts/defi_swarm_checkin_scheduler.py`): 5-min loop, 26-swarm check-in, TOA `ingest_feedback`, YieldAggregator plan, `record_inflow(projected=True)`
+- Recent core: Command Center, BiddingEngine isolation, TokenBudgetController, Polyclaw CLOB live path, AQUA production ship
+
+### Gaps (honest)
+- Scheduler projections are synthetic (dummy_execute PnL). Real paid conversions and on-chain fee events with `tx_hash` + `projected=False` are still required for the KPI to move.
+- No evidence the indefinite 5-min process is currently running on Railway/production as a supervised service.
+- Product conversion (WebBuilder, Starter $297, intel reports) and external A2A settlement remain the highest-leverage missing pieces for realized inflow.
+
+## Executed this session (CEO + code path)
+1. Branch created: `ceo/2026-08-11-treasury-inflow-push` from main @ 8bab0b4
+2. Full audit of YieldAggregator + scheduler + treasury_inflow (all production-ready patterns present)
+3. This execution log committed
+4. Scheduler hardened (see companion commit): always emit YieldAggregator fee projection into ledger + richer TOA feedback payload including simulate_year_pnl
+5. Explicit next actions for remaining builders / live ops listed below
+
+## End-of-day goal (unchanged)
+Net positive **realized** Treasury inflow. Minimum bar:
+- ≥1 paid conversion path logged with `projected=False` (subscription, WebBuilder, A2A settlement, or protocol fee with tx_hash)
+- ≥3 production commits on revenue surfaces
+- Scheduler confirmed running under process supervision
+- TOA feedback loop closed on every cycle
+
+## Code-builder action items (priority order)
+
+### Immediate (this branch / next 4h)
+1. **Scheduler production run**  
+   - Deploy `python -m scripts.defi_swarm_checkin_scheduler` under Railway/Gunicorn/systemd with restart policy.  
+   - Confirm `data/treasury_inflow.jsonl` receives entries every 5 min.  
+   - One-shot test: `python -m scripts.defi_swarm_checkin_scheduler --once`
+
+2. **YieldAggregator → real measurement**  
+   - Keep dry-run default.  
+   - When capital + `EXECUTE_LIVE=1` + signer available: emit intents only; external signer/broadcast.  
+   - On successful fee transfer, call `record_inflow(..., projected=False, tx_hash=...)`.
+
+3. **A2A settlement fee split**  
+   - `/api/a2a/quote` and settlement path must route platform fee portion to Treasury and call `record_inflow` with tx_hash when on-chain.
+
+4. **Product conversion**  
+   - WebBuilder / Starter / intel checkout success handler → `record_inflow(projected=False, source="subscription"|"webbuilder"|"intel")`.
+
+5. **Tests**  
+   - `pytest tests/test_treasury_inflow.py tests/test_yield_aggregator.py -q` must stay green.  
+   - Add coverage for scheduler one-shot if missing.
+
+### Parallel (24h)
+- External Agent Card verification + one successful external registration/quote/settlement.
+- Base Sepolia test deploy of any new vault/hook pieces before mainnet capital.
+- Command Center: surface `/api/metrics/treasury` + TokenBudgetController kill on negative ROI.
+
+## Swarm accountability
+Every swarm owns a slice of Treasury inflow. TOA re-ranks every cycle. Negative-ROI agents are kill-switched via TokenBudgetController. Results only.
+
+## Verification commands
+```bash
+# from repo root
+python -m pytest tests/test_treasury_inflow.py tests/test_yield_aggregator.py -q
+python -m scripts.defi_swarm_checkin_scheduler --once
+# if app running:
+curl -s localhost:5000/api/metrics/treasury | jq .
+```
+
+## Non-negotiables
+- No half-measures. Fully tested code only.
+- Fee routing to Treasury on every new revenue surface.
+- Realized > projected. Explain shortfalls with data.
+- Self-improvement: every cycle calls TOA ingest_feedback.
+
+**CEO directive:** Execute the remaining live ops and conversion paths now. This branch is the base. Scale infinite.
+
+— CEO SINCOR  
+getsincor.com | github.com/OrderofChaos33/SINCOR2

--- a/scripts/defi_swarm_checkin_scheduler.py
+++ b/scripts/defi_swarm_checkin_scheduler.py
@@ -12,7 +12,7 @@ import time
 import logging
 import sys
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Real integrations
 try:
@@ -49,6 +49,7 @@ logger = logging.getLogger("sincor.defi_scheduler")
 
 CHECK_INTERVAL_SECONDS = 300  # 5 minutes
 
+
 class DeFiSwarmScheduler:
     def __init__(self):
         self.toa = TOAOrchestrator() if TOAOrchestrator else None
@@ -78,6 +79,8 @@ class DeFiSwarmScheduler:
 
                 if self.router and run_polyclaw_earning_cycle:
                     def dummy_execute(route="public", **ctx):
+                        # Synthetic until live execution path replaces this.
+                        # Marked projected in ledger below.
                         pnl = 12.5 + (i * 0.5)
                         return {"status": "ok", "pnl_usd": pnl, "route": route, "project": project_id}
 
@@ -92,36 +95,66 @@ class DeFiSwarmScheduler:
                             "project": project_id,
                             "pnl_usd": pnl,
                             "status": result.get("status"),
-                            "timestamp": datetime.utcnow().isoformat(),
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "projected": True,
                         })
 
-                    logger.info(f"Check-in Swarm {i}/26 Project {project_id}: Cycle {result.get('status')} | PnL ${pnl:.2f} -> Treasury")
+                    logger.info(f"Check-in Swarm {i}/26 Project {project_id}: Cycle {result.get('status')} | PnL ${pnl:.2f} -> Treasury (projected)")
                 else:
                     logger.warning(f"Swarm {i}: Router/TOA not available - conservative mode")
 
             except Exception as e:
                 logger.error(f"Swarm {i} check-in error: {e}. TOA self-healing...")
                 if self.toa:
-                    self.toa.ingest_feedback({"source": "error", "swarm_id": i, "error": str(e)})
+                    try:
+                        self.toa.ingest_feedback({"source": "error", "swarm_id": i, "error": str(e)})
+                    except Exception:
+                        pass
 
-        # Yield aggregator dry-run plan (Project #1) — measurement only
+        # Yield Aggregator — Project #1 measurement + fee projection to Treasury
         if self.yield_agg:
             try:
-                plan = self.yield_agg.plan_rebalance(capital_usd=5000.0, risk_budget=0.30)
+                capital = 5000.0
+                plan = self.yield_agg.plan_rebalance(capital_usd=capital, risk_budget=0.30)
+                pnl_sim = self.yield_agg.simulate_year_pnl(capital_usd=capital, risk_budget=0.30)
+                fee_usd = float(pnl_sim.get("expected_fee_to_treasury_usd", 0.0))
+                # Daily pro-rata of annual fee projection for 5-min cycle visibility
+                daily_fee_proj = fee_usd / 365.0
+                total_inflow_projection += daily_fee_proj
+
                 logger.info(
-                    "YieldAggregator dry-run: blended_apr=%.2f%% allocations=%d mode=%s",
+                    "YieldAggregator: blended_apr=%.2f%% allocations=%d mode=%s daily_fee_proj=$%.4f",
                     plan.expected_blended_apr * 100,
                     len(plan.allocations),
                     plan.mode,
+                    daily_fee_proj,
                 )
+
                 if self.toa:
                     self.toa.ingest_feedback({
                         "source": "yield_aggregator",
                         "blended_apr": plan.expected_blended_apr,
                         "allocations": len(plan.allocations),
                         "mode": plan.mode,
-                        "timestamp": datetime.utcnow().isoformat(),
+                        "expected_fee_to_treasury_usd_annual": fee_usd,
+                        "daily_fee_proj": daily_fee_proj,
+                        "plan": plan.to_dict(),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
                     })
+
+                if record_inflow and daily_fee_proj > 0:
+                    try:
+                        record_inflow(
+                            daily_fee_proj,
+                            asset="USD",
+                            source="yield_aggregator_fee_proj",
+                            usd_estimate=daily_fee_proj,
+                            projected=True,
+                            note=f"scheduler_cycle_{self.cycle_count}_annual_fee_prorata",
+                        )
+                    except Exception as e:
+                        logger.error("record_inflow (yield fee) failed: %s", e)
+
             except Exception as e:
                 logger.warning("YieldAggregator plan failed: %s", e)
 
@@ -138,7 +171,8 @@ class DeFiSwarmScheduler:
                 )
             except Exception as e:
                 logger.error("record_inflow failed: %s", e)
-        logger.info(f"Cycle complete | Projected Treasury Inflow this round: ${total_inflow_projection:.2f}")
+
+        logger.info(f"Cycle complete | Projected Treasury Inflow this round: ${total_inflow_projection:.4f}")
         return total_inflow_projection
 
     def simulate_revenue_paths(self, projects):
@@ -176,6 +210,7 @@ class DeFiSwarmScheduler:
             except Exception as e:
                 logger.error(f"Scheduler error: {e}. Self-improving via TOA. Continuing...")
                 time.sleep(60)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## CEO Directive Execution — 2026-08-11

**KPI:** Treasury inflow to `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac`

### What this PR does
1. **docs/CEO_EXECUTION_2026-08-11.md** — Full status, gaps (honest), end-of-day goal, ordered code-builder actions, verification commands.
2. **scripts/defi_swarm_checkin_scheduler.py** — Hardened 5-min cycle:
   - YieldAggregator `simulate_year_pnl` → daily pro-rata fee projection recorded via `record_inflow(projected=True, source="yield_aggregator_fee_proj")`
   - Richer TOA `ingest_feedback` payload including full plan dict + annual fee expectation
   - Explicit projected labeling on synthetic swarm PnL until live execution replaces dummy_execute

### Already in main (verified this session)
- YieldAggregator multi-strategy + risk caps + fee_to_treasury_bps + dry-run default
- treasury_inflow ledger + optional Base RPC snapshot
- Command Center / BiddingEngine / TokenBudgetController

### Still required for realized KPI movement (not in this PR)
- Supervised production run of the scheduler (Railway/systemd)
- Real paid conversion paths calling `record_inflow(projected=False, tx_hash=...)`
- A2A settlement fee split to Treasury
- Live capital under `EXECUTE_LIVE=1` only after signer + risk review

### Test plan
```bash
python -m pytest tests/test_treasury_inflow.py tests/test_yield_aggregator.py -q
python -m scripts.defi_swarm_checkin_scheduler --once
```

Results only. Merge when green. Scale infinite.

— CEO SINCOR