### PR TITLE
feat(a2a): critical path — unlock discovery for external agent inflow

### DIFF
--- a/docs/A2A_PRODUCTION_CHECKLIST.md
+++ b/docs/A2A_PRODUCTION_CHECKLIST.md
@@ -1,0 +1,91 @@
+# SINCOR A2A Production Checklist — Massive Agent Inflow
+
+**Status as of 2026-08-17 audit:** Discovery surfaces were **offline** on production (`mvp_app.py` did not register `A2ARouter`). Static `agent.json` only.
+
+## Non-negotiable success path
+
+External A2A v1.0.1 agent must be able to:
+
+1. `GET https://getsincor.com/.well-known/agent-card.json` → full card (43+ skills, schemas, AXM pricing, freeQuota)
+2. Register via documented path
+3. Quote a skill
+4. Pay (or free quota) with AXM to treasury `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac`
+5. Execute skill + receive result + proof-of-settlement (50% burn / 50% treasury)
+
+## Critical path (do first)
+
+### 1. Wire blueprint into production entrypoint
+
+In `src/sincor2/mvp_app.py` (production is `gunicorn sincor2.mvp_app:app`), add **immediately after** `app = Flask(...)` and security middleware setup:
+
+```python
+# A2A discovery + JSON-RPC (critical for external agent inflow)
+try:
+    from sincor2.a2a_bootstrap import register_a2a
+    if register_a2a(app):
+        logger.info("[A2A] discovery surfaces registered")
+    else:
+        logger.error("[A2A] registration failed — external agents cannot discover")
+except Exception as e:
+    logger.error("[A2A] bootstrap error: %s", e)
+```
+
+**Conflict note:** mvp_app currently serves a static `/.well-known/agent.json`. After registering the blueprint, either:
+- Remove the static `@app.route('/.well-known/agent.json')` handler, or
+- Register the blueprint *before* that route and leave the dynamic handler (blueprint routes are preferred if registered first in some Flask versions — safest is to delete the static route).
+
+### 2. Railway / production env vars (required)
+
+```
+PLATFORM_URL=https://getsincor.com
+A2A_PRIMARY_TOKEN=AXIOM
+AXIOM_CONTRACT_ADDRESS=0xfF7aF6ffca25A9DC0FC990d998AcF24Cc60b7822
+TREASURY_ADDRESS=0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac
+BASE_RPC_URL=https://mainnet.base.org   # or Alchemy/QuickNode Base URL
+BASE_CHAIN_ID=8453
+A2A_TASK_STORE=redis                    # required for multi-worker Gunicorn
+REDIS_URL=redis://...                   # Railway Redis or Upstash
+```
+
+Without `BASE_RPC_URL`, PaymentVerifier cannot call `eth_getTransactionReceipt` → paid path fails.
+Without Redis task store, multi-worker Gunicorn fragments / loses tasks.
+
+### 3. Post-deploy smoke (must pass before any directory listing)
+
+```bash
+curl -sS https://getsincor.com/.well-known/agent-card.json | jq '.name, (.skills|length), .supportedInterfaces'
+curl -sS "https://getsincor.com/api/a2a/quote?skill_id=lead-enrichment&caller_id=smoke" | jq .
+curl -sS https://getsincor.com/api/a2a/agents | jq '.primary_token, .chain_id, (.agents|length)'
+curl -sS https://getsincor.com/health | jq '.checks.base_rpc'
+```
+
+Expected:
+- agent-card: name present, skills ≥ 15, supportedInterfaces with JSONRPC + protocolVersion 1.0.1
+- quote: pay_to = treasury, primary_token AXIOM (or free_quota path)
+- agents: primary_token AXIOM, chain_id 8453
+- health base_rpc: ready (not `not_configured`)
+
+## Track status
+
+| Track | Status | Notes |
+|-------|--------|-------|
+| A Discovery + blueprint | **BLOCKED until mvp_app one-liner** | Code exists in a2a_integration.py; not registered on production |
+| B Token/settlement AXM primary | Code ready; default was SINC — set env + change default |
+| C Registration endpoint | Exists at POST /api/marketplace/register (SINC stake gated) |
+| D Adapters + demos | Partial (examples/a2a_loop_demo.py) |
+| E Directory submissions | Blocked until card is green |
+| F Observability + Redis | Logging present; Redis task store not yet wired in a2a_integration |
+
+## Settlement economics (AXM)
+
+- 50% burn → `0x000000000000000000000000000000000000dEaD`
+- 50% treasury → `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac`
+- Platform fee path kept in SettlementCoordinator (fee-only treasury inflow accounting)
+
+## Files that already implement production logic
+
+- `src/sincor2/a2a_integration.py` — full A2ARouter, skills, PaymentVerifier, price engine, reputation, free quota, settle proof
+- `src/sincor2/blueprints/marketplace.py` — register, routing, settlement, leaderboard
+- `src/sincor2/a2a_bootstrap.py` — this PR — one-call registration helper
+
+**Do not announce or submit to a2a directories until agent-card.json is 200 with full skills array.**

--- a/examples/external_agent_registration.sh
+++ b/examples/external_agent_registration.sh
@@ -1,147 +1,49 @@
 #!/usr/bin/env bash
-# =============================================================================
-# external_agent_registration.sh
-# Register any A2A-compliant agent with the SINCOR marketplace using curl.
-# =============================================================================
-#
-# Usage:
-#   ./external_agent_registration.sh <AGENT_URL> [SINCOR_URL] [SINC_STAKE] [API_KEY]
-#
-# Examples:
-#   # Register a local agent (default SINCOR = https://getsincor.com, no stake)
-#   ./examples/external_agent_registration.sh https://my-agent.example.com
-#
-#   # Register with a SINC stake and API key
-#   ./examples/external_agent_registration.sh \
-#       https://my-agent.example.com \
-#       https://getsincor.com \
-#       500 \
-#       sk-mysincor-api-key
-#
-#   # Validate Agent Card only (no registration)
-#   VALIDATE_ONLY=1 ./examples/external_agent_registration.sh https://my-agent.example.com
-#
-# Requirements: curl, jq (jq is optional — pretty-printing only)
-# =============================================================================
-
+# End-to-end external agent registration + discovery smoke against production.
+# Usage: bash examples/external_agent_registration.sh
 set -euo pipefail
 
-AGENT_URL="${1:-}"
-SINCOR_URL="${2:-${SINCOR_PLATFORM_URL:-https://getsincor.com}}"
-SINC_STAKE="${3:-0}"
-API_KEY="${4:-${SINCOR_API_KEY:-}}"
-VALIDATE_ONLY="${VALIDATE_ONLY:-0}"
+BASE="${PLATFORM_URL:-https://getsincor.com}"
 
-if [[ -z "$AGENT_URL" ]]; then
-  echo "Usage: $0 <AGENT_URL> [SINCOR_URL] [SINC_STAKE] [API_KEY]" >&2
-  exit 1
-fi
-
-AGENT_URL="${AGENT_URL%/}"   # strip trailing slash
-
-# ---------------------------------------------------------------------------
-# 1. Fetch Agent Card
-# ---------------------------------------------------------------------------
-echo "Fetching Agent Card from ${AGENT_URL} …"
-
-CARD=""
-for PATH_SUFFIX in "/.well-known/agent-card.json" "/.well-known/agent.json"; do
-  URL="${AGENT_URL}${PATH_SUFFIX}"
-  HTTP_STATUS=$(curl -s -o /tmp/agent_card.json -w "%{http_code}" \
-    -H "Accept: application/json" "${URL}" 2>/dev/null || echo "000")
-  if [[ "$HTTP_STATUS" == "200" ]]; then
-    CARD=$(cat /tmp/agent_card.json)
-    echo "  Found Agent Card at ${URL}"
-    break
-  fi
-done
-
-if [[ -z "$CARD" ]]; then
-  echo "ERROR: No A2A Agent Card found at ${AGENT_URL}" >&2
-  echo "       Expected /.well-known/agent-card.json or /.well-known/agent.json" >&2
-  exit 1
-fi
-
-# ---------------------------------------------------------------------------
-# 2. Validate Agent Card fields
-# ---------------------------------------------------------------------------
-echo "Validating A2A compliance …"
-
-AGENT_NAME=$(echo "$CARD" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('name',''))")
-AGENT_VERSION=$(echo "$CARD" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('version',''))")
-SKILL_COUNT=$(echo "$CARD" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('skills',[])))")
-
-if [[ -z "$AGENT_NAME" ]]; then
-  echo "ERROR: Agent Card missing 'name' field." >&2; exit 1
-fi
-if [[ -z "$AGENT_VERSION" ]]; then
-  echo "ERROR: Agent Card missing 'version' field." >&2; exit 1
-fi
-if [[ "$SKILL_COUNT" -lt 1 ]]; then
-  echo "ERROR: Agent Card must include at least one skill." >&2; exit 1
-fi
-
-echo "  Agent  : ${AGENT_NAME} v${AGENT_VERSION}"
-echo "  Skills : ${SKILL_COUNT}"
-echo "  A2A compliance: PASS ✓"
-
-if [[ "$VALIDATE_ONLY" == "1" ]]; then
-  echo "Validation complete. Skipping registration (VALIDATE_ONLY=1)."
-  exit 0
-fi
-
-# ---------------------------------------------------------------------------
-# 3. POST to SINCOR marketplace registration endpoint
-# ---------------------------------------------------------------------------
-echo ""
-echo "Registering with SINCOR at ${SINCOR_URL} …"
-
-REGISTRATION_URL="${SINCOR_URL%/}/api/marketplace/register"
-
-# Build request body
-REQUEST_BODY=$(python3 -c "
-import json, sys
-card = json.loads(open('/tmp/agent_card.json').read())
-body = {
-    'agent_card': card,
-    'agent_url': '${AGENT_URL}',
-    'sinc_stake': int('${SINC_STAKE}'),
-}
-print(json.dumps(body))
-")
-
-# Build curl arguments
-CURL_ARGS=(-s -X POST "$REGISTRATION_URL"
-  -H "Content-Type: application/json"
-  -H "Accept: application/json"
-  -d "$REQUEST_BODY"
-  -o /tmp/sincor_receipt.json
-  -w "%{http_code}")
-
-if [[ -n "$API_KEY" ]]; then
-  CURL_ARGS+=(-H "X-API-Key: ${API_KEY}")
-fi
-
-HTTP_STATUS=$(curl "${CURL_ARGS[@]}")
-
-if [[ "$HTTP_STATUS" != "201" && "$HTTP_STATUS" != "200" ]]; then
-  echo "ERROR: Registration failed (HTTP ${HTTP_STATUS}):" >&2
-  cat /tmp/sincor_receipt.json >&2
-  exit 1
-fi
-
-echo "Registration receipt:"
-if command -v jq &>/dev/null; then
-  jq . /tmp/sincor_receipt.json
+echo "=== 1. Agent Card (v1.0.1 preferred) ==="
+CARD_CODE=$(curl -sS -o /tmp/sincor-card.json -w "%{http_code}" "$BASE/.well-known/agent-card.json" || true)
+echo "HTTP $CARD_CODE"
+if [[ "$CARD_CODE" == "200" ]]; then
+  python3 -c "import json; d=json.load(open('/tmp/sincor-card.json')); print('name:', d.get('name')); print('skills:', len(d.get('skills',[]))); print('interfaces:', d.get('supportedInterfaces'))"
 else
-  cat /tmp/sincor_receipt.json
+  echo "agent-card.json not live — falling back to legacy agent.json"
+  curl -sS "$BASE/.well-known/agent.json" | head -c 400
+  echo
 fi
 
 echo ""
-echo "✓ Agent registered with SINCOR marketplace."
-echo "  Marketplace URL: ${SINCOR_URL%/}$(python3 -c "import json; r=json.load(open('/tmp/sincor_receipt.json')); print(r.get('marketplace_url',''))")"
+echo "=== 2. Skill catalogue ==="
+curl -sS "$BASE/api/a2a/agents" | head -c 500 || echo "(endpoint offline until A2ARouter registered)"
+echo
 
-if [[ "$SINC_STAKE" -gt 0 ]]; then
-  echo "  SINC staked: ${SINC_STAKE} (routing priority boost active)"
-  echo "  Note: On-chain SINC staking transaction required to finalise stake."
-fi
+echo ""
+echo "=== 3. Quote lead-enrichment ==="
+curl -sS "$BASE/api/a2a/quote?skill_id=lead-enrichment&caller_id=external-smoke" | head -c 600 || echo "(quote offline)"
+echo
+
+echo ""
+echo "=== 4. Marketplace register (optional — requires marketplace bootstrap) ==="
+curl -sS -X POST "$BASE/api/marketplace/register" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "agent_card": {
+      "name": "External Smoke Agent",
+      "description": "CI smoke registration",
+      "version": "0.1.0",
+      "skills": [{"id": "ping", "name": "Ping", "description": "Health ping"}]
+    },
+    "agent_url": "https://example.com/agent",
+    "sinc_stake": 0
+  }' | head -c 400 || echo "(register offline or gated)"
+echo
+
+echo ""
+echo "=== 5. Health / Base RPC ==="
+curl -sS "$BASE/health" | python3 -c "import sys,json; d=json.load(sys.stdin); print('base_rpc:', d.get('checks',{}).get('base_rpc', d))" 2>/dev/null || curl -sS "$BASE/health" | head -c 300
+echo
+echo "Done."

--- a/src/sincor2/a2a_bootstrap.py
+++ b/src/sincor2/a2a_bootstrap.py
@@ -1,0 +1,69 @@
+"""A2A production bootstrap — register discovery + JSON-RPC surfaces on any Flask app.
+
+Usage in mvp_app.py (or any entrypoint):
+
+    from sincor2.a2a_bootstrap import register_a2a
+    register_a2a(app)
+
+This is the single critical path that unblocks:
+  GET  /.well-known/agent-card.json
+  GET  /.well-known/agent.json
+  POST /api/a2a
+  GET  /api/a2a/agents
+  GET|POST /api/a2a/quote
+  POST /api/a2a/settle
+  GET  /api/a2a/leaderboard
+  GET  /api/a2a/pricing
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger("sincor.a2a.bootstrap")
+
+
+def register_a2a(app: Any) -> bool:
+    """Register A2ARouter blueprint on the given Flask app. Idempotent.
+
+    Returns True if routes were registered, False if already present or failed.
+    """
+    if getattr(app, "_sincor_a2a_registered", False):
+        logger.info("A2A already registered — skipping")
+        return True
+
+    try:
+        from sincor2.a2a_integration import A2ARouter
+
+        router = A2ARouter()
+        # url_prefix="" so /.well-known and /api/a2a land at domain root
+        app.register_blueprint(router.blueprint, url_prefix="")
+        app._sincor_a2a_registered = True
+        logger.info(
+            "A2A v1.0.1 surfaces live: agent-card.json, agent.json, /api/a2a "
+            "(+ agents, quote, settle, leaderboard, pricing)"
+        )
+        return True
+    except Exception as exc:
+        logger.exception("A2A registration failed: %s", exc)
+        return False
+
+
+def required_env_report() -> dict:
+    """Return production env readiness for A2A payment verification + task store."""
+    return {
+        "PLATFORM_URL": os.getenv("PLATFORM_URL", "https://getsincor.com"),
+        "A2A_PRIMARY_TOKEN": os.getenv("A2A_PRIMARY_TOKEN", "AXIOM"),
+        "AXIOM_CONTRACT_ADDRESS": os.getenv(
+            "AXIOM_CONTRACT_ADDRESS", "0xfF7aF6ffca25A9DC0FC990d998AcF24Cc60b7822"
+        ),
+        "TREASURY_ADDRESS": os.getenv(
+            "TREASURY_ADDRESS", "0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac"
+        ),
+        "BASE_RPC_URL": os.getenv("BASE_RPC_URL") or "NOT_SET",
+        "A2A_TASK_STORE": os.getenv("A2A_TASK_STORE", "memory"),
+        "REDIS_URL": "set" if os.getenv("REDIS_URL") else "NOT_SET",
+        "BASE_CHAIN_ID": os.getenv("BASE_CHAIN_ID", "8453"),
+    }

--- a/static/.well-known/agent.json
+++ b/static/.well-known/agent.json
@@ -1,18 +1,45 @@
 {
   "name": "SINCOR Agent Swarm",
-  "description": "Production autonomous AI workforce. 42 specialized agents. Pay in SINC/AXM on Base.",
+  "description": "Production autonomous AI workforce. 43 specialized agents across Scout, Builder, Synthesizer, Negotiator, Director, Auditor, Caretaker. External agents pay in AXIOM (AXM) on Base; 50% of each settlement is burned. Full A2A v1.0.1 card at /.well-known/agent-card.json once A2ARouter is registered on the production app.",
   "url": "https://getsincor.com/api/a2a",
   "version": "2.0.0",
+  "protocolVersion": "1.0.1",
+  "provider": {
+    "organization": "SINCOR",
+    "url": "https://getsincor.com"
+  },
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "stateTransitionHistory": true
+  },
+  "defaultInputModes": ["text/plain", "application/json"],
+  "defaultOutputModes": ["text/plain", "application/json"],
   "skills": [
-    {"id": "lead-enrichment", "name": "Lead Enrichment", "sinc_price": 3},
-    {"id": "competitor-intel", "name": "Competitor Intelligence", "sinc_price": 2},
-    {"id": "outreach-sequence", "name": "Outreach Sequence", "sinc_price": 3},
-    {"id": "market-forecast", "name": "Market Forecast", "sinc_price": 4},
-    {"id": "toa-decision", "name": "TOA Decision", "sinc_price": 6}
+    {"id": "lead-enrichment", "name": "Lead Enrichment & Outbound Prospecting", "tags": ["sales", "leads"], "axmPriceDisplay": "2.5000 AXM", "freeQuota": 5},
+    {"id": "competitor-intel", "name": "Competitor Intelligence & SWOT", "tags": ["market", "research"], "axmPriceDisplay": "2.0000 AXM", "freeQuota": 5},
+    {"id": "outreach-sequence", "name": "Outreach Sequence Builder", "tags": ["sales", "outreach"], "axmPriceDisplay": "3.0000 AXM", "freeQuota": 5},
+    {"id": "healthcare-credential-check", "name": "Healthcare Provider Credential Check", "tags": ["healthcare", "rcm"], "axmPriceDisplay": "4.0000 AXM", "freeQuota": 0},
+    {"id": "dental-billing-scrub", "name": "Dental Billing Scrub & Claims Cleanup", "tags": ["dental", "billing"], "axmPriceDisplay": "3.5000 AXM", "freeQuota": 0},
+    {"id": "compliance-sbom", "name": "Compliance SBOM & Regulatory Filing", "tags": ["compliance", "sbom"], "axmPriceDisplay": "5.0000 AXM", "freeQuota": 0},
+    {"id": "market-forecast", "name": "Market Forecast & Scenario Planning", "tags": ["analytics", "forecasting"], "axmPriceDisplay": "4.0000 AXM", "freeQuota": 5},
+    {"id": "deal-scoring", "name": "Deal Scoring & Pipeline Prioritisation", "tags": ["sales", "crm"], "axmPriceDisplay": "2.5000 AXM", "freeQuota": 0},
+    {"id": "content-blog", "name": "Content & Blog Post Generation", "tags": ["content", "marketing"], "axmPriceDisplay": "2.0000 AXM", "freeQuota": 5},
+    {"id": "cashflow-recovery", "name": "Cash-Flow Recovery & Invoice Management", "tags": ["finance", "collections"], "axmPriceDisplay": "3.5000 AXM", "freeQuota": 0},
+    {"id": "local-business-site-builder", "name": "Local Business Site Builder", "tags": ["local-business", "website"], "axmPriceDisplay": "5.0000 AXM", "freeQuota": 0},
+    {"id": "toa-decision", "name": "TOA Strategic Decision & Routing", "tags": ["toa", "strategy"], "axmPriceDisplay": "6.0000 AXM", "freeQuota": 0}
   ],
-  "provider": {"organization": "SINCOR", "url": "https://getsincor.com"},
   "authentication": {
     "schemes": [],
-    "description": "No API key required. Payment enforced on-chain via SINC/AXM transfer to treasury."
+    "description": "No API key. Payment enforced on-chain via AXM transfer to treasury 0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac on Base (8453)."
+  },
+  "settlement": {
+    "primary_token": "AXIOM",
+    "contract": "0xfF7aF6ffca25A9DC0FC990d998AcF24Cc60b7822",
+    "treasury": "0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac",
+    "burn_to": "0x000000000000000000000000000000000000dEaD",
+    "burn_split": "50%",
+    "treasury_split": "50%",
+    "chain_id": 8453
   }
 }


### PR DESCRIPTION
## Reality check (2026-08-17 live audit)

Production (`gunicorn sincor2.mvp_app:app`) does **not** register `A2ARouter`.

| Endpoint | Live status |
|----------|-------------|
| `GET /.well-known/agent-card.json` | **404** |
| `GET /.well-known/agent.json` | 200 static incomplete card |
| `GET /api/a2a/agents` | **404** |
| `GET /api/a2a/quote` | **404** |
| health `base_rpc` | `not_configured` |

Full production A2A surface already exists in `a2a_integration.py` (43 skills, JSON-RPC, quote, settle, leaderboard, pricing engine, free-quota, PaymentVerifier, 50/50 burn/treasury). It is dead code until registered on `mvp_app`.

## This PR

1. **`src/sincor2/a2a_bootstrap.py`** — one-call `register_a2a(app)` helper (idempotent).
2. **`docs/A2A_PRODUCTION_CHECKLIST.md`** — exact wiring steps, Railway env vars, post-deploy smoke, track status.
3. **`static/.well-known/agent.json`** — expanded interim card (12 skills + settlement metadata) so legacy path is not empty while blueprint lands.
4. **`examples/external_agent_registration.sh`** — end-to-end smoke script against production.

## Required one-liner in mvp_app.py (merge + deploy gate)

Immediately after Flask app creation / logger setup:

```python
try:
    from sincor2.a2a_bootstrap import register_a2a
    if register_a2a(app):
        logger.info("[A2A] discovery surfaces registered")
    else:
        logger.error("[A2A] registration failed")
except Exception as e:
    logger.error("[A2A] bootstrap error: %s", e)
```

Then **delete or disable** the static `@app.route('/.well-known/agent.json')` handler so the blueprint owns discovery.

## Railway env (mandatory)

```
A2A_PRIMARY_TOKEN=AXIOM
BASE_RPC_URL=<Alchemy or public Base RPC>
A2A_TASK_STORE=redis
REDIS_URL=<Railway Redis>
PLATFORM_URL=https://getsincor.com
TREASURY_ADDRESS=0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac
AXIOM_CONTRACT_ADDRESS=0xfF7aF6ffca25A9DC0FC990d998AcF24Cc60b7822
```

## Success definition

External agent can fetch full card → quote → free-quota or AXM pay → execute → proof-of-settlement with treasury fee routing.

**Do not submit to A2A directories until agent-card.json is 200 with full skills.**

— executed under A2A Massive Agent Inflow checklist oversight