### PR TITLE
Add async task queue and real A2A SSE streaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,22 @@ POLYCLAW_DB_PATH=/data/polyclaw.db
 # DATABASE_URL=postgresql://user:password@localhost:5432/sincor2
 
 # ==============================================================================
+# Async task queue (Celery + Redis)
+# ==============================================================================
+# Without REDIS_URL the web process falls back to an in-process thread pool
+# so gunicorn still returns 202 instead of blocking for 180s.
+# SINCOR_TASK_QUEUE=auto|celery|thread|eager   (eager is forced in FLASK_ENV=test)
+REDIS_URL=redis://localhost:6379/0
+# REDIS_PRIVATE_URL=
+# CELERY_BROKER_URL=redis://localhost:6379/0
+# CELERY_RESULT_BACKEND=redis://localhost:6379/0
+SINCOR_TASK_QUEUE=auto
+SINCOR_QUEUE_WORKERS=4
+SINCOR_TASK_SOFT_LIMIT=540
+SINCOR_TASK_HARD_LIMIT=600
+A2A_TASK_STORE=redis
+
+# ==============================================================================
 # API Keys & Integrations
 # ==============================================================================
 ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxx

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: python -m gunicorn sincor2.mvp_app:app --config gunicorn.conf.py
+worker: celery -A sincor2.celery_app.celery worker --loglevel=info --concurrency=2 -Q sincor.long

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
       JWT_SECRET_KEY: dev-jwt-secret-key-change-in-production
       DATABASE_URL: sqlite:////data/orders.db
       SINCOR_DATA_DIR: /data
+      REDIS_URL: redis://redis:6379/0
+      CELERY_BROKER_URL: redis://redis:6379/0
+      SINCOR_TASK_QUEUE: celery
+      A2A_TASK_STORE: redis
     volumes:
       - ./src:/app/src
       - ./templates:/app/templates
@@ -28,6 +32,45 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    depends_on:
+      - redis
+
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: sincor2-worker
+    command: celery -A sincor2.celery_app.celery worker --loglevel=info --concurrency=2 -Q sincor.long
+    environment:
+      FLASK_ENV: development
+      REDIS_URL: redis://redis:6379/0
+      CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
+      SINCOR_TASK_QUEUE: celery
+      A2A_TASK_STORE: redis
+      SINCOR_DATA_DIR: /data
+      JWT_SECRET_KEY: dev-jwt-secret-key-change-in-production
+      SECRET_KEY: dev-secret-key-change-in-production
+    volumes:
+      - ./src:/app/src
+      - sincor_data:/data
+    networks:
+      - sincor-network
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7-alpine
+    container_name: sincor2-redis
+    ports:
+      - "6379:6379"
+    networks:
+      - sincor-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
 
   postgres:
     image: postgres:15-alpine

--- a/docs/ASYNC_TASK_QUEUE.md
+++ b/docs/ASYNC_TASK_QUEUE.md
@@ -1,0 +1,65 @@
+# Async task queue + real A2A streaming
+
+Gunicorn runs a **single sync worker** with a **180s timeout**. Anything that
+does real work on the request thread (A2A dispatch, content generation,
+webbuilder phases) will 504 the site.
+
+## Contract
+
+| Endpoint | HTTP | Body |
+|---|---|---|
+| `POST /api/a2a` `message/send` | 200 (JSON-RPC) | Task, `status.state` is `submitted`/`working` until the worker finishes. Poll `tasks/get`. |
+| `POST /api/a2a/tasks/send` | **202 Accepted** | `{ accepted, task_id, poll_url, result }` |
+| `POST /admin/content/generate` | **202** | `{ accepted, task_id, poll_url }` |
+| `POST /api/webbuilder/projects/<id>/run` | **202** | same |
+| `POST /api/webbuilder/projects/<id>/rebuild` | **202** | same |
+| `GET /api/tasks/<id>` | 200 | `{ task_id, kind, status, progress, result, error }` |
+| `POST /api/a2a` `message/stream` | 200 `text/event-stream` | Token SSE (stays on the socket) |
+
+Clients: return immediately, then poll `/api/tasks/<id>` (or A2A `tasks/get`)
+until `status` is `completed` or `failed`.
+
+## Backends
+
+`SINCOR_TASK_QUEUE=auto|celery|thread|eager`
+
+- **eager** — forced when `FLASK_ENV=test`. Runs the job inline so pytest
+  still sees a completed A2A task.
+- **celery** — when `REDIS_URL` / `CELERY_BROKER_URL` is reachable.
+- **thread** — in-process `ThreadPoolExecutor`. Unsticks gunicorn even on a
+  host that has no Redis yet (current Railway default). Shared memory, so
+  keep `gunicorn.conf.py` at `workers = 1` unless you also set
+  `A2A_TASK_STORE=redis`.
+
+### Celery worker
+
+```
+celery -A sincor2.celery_app.celery worker --loglevel=info -Q sincor.long
+```
+
+Procfile defines a `worker` process. Railway: add a second service with that
+start command and the same `REDIS_URL`. Compose: `docker compose up redis worker sincor2`.
+
+Celery workers are a **separate process**. Set `A2A_TASK_STORE=redis` (or
+sqlite on a shared volume) so the worker can see A2A tasks created by the web
+process.
+
+## Real A2A SSE
+
+`message/stream` no longer waits for `_dispatch_to_swarm()` and dumps one
+artifact. It:
+
+1. Yields `status-update` `submitted`
+2. Yields `status-update` `working`
+3. Yields `artifact-update` chunks (`append: true`) from
+   `client.messages.stream()` / `text_stream` when `ANTHROPIC_API_KEY` is set
+4. Yields `lastChunk: true`
+5. Yields `status-update` `completed` with `final: true`
+
+Streaming stays on the HTTP connection on purpose. Use `message/send` + the
+queue for jobs you don't want to hold a socket for.
+
+## Health
+
+`GET /health` includes `checks.task_queue.detail` = `celery|thread|eager`.
+The queue is non-critical: the thread fallback always accepts work.

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -3,6 +3,12 @@
 Using a Python config file means no shell-variable expansion is needed in
 the start command, so it works whether Railway executes the command via a
 shell or in exec/array form.
+
+sync workers + timeout=180: long jobs (A2A, content, webbuilder) MUST go
+through sincor2.task_queue (Celery/Redis or the thread-pool fallback) and
+return 202. Do not raise this timeout to "fix" 504s — that just blocks the
+only worker for longer. Streamed A2A (message/stream) stays on the socket
+on purpose; everything else is async.
 """
 import os
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ eth-account>=0.10.0
 # Scheduling & Async
 APScheduler==3.10.4
 aiofiles==24.1.0
+celery[redis]>=5.4.0
 
 # Logging & Observability
 watchtower==3.3.1

--- a/src/sincor2/a2a_integration.py
+++ b/src/sincor2/a2a_integration.py
@@ -1442,7 +1442,7 @@ class PaymentVerifier:
                     expected_amount_wei=expected_amount_wei,
                 )
         except Exception as exc:
-            logger.error("PaymentVerifier RPC error: %s", e xc)
+            logger.error("PaymentVerifier RPC error: %s", exc)
 
         if result:
             with cls._lock:
@@ -1571,7 +1571,17 @@ class A2ARouter:
         def tasks_send():
             from flask import jsonify, request
             body = request.get_json(force=True, silent=True) or {}
-            return jsonify(_handle_send(body))
+            payload = _handle_send(body)
+            if payload.get("error"):
+                return jsonify(payload), 400
+            task = payload.get("result") or {}
+            task_id = task.get("id")
+            return jsonify({
+                **payload,
+                "accepted": True,
+                "task_id": task_id,
+                "poll_url": f"/api/a2a/tasks/{task_id}" if task_id else None,
+            }), 202
 
         @bp.route("/api/a2a/tasks/<task_id>", methods=["GET"])
         def tasks_get_rest(task_id: str):
@@ -1922,7 +1932,7 @@ def _handle_send(body: Dict[str, Any]) -> Dict[str, Any]:
     if free_call:
         _free_quota_tracker.consume(caller_id, skill_id)
 
-    # --- Create task & dispatch ------------------------------------------
+    # --- Create task & enqueue (never block the gunicorn worker) ----------
     task = _new_task(
         skill_id=skill_id,
         input_text=input_text,
@@ -1939,64 +1949,20 @@ def _handle_send(body: Dict[str, Any]) -> Dict[str, Any]:
         task.id, skill_id, caller_id, caller_reputation, is_high_rep, free_call,
     )
 
-    _update_task(task, state=TaskState.WORKING)
-    output, error = _dispatch_to_swarm(task)
-    if error:
-        _update_task(task, state=TaskState.FAILED, error=error)
-    else:
-        # Store output as an artifact
-        if output:
-            artifact = A2AArtifact(
-                artifact_id=str(uuid.uuid4()),
-                parts=[{"text": output}],
-                name="result",
-            )
-            task.artifacts.append(artifact)
-            # Also append the agent reply to history
-            agent_msg = A2AMessage(
-                message_id=str(uuid.uuid4()),
-                role="agent",
-                parts=[{"text": output}],
-                context_id=task.context_id,
-                task_id=task.id,
-            )
-            task.history.append(agent_msg)
+    try:
+        from sincor2.task_queue import enqueue
 
-        # Build proof of settlement
-        result_content = output or ""
-        result_hash = hashlib.sha256((task.id + result_content).encode()).hexdigest()
-        proof = {
-            "task_id":            task.id,
-            "skill_id":           skill_id,
-            "caller_id":          caller_id,
-            "tx_hash":            tx_hash or "",
-            "axm_paid_wei":       str(axm_paid),
-            "burn_amount_wei":    str(axm_paid // 2),
-            "burn_to":            DEAD_ADDRESS,
-            "treasury_amount_wei": str(axm_paid - axm_paid // 2),
-            "treasury":           TREASURY_WALLET,
-            "result_hash":        result_hash,
-            "settled_at":         _now(),
-            "chain_id":           CHAIN_ID,
-            "basescan_url":       (
-                f"https://basescan.org/tx/{tx_hash}" if tx_hash else ""
-            ),
-            "free_call":          free_call,
-        }
-        _update_task(task, state=TaskState.COMPLETED, output=output,
-                     metadata={**task.metadata, "proof_of_settlement": proof})
-
-        # Record settlement and update pricing fill count
-        if (axm_paid > 0 and tx_hash) or free_call:
-            _record_a2a_settlement(task, axm_paid, tx_hash or "")
-            _reputation_ledger.record(
-                caller_id=caller_id,
-                skill_id=skill_id,
-                task_id=task.id,
-                axm_paid_wei=axm_paid,
-            )
-            _price_engine.record_fill(skill_id)
-            _fire_toa_feedback(task, success=True)
+        job = enqueue("a2a.execute", {"task_id": task.id})
+        task.metadata["queue_job_id"] = job.id
+        _update_task(task)
+        # Eager (tests) already finalized the A2A task; reload.
+        task = _get_task(task.id) or task
+    except Exception as exc:
+        logger.exception("Queue enqueue failed for A2A task %s: %s", task.id, exc)
+        _update_task(task, state=TaskState.WORKING)
+        output, error = _dispatch_to_swarm(task)
+        _finalize_a2a_task(task, output, error)
+        task = _get_task(task.id) or task
 
     task_dict = _task_to_rpc(task, history_length=history_length)
     # Surface proof of settlement at top-level for convenience
@@ -2007,17 +1973,99 @@ def _handle_send(body: Dict[str, Any]) -> Dict[str, Any]:
     return _rpc_ok(task_dict, rpc_id=rpc_id)
 
 
+def _finalize_a2a_task(task: "A2ATask", output: Optional[str], error: Optional[str]) -> Dict[str, Any]:
+    """Persist swarm output, proof of settlement, and terminal task state.
+
+    Called from the async worker (and the eager test path). Safe to invoke
+    outside a Flask request context.
+    """
+    if error:
+        _update_task(task, state=TaskState.FAILED, error=error)
+        _fire_toa_feedback(task, success=False)
+        return {"task_id": task.id, "state": task.state.value, "error": error}
+
+    if output:
+        artifact = A2AArtifact(
+            artifact_id=str(uuid.uuid4()),
+            parts=[{"text": output}],
+            name="result",
+        )
+        task.artifacts.append(artifact)
+        agent_msg = A2AMessage(
+            message_id=str(uuid.uuid4()),
+            role="agent",
+            parts=[{"text": output}],
+            context_id=task.context_id,
+            task_id=task.id,
+        )
+        task.history.append(agent_msg)
+
+    result_content = output or ""
+    result_hash = hashlib.sha256((task.id + result_content).encode()).hexdigest()
+    skill_id = task.skill_id
+    caller_id = task.caller_id
+    tx_hash = task.tx_hash
+    axm_paid = task.axm_paid
+    free_call = bool(task.metadata.get("free_call"))
+    proof = {
+        "task_id":             task.id,
+        "skill_id":            skill_id,
+        "caller_id":           caller_id,
+        "tx_hash":             tx_hash or "",
+        "axm_paid_wei":        str(axm_paid),
+        "burn_amount_wei":     str(axm_paid // 2),
+        "burn_to":             DEAD_ADDRESS,
+        "treasury_amount_wei": str(axm_paid - axm_paid // 2),
+        "treasury":            TREASURY_WALLET,
+        "result_hash":         result_hash,
+        "settled_at":          _now(),
+        "chain_id":            CHAIN_ID,
+        "basescan_url":        (
+            f"https://basescan.org/tx/{tx_hash}" if tx_hash else ""
+        ),
+        "free_call":           free_call,
+    }
+    _update_task(task, state=TaskState.COMPLETED, output=output,
+                 metadata={**task.metadata, "proof_of_settlement": proof})
+
+    if (axm_paid > 0 and tx_hash) or free_call:
+        _record_a2a_settlement(task, axm_paid, tx_hash or "")
+        _reputation_ledger.record(
+            caller_id=caller_id,
+            skill_id=skill_id,
+            task_id=task.id,
+            axm_paid_wei=axm_paid,
+        )
+        _price_engine.record_fill(skill_id)
+        _fire_toa_feedback(task, success=True)
+
+    return {
+        "task_id": task.id,
+        "state": task.state.value,
+        "output": output,
+        "proof_of_settlement": proof,
+    }
+
+
 def _record_a2a_settlement(task: "A2ATask", axm_paid: int, tx_hash: str) -> None:
     """Create a settlement record in the platform coordinator for a paid A2A task."""
     try:
         from decimal import Decimal
 
-        from flask import current_app, has_request_context
+        from flask import current_app, has_app_context, has_request_context
 
-        if not has_request_context():
-            return
-
-        platform_state = current_app.extensions.get("sincor_platform")
+        platform_state = None
+        if has_request_context() or has_app_context():
+            platform_state = current_app.extensions.get("sincor_platform")
+        if not platform_state:
+            for _mod in ("sincor2.app", "sincor2.mvp_app"):
+                try:
+                    import importlib
+                    platform_state = getattr(importlib.import_module(_mod), "app").extensions.get("sincor_platform")
+                    if platform_state:
+                        break
+                except Exception:
+                    continue
         if not platform_state:
             return
 
@@ -2047,51 +2095,91 @@ def _record_a2a_settlement(task: "A2ATask", axm_paid: int, tx_hash: str) -> None
             float(amount_display),
             tx_hash,
         )
-    except Exception as e xc:
-        logger.warning("Settlement record failed for task %s: %s", task.id, e xc)
+    except Exception as exc:
+        logger.warning("Settlement record failed for task %s: %s", task.id, exc)
+
+
+def _sse_status(task: A2ATask, rpc_id: Any, final: bool = False,
+                msg_text: Optional[str] = None) -> str:
+    """A2A TaskStatusUpdateEvent (spec + legacy taskStatus envelope)."""
+    status: Dict[str, Any] = {
+        "state":     task.state.value,
+        "timestamp": task.updated_at,
+    }
+    if msg_text:
+        status["message"] = {
+            "messageId": str(uuid.uuid4()),
+            "role":      "agent",
+            "parts":     [{"kind": "text", "text": msg_text}],
+            "contextId": task.context_id,
+            "taskId":    task.id,
+        }
+    result: Dict[str, Any] = {
+        "kind":      "status-update",
+        "taskId":    task.id,
+        "contextId": task.context_id,
+        "status":    status,
+        "final":     final,
+        "taskStatus": {
+            "taskId":    task.id,
+            "contextId": task.context_id,
+            "status":    status,
+            "final":     final,
+        },
+    }
+    return _sse_event({"jsonrpc": "2.0", "id": rpc_id, "result": result})
+
+
+def _sse_artifact_chunk(
+    task: A2ATask,
+    rpc_id: Any,
+    artifact_id: str,
+    text: str,
+    *,
+    append: bool = True,
+    last_chunk: bool = False,
+) -> str:
+    """A2A TaskArtifactUpdateEvent with append / lastChunk for token streaming."""
+    artifact = {
+        "artifactId": artifact_id,
+        "name": "result",
+        "parts": [{"kind": "text", "text": text}],
+    }
+    result: Dict[str, Any] = {
+        "kind":      "artifact-update",
+        "taskId":    task.id,
+        "contextId": task.context_id,
+        "artifact":  artifact,
+        "append":    append,
+        "lastChunk": last_chunk,
+        "taskArtifact": {
+            "taskId":    task.id,
+            "contextId": task.context_id,
+            "artifact":  artifact,
+            "append":    append,
+            "lastChunk": last_chunk,
+            "final":     last_chunk,
+        },
+    }
+    return _sse_event({"jsonrpc": "2.0", "id": rpc_id, "result": result})
 
 
 def _handle_stream(body: Dict[str, Any]) -> Generator[str, None, None]:
     """
-    Handle message/stream — yields SSE events for the A2A v1.0.1 streaming flow.
+    Handle message/stream — real SSE token streaming for A2A v1.0.1.
 
     Event sequence:
       1. TaskStatusUpdateEvent: state=submitted
       2. TaskStatusUpdateEvent: state=working
-      3. (dispatch to swarm)
-      4. TaskArtifactUpdateEvent: artifact with result
+      3. TaskArtifactUpdateEvent chunks (append=true) as tokens arrive
+      4. TaskArtifactUpdateEvent lastChunk=true
       5. TaskStatusUpdateEvent: state=completed (or failed), final=true
+
+    Stays on the HTTP connection (not Celery) so the client can consume
+    tokens live. Long non-stream jobs use message/send + the async queue.
     """
     (rpc_id, skill_id, context_id, caller_id, input_text,
      tx_hash, axm_paid, _) = _extract_send_params(body)
-
-    def _status_event(task: A2ATask, final: bool = False,
-                      msg_text: Optional[str] = None) -> str:
-        status: Dict[str, Any] = {
-            "state":     task.state.value,
-            "timestamp": task.updated_at,
-        }
-        if msg_text:
-            status["message"] = {
-                "messageId": str(uuid.uuid4()),
-                "role":      "agent",
-                "parts":     [{"text": msg_text}],
-                "contextId": task.context_id,
-                "taskId":    task.id,
-            }
-        event: Dict[str, Any] = {
-            "jsonrpc": "2.0",
-            "id":      rpc_id,
-            "result":  {
-                "taskStatus": {
-                    "taskId":    task.id,
-                    "contextId": task.context_id,
-                    "status":    status,
-                    "final":     final,
-                },
-            },
-        }
-        return _sse_event(event)
 
     if not input_text:
         yield _sse_event(_err("No input text in message.parts", -32602, rpc_id))
@@ -2129,54 +2217,54 @@ def _handle_stream(body: Dict[str, Any]) -> Generator[str, None, None]:
     )
     logger.info("A2A stream task %s  skill=%s caller=%s", task.id, skill_id, caller_id)
 
-    # Event 1: submitted
-    yield _status_event(task)
+    yield _sse_status(task, rpc_id)
 
-    # Event 2: working
     _update_task(task, state=TaskState.WORKING)
-    yield _status_event(task)
+    yield _sse_status(task, rpc_id)
 
-    # Dispatch
-    output, error = _dispatch_to_swarm(task)
+    artifact_id = str(uuid.uuid4())
+    chunks: List[str] = []
+    error: Optional[str] = None
+    try:
+        for token in _dispatch_to_swarm_stream(task):
+            if not token:
+                continue
+            chunks.append(token)
+            yield _sse_artifact_chunk(
+                task, rpc_id, artifact_id, token, append=True, last_chunk=False,
+            )
+    except Exception as exc:
+        logger.exception("A2A stream dispatch failed for %s", task.id)
+        error = str(exc)
+
+    output = "".join(chunks) if chunks else None
+    yield _sse_artifact_chunk(
+        task, rpc_id, artifact_id, "", append=True, last_chunk=True,
+    )
 
     if error:
         _update_task(task, state=TaskState.FAILED, error=error)
-        yield _status_event(task, final=True, msg_text=f"Error: {error}")
+        yield _sse_status(task, rpc_id, final=True, msg_text=f"Error: {error}")
         return
 
-    # Event 3: artifact
     if output:
         artifact = A2AArtifact(
-            artifact_id=str(uuid.uuid4()),
-            parts=[{"text": output}],
+            artifact_id=artifact_id,
+            parts=[{"kind": "text", "text": output}],
             name="result",
         )
         task.artifacts.append(artifact)
         agent_msg = A2AMessage(
             message_id=str(uuid.uuid4()),
             role="agent",
-            parts=[{"text": output}],
+            parts=[{"kind": "text", "text": output}],
             context_id=task.context_id,
             task_id=task.id,
         )
         task.history.append(agent_msg)
-        artifact_event: Dict[str, Any] = {
-            "jsonrpc": "2.0",
-            "id":      rpc_id,
-            "result":  {
-                "taskArtifact": {
-                    "taskId":    task.id,
-                    "contextId": task.context_id,
-                    "artifact":  artifact.to_dict(),
-                    "final":     False,
-                },
-            },
-        }
-        yield _sse_event(artifact_event)
 
-    # Event 4: completed
     _update_task(task, state=TaskState.COMPLETED, output=output)
-    yield _status_event(task, final=True)
+    yield _sse_status(task, rpc_id, final=True)
 
 
 def _handle_get(task_id: str) -> Dict[str, Any]:
@@ -2371,8 +2459,8 @@ def _fire_toa_feedback(task: "A2ATask", success: bool) -> None:
                 "success":    success,
                 "ts":         task.updated_at,
             })
-        except Exception as e xc:
-            logger.debug("TOA feedback skipped (router unavailable): %s", e xc)
+        except Exception as exc:
+            logger.debug("TOA feedback skipped (router unavailable): %s", exc)
 
     threading.Thread(target=_send, daemon=True, name="toa-feedback").start()
 
@@ -2449,9 +2537,42 @@ def _dispatch_to_swarm(task: A2ATask):
         )
         return stub, None
 
-    except Exception as e xc:
+    except Exception as exc:
         logger.exception("Swarm dispatch error for task %s", task.id)
-        return None, str(e xc)
+        return None, str(exc)
+
+
+def _dispatch_to_swarm_stream(task: A2ATask) -> Generator[str, None, None]:
+    """
+    Yield tokens as they arrive.
+
+    Prefer Anthropic `messages.stream()` when ANTHROPIC_API_KEY is set so
+    A2A clients see real token-by-token SSE. Otherwise run the existing
+    (non-streaming) swarm dispatch and chunk the completed string so the
+    wire protocol still emits append/lastChunk events instead of one blob.
+    """
+    from sincor2.llm_stream import chunk_text, has_anthropic, skill_system_prompt, stream_claude
+
+    if has_anthropic():
+        try:
+            yielded = False
+            for token in stream_claude(
+                task.input_text,
+                system=skill_system_prompt(task.skill_id),
+                max_tokens=2048,
+            ):
+                yielded = True
+                yield token
+            if yielded:
+                return
+        except Exception as exc:
+            logger.warning("LLM stream failed for task %s (%s); falling back to dispatch", task.id, exc)
+
+    output, error = _dispatch_to_swarm(task)
+    if error:
+        raise RuntimeError(error)
+    delay = 0.0 if os.getenv("FLASK_ENV", "").lower() in ("test", "testing") else 0.015
+    yield from chunk_text(output or "", delay=delay)
 
 
 # ---------------------------------------------------------------------------

--- a/src/sincor2/app.py
+++ b/src/sincor2/app.py
@@ -143,6 +143,12 @@ try:
     _a2a_router = A2ARouter()
     app.register_blueprint(_a2a_router.blueprint)
     print("✓ A2A routes initialized")
+    try:
+        from sincor2.task_queue import register_flask_routes
+        register_flask_routes(app)
+        print("✓ Task queue poll routes initialized")
+    except Exception as _q_err:
+        print(f"WARNING: Task queue routes not available: {_q_err}")
 except Exception as _a2a_err:
     print(f"WARNING: A2A routes not available: {_a2a_err}")
 
@@ -1395,6 +1401,8 @@ def create_app():
         from sincor2.a2a_integration import A2ARouter
         router = A2ARouter()
         app.register_blueprint(router.blueprint)
+        from sincor2.task_queue import register_flask_routes
+        register_flask_routes(app)
     except Exception as e:
         print(f"A2A integration not available: {e}")
     return app

--- a/src/sincor2/async_tasks.py
+++ b/src/sincor2/async_tasks.py
@@ -1,0 +1,107 @@
+"""
+Celery / thread-pool job handlers for long-running SINCOR work.
+
+Kinds:
+  a2a.execute          A2A message/send dispatch
+  content.generate     /admin/content/generate
+  webbuilder.run       /api/webbuilder/projects/<id>/run
+  webbuilder.rebuild   /api/webbuilder/projects/<id>/rebuild
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+from sincor2.task_queue import register_handler, run_job, update_job
+
+logger = logging.getLogger("sincor.async_tasks")
+
+try:
+    from sincor2.celery_app import celery
+except Exception:  # pragma: no cover — celery extra missing
+    celery = None  # type: ignore[assignment]
+
+
+def _celery_task(*dargs, **dkwargs):
+    if celery is None:
+        def _wrap(fn):
+            return fn
+        return _wrap
+    return celery.task(*dargs, **dkwargs)
+
+
+@_celery_task(bind=True, name="sincor2.execute_job", queue="sincor.long")
+def execute_job(self=None, job_id: str = "") -> Any:
+    if self is not None:
+        try:
+            update_job(job_id, celery_id=getattr(self.request, "id", None), state="running")
+        except Exception:
+            pass
+    job = run_job(job_id)
+    return job.result if job else None
+
+
+def _handle_a2a(payload: Dict[str, Any], job_id: str) -> Any:
+    from sincor2.a2a_integration import (
+        TaskState,
+        _dispatch_to_swarm,
+        _finalize_a2a_task,
+        _get_task,
+        _update_task,
+    )
+
+    task_id = payload.get("task_id") or ""
+    task = _get_task(task_id)
+    if not task:
+        raise RuntimeError(f"A2A task {task_id} not found (shared TaskStore required for Celery)")
+    _update_task(task, state=TaskState.WORKING)
+    update_job(job_id, progress=20)
+    output, error = _dispatch_to_swarm(task)
+    update_job(job_id, progress=85)
+    finalized = _finalize_a2a_task(task, output, error)
+    return finalized
+
+
+def _handle_content(payload: Dict[str, Any], job_id: str) -> Any:
+    from sincor2.content_agent import WordPressPublisher, generate_blog_post, init_db, save_post
+
+    update_job(job_id, progress=10)
+    init_db()
+    keyword = payload.get("keyword") or ""
+    ctype = payload.get("ctype") or "how-to"
+    model = payload.get("model") or os.environ.get("CONTENT_MODEL", "claude-haiku-4-5")
+    post = generate_blog_post(keyword, ctype, model=model)
+    update_job(job_id, progress=70)
+    path = save_post(post)
+    result = {
+        "title": post["title"],
+        "slug": post["slug"],
+        "word_count": post["word_count"],
+        "path": str(path),
+    }
+    if payload.get("do_publish"):
+        wp = WordPressPublisher()
+        result["wordpress"] = wp.publish(post)
+    return result
+
+
+def _handle_webbuilder_run(payload: Dict[str, Any], job_id: str) -> Any:
+    from sincor2.webbuilder_studio import run_autonomous_phases
+
+    update_job(job_id, progress=15)
+    result = run_autonomous_phases(payload.get("project_id") or "")
+    return result
+
+
+def _handle_webbuilder_rebuild(payload: Dict[str, Any], job_id: str) -> Any:
+    from sincor2.webbuilder_studio import rebuild_draft
+
+    update_job(job_id, progress=15)
+    return rebuild_draft(payload.get("project_id") or "", prompt=payload.get("prompt"))
+
+
+register_handler("a2a.execute", _handle_a2a)
+register_handler("content.generate", _handle_content)
+register_handler("webbuilder.run", _handle_webbuilder_run)
+register_handler("webbuilder.rebuild", _handle_webbuilder_rebuild)

--- a/src/sincor2/celery_app.py
+++ b/src/sincor2/celery_app.py
@@ -1,0 +1,61 @@
+"""
+SINCOR Celery application.
+
+Broker/backend default to REDIS_URL (or CELERY_BROKER_URL). The web process
+never runs tasks inline when a broker is configured — gunicorn stays free
+inside its 180s timeout.
+
+Start a worker:
+
+    celery -A sincor2.celery_app.celery worker --loglevel=info -Q sincor.long
+
+See docs/ASYNC_TASK_QUEUE.md.
+"""
+from __future__ import annotations
+
+import os
+
+from celery import Celery
+
+_broker = (
+    os.getenv("CELERY_BROKER_URL")
+    or os.getenv("REDIS_URL")
+    or os.getenv("REDIS_PRIVATE_URL")
+    or "redis://localhost:6379/0"
+)
+_backend = os.getenv("CELERY_RESULT_BACKEND") or _broker
+
+celery = Celery(
+    "sincor2",
+    broker=_broker,
+    backend=_backend,
+)
+
+celery.conf.update(
+    task_serializer="json",
+    accept_content=["json"],
+    result_serializer="json",
+    timezone="UTC",
+    enable_utc=True,
+    task_acks_late=True,
+    task_reject_on_worker_lost=True,
+    worker_prefetch_multiplier=1,
+    task_track_started=True,
+    task_time_limit=int(os.getenv("SINCOR_TASK_HARD_LIMIT", "600")),
+    task_soft_time_limit=int(os.getenv("SINCOR_TASK_SOFT_LIMIT", "540")),
+    task_default_queue="sincor.long",
+    task_default_delivery_mode=2,
+    result_expires=86400,
+    broker_connection_retry_on_startup=True,
+    include=["sincor2.async_tasks"],
+)
+
+
+def ping_broker(timeout: float = 1.5) -> bool:
+    """True if the broker answers a connection attempt."""
+    try:
+        with celery.connection_for_write() as conn:
+            conn.ensure_connection(max_retries=1, timeout=timeout)
+        return True
+    except Exception:
+        return False

--- a/src/sincor2/cortecs_core.py
+++ b/src/sincor2/cortecs_core.py
@@ -16,7 +16,7 @@ import json
 import os
 import asyncio
 import hashlib
-from typing import Dict, List, Optional, Any, Union, Tuple
+from typing import Dict, List, Optional, Any, Union, Tuple, Generator
 from datetime import datetime, timedelta
 from dataclasses import dataclass, asdict
 import uuid
@@ -98,6 +98,30 @@ class ClaudeClient:
             error_msg = f"Claude API error: {str(e)}"
             print(error_msg)
             raise Exception(error_msg)
+
+    def stream_sync(
+        self,
+        prompt: str,
+        max_tokens: int = 4000,
+        system: str = None,
+        model: Optional[str] = None,
+    ) -> Generator[str, None, None]:
+        """Yield text deltas from Anthropic `messages.stream()` / `text_stream`."""
+        if not self.client:
+            raise ValueError("Claude API not configured - set ANTHROPIC_API_KEY environment variable")
+
+        if not system:
+            system = "You are a helpful AI assistant for business automation and agent coordination."
+
+        with self.client.messages.stream(
+            model=model or self.model,
+            max_tokens=max_tokens,
+            system=system,
+            messages=[{"role": "user", "content": prompt}],
+        ) as stream:
+            for text in stream.text_stream:
+                if text:
+                    yield text
 
 
 @dataclass

--- a/src/sincor2/llm_stream.py
+++ b/src/sincor2/llm_stream.py
@@ -1,0 +1,92 @@
+"""
+Generator-based LLM streaming for A2A message/stream.
+
+Prefers Anthropic `client.messages.stream()` / `text_stream` so tokens
+leave the process as they arrive. When no API key is configured, callers
+chunk a completed string so SSE clients still see append/lastChunk events
+instead of a single blob.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Generator, Iterable, Optional
+
+logger = logging.getLogger("sincor.llm_stream")
+
+DEFAULT_CHUNK_CHARS = 28
+
+
+def has_anthropic() -> bool:
+    return bool((os.getenv("ANTHROPIC_API_KEY") or "").strip())
+
+
+def stream_claude(
+    prompt: str,
+    *,
+    system: Optional[str] = None,
+    max_tokens: int = 2048,
+    model: Optional[str] = None,
+) -> Generator[str, None, None]:
+    """
+    Yield text deltas from Anthropic `messages.stream()`.
+
+    Raises if the client cannot be constructed; yields nothing if the API
+    key is missing so callers can fall through to a stub.
+    """
+    if not has_anthropic():
+        return
+        yield  # pragma: no cover — makes this a generator even on early return
+
+    from sincor2.cortecs_core import ClaudeClient
+
+    client = ClaudeClient()
+    yield from client.stream_sync(
+        prompt,
+        max_tokens=max_tokens,
+        system=system,
+        model=model,
+    )
+
+
+def chunk_text(
+    text: str,
+    *,
+    size: int = DEFAULT_CHUNK_CHARS,
+    delay: float = 0.0,
+) -> Generator[str, None, None]:
+    """Split a completed string into SSE-sized chunks (word-aware)."""
+    if not text:
+        return
+    size = max(8, int(size))
+    words = text.split(" ")
+    buf: list[str] = []
+    n = 0
+    for word in words:
+        extra = len(word) + (1 if buf else 0)
+        if buf and n + extra > size:
+            yield " ".join(buf)
+            if delay:
+                time.sleep(delay)
+            buf = [word]
+            n = len(word)
+        else:
+            buf.append(word)
+            n += extra
+    if buf:
+        yield " ".join(buf)
+
+
+def iter_chunks(parts: Iterable[str]) -> Generator[str, None, None]:
+    for part in parts:
+        if part:
+            yield part
+
+
+def skill_system_prompt(skill_id: str) -> str:
+    return (
+        "You are a SINCOR swarm skill running over the A2A protocol. "
+        f"Skill id: {skill_id}. Answer as the specialist for that skill. "
+        "Be concrete, structured, and skip filler."
+    )

--- a/src/sincor2/mvp_app.py
+++ b/src/sincor2/mvp_app.py
@@ -99,6 +99,22 @@ app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
 app.config['SESSION_COOKIE_SECURE'] = bool(os.environ.get('RAILWAY_ENVIRONMENT'))
 jwt = JWTManager(app)
 
+# A2A JSON-RPC + discovery. Production gunicorn entry is this module, so the
+# router must live here (app.py already registers it for the test client).
+try:
+    from sincor2.a2a_integration import A2ARouter
+    app.register_blueprint(A2ARouter().blueprint)
+    logger.info('[A2A] Router registered on mvp_app')
+except Exception as _a2a_exc:
+    logger.warning('[A2A] Router not registered: %s', _a2a_exc)
+
+try:
+    from sincor2.task_queue import register_flask_routes as _register_queue_routes
+    _register_queue_routes(app)
+    logger.info('[QUEUE] /api/tasks poll routes registered')
+except Exception as _q_exc:
+    logger.warning('[QUEUE] poll routes not registered: %s', _q_exc)
+
 # OAuth (Google + GitHub)
 oauth = None
 OAUTH_REDIRECT_BASE = _env_first('OAUTH_REDIRECT_BASE_URL', 'PUBLIC_BASE_URL', 'SITE_URL', default='').rstrip('/')
@@ -872,6 +888,17 @@ def _build_runtime_health_report(include_optional: bool = True) -> dict:
         'paypal': {'ready': True, 'critical': False, 'detail': 'configured' if paypal_configured else 'not_configured'},
         'anthropic': {'ready': True, 'critical': False, 'detail': 'configured' if anthropic_configured else 'not_configured'},
     }
+    try:
+        from sincor2.task_queue import queue_health
+        qh = queue_health()
+        checks['task_queue'] = {
+            'ready': True,
+            'critical': False,
+            'detail': qh.get('backend', 'unknown'),
+            'redis': qh.get('redis'),
+        }
+    except Exception as qexc:
+        checks['task_queue'] = {'ready': True, 'critical': False, 'detail': f'unavailable:{qexc}'}
     if not include_optional:
         checks = {k: v for k, v in checks.items() if v.get('critical')}
 
@@ -2672,9 +2699,10 @@ def api_webbuilder_run(project_id):
     denied = _require_admin(request)
     if denied:
         return denied
-    from sincor2.webbuilder_studio import run_autonomous_phases
+    from sincor2.task_queue import accepted_payload, enqueue
 
-    return jsonify(run_autonomous_phases(project_id))
+    job = enqueue('webbuilder.run', {'project_id': project_id})
+    return jsonify(accepted_payload(job)), 202
 
 
 @app.route('/api/webbuilder/projects/<project_id>/approve', methods=['POST'])
@@ -2723,10 +2751,11 @@ def api_webbuilder_rebuild(project_id):
     denied = _require_admin(request)
     if denied:
         return denied
-    from sincor2.webbuilder_studio import rebuild_draft
+    from sincor2.task_queue import accepted_payload, enqueue
 
     data = request.get_json(silent=True) or {}
-    return jsonify(rebuild_draft(project_id, prompt=data.get('prompt')))
+    job = enqueue('webbuilder.rebuild', {'project_id': project_id, 'prompt': data.get('prompt')})
+    return jsonify(accepted_payload(job)), 202
 
 
 @app.route('/api/webbuilder/projects/<project_id>/republish-preview', methods=['POST'])
@@ -3038,15 +3067,6 @@ def launch_review_action(draft_id):
         result = approve_and_post(draft_id)
         return jsonify(result)
     return jsonify({'ok': False, 'error': 'invalid_action'}), 400
-
-
-@app.route('/.well-known/agent.json')
-def agent_card():
-    """A2A-style agent card for SINCOR swarm discovery."""
-    path = os.path.join(static_dir, '.well-known', 'agent.json')
-    if not os.path.isfile(path):
-        return jsonify({'error': 'agent card not found'}), 404
-    return send_file(path, mimetype='application/json')
 
 
 @app.route('/media-packs')
@@ -3562,7 +3582,7 @@ def content_status():
 @app.route('/admin/content/generate', methods=['POST'])
 @limiter.limit("10 per minute")
 def content_generate():
-    """Manually trigger post generation. Body: {keyword, type, publish}"""
+    """Manually trigger post generation. Returns 202 + task_id; poll /api/tasks/<id>."""
     if not _check_admin_token(request):
         return jsonify({'error': 'Admin access required'}), 403
     try:
@@ -3576,19 +3596,15 @@ def content_generate():
         if ctype not in ('how-to', 'comparison', 'alternatives', 'case-study', 'industry-trend'):
             return jsonify({'error': 'invalid type'}), 400
 
-        from sincor2.content_agent import generate_blog_post, save_post, WordPressPublisher, init_db
-        init_db()
-        model = os.environ.get('CONTENT_MODEL', 'claude-haiku-4-5')
-        post = generate_blog_post(keyword, ctype, model=model)
-        path = save_post(post)
-        result = {"title": post["title"], "slug": post["slug"], "word_count": post["word_count"], "path": str(path)}
+        from sincor2.task_queue import accepted_payload, enqueue
 
-        if do_publish:
-            wp = WordPressPublisher()
-            wp_result = wp.publish(post)
-            result["wordpress"] = wp_result
-
-        return jsonify(result)
+        job = enqueue('content.generate', {
+            'keyword': keyword,
+            'ctype': ctype,
+            'do_publish': bool(do_publish),
+            'model': os.environ.get('CONTENT_MODEL', 'claude-haiku-4-5'),
+        })
+        return jsonify(accepted_payload(job)), 202
     except Exception as e:
         logger.error(f"[CONTENT] Generate error: {e}")
         return jsonify({"error": str(e)}), 500

--- a/src/sincor2/task_queue.py
+++ b/src/sincor2/task_queue.py
@@ -1,0 +1,377 @@
+"""
+SINCOR async job queue.
+
+Long-running Flask work (A2A dispatch, content generation, webbuilder)
+must not run on the gunicorn sync worker — timeout is 180s and a blocked
+worker 504s the whole site.
+
+Backends (auto-selected, override with SINCOR_TASK_QUEUE):
+  eager   FLASK_ENV=test — run inline so existing pytest still settles
+  celery  REDIS_URL/CELERY_BROKER_URL reachable and celery importable
+  thread  in-process ThreadPoolExecutor (unsticks gunicorn without Redis)
+
+HTTP contract: enqueue() returns immediately with a Job. Callers respond
+202 Accepted + task_id; clients poll GET /api/tasks/<id>.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger("sincor.queue")
+
+QUEUED = "queued"
+RUNNING = "running"
+COMPLETED = "completed"
+FAILED = "failed"
+CANCELED = "canceled"
+
+_TERMINAL = frozenset({COMPLETED, FAILED, CANCELED})
+
+Handler = Callable[[Dict[str, Any], str], Any]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _env_queue() -> str:
+    return (os.getenv("SINCOR_TASK_QUEUE") or "").strip().lower()
+
+
+def is_test_env() -> bool:
+    env = (os.getenv("FLASK_ENV") or os.getenv("ENVIRONMENT") or "").lower()
+    return env in ("test", "testing")
+
+
+def is_eager() -> bool:
+    forced = _env_queue()
+    if forced == "eager":
+        return True
+    if forced in ("celery", "thread"):
+        return False
+    return is_test_env()
+
+
+def _celery_configured() -> bool:
+    return bool(
+        (os.getenv("CELERY_BROKER_URL") or os.getenv("REDIS_URL") or os.getenv("REDIS_PRIVATE_URL") or "").strip()
+    )
+
+
+def detect_backend() -> str:
+    forced = _env_queue()
+    if forced in ("eager", "celery", "thread"):
+        if forced == "celery" and not _celery_configured():
+            logger.warning("SINCOR_TASK_QUEUE=celery but no broker URL; falling back to thread")
+            return "thread"
+        return forced
+    if is_eager():
+        return "eager"
+    if _celery_configured():
+        try:
+            from sincor2.celery_app import ping_broker
+
+            if ping_broker():
+                return "celery"
+            logger.warning("Celery broker configured but unreachable; using thread pool")
+        except Exception as exc:
+            logger.warning("Celery unavailable (%s); using thread pool", exc)
+    return "thread"
+
+
+@dataclass
+class Job:
+    id: str
+    kind: str
+    state: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    result: Any = None
+    error: Optional[str] = None
+    progress: int = 0
+    created_at: str = ""
+    updated_at: str = ""
+    celery_id: Optional[str] = None
+
+    def to_public_dict(self) -> Dict[str, Any]:
+        return {
+            "task_id": self.id,
+            "kind": self.kind,
+            "status": self.state,
+            "progress": self.progress,
+            "result": self.result,
+            "error": self.error,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "poll_url": f"/api/tasks/{self.id}",
+        }
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Job":
+        known = {k: data.get(k) for k in (
+            "id", "kind", "state", "payload", "result", "error",
+            "progress", "created_at", "updated_at", "celery_id",
+        )}
+        known.setdefault("payload", {})
+        known.setdefault("progress", 0)
+        return cls(**known)  # type: ignore[arg-type]
+
+
+class _MemoryJobStore:
+    def __init__(self) -> None:
+        self._jobs: Dict[str, Dict[str, Any]] = {}
+        self._order: List[str] = []
+        self._lock = threading.Lock()
+
+    def put(self, job: Job) -> None:
+        with self._lock:
+            if job.id not in self._jobs:
+                self._order.append(job.id)
+            self._jobs[job.id] = job.to_dict()
+
+    def get(self, job_id: str) -> Optional[Job]:
+        with self._lock:
+            raw = self._jobs.get(job_id)
+        return Job.from_dict(raw) if raw else None
+
+    def list_recent(self, limit: int = 50) -> List[Job]:
+        with self._lock:
+            ids = list(reversed(self._order[-limit:]))
+            rows = [self._jobs[i] for i in ids if i in self._jobs]
+        return [Job.from_dict(r) for r in rows]
+
+
+class _RedisJobStore:
+    def __init__(self, url: str) -> None:
+        import redis
+
+        self._r = redis.Redis.from_url(url, decode_responses=True)
+        self._ttl = int(os.getenv("SINCOR_JOB_TTL_SECONDS", "86400"))
+
+    def put(self, job: Job) -> None:
+        pipe = self._r.pipeline()
+        pipe.set(f"sincor:job:{job.id}", json.dumps(job.to_dict()), ex=self._ttl)
+        pipe.lpush("sincor:jobs", job.id)
+        pipe.ltrim("sincor:jobs", 0, 499)
+        pipe.execute()
+
+    def get(self, job_id: str) -> Optional[Job]:
+        raw = self._r.get(f"sincor:job:{job_id}")
+        if not raw:
+            return None
+        return Job.from_dict(json.loads(raw))
+
+    def list_recent(self, limit: int = 50) -> List[Job]:
+        ids = self._r.lrange("sincor:jobs", 0, limit - 1)
+        jobs: List[Job] = []
+        for jid in ids:
+            job = self.get(jid)
+            if job:
+                jobs.append(job)
+        return jobs
+
+
+_store_lock = threading.Lock()
+_store: Any = None
+_handlers: Dict[str, Handler] = {}
+_pool: Optional[ThreadPoolExecutor] = None
+_backend_cached: Optional[str] = None
+
+
+def _job_store():
+    global _store
+    if _store is not None:
+        return _store
+    with _store_lock:
+        if _store is not None:
+            return _store
+        url = (os.getenv("REDIS_URL") or os.getenv("REDIS_PRIVATE_URL") or "").strip()
+        if url:
+            try:
+                _store = _RedisJobStore(url)
+                _store.get("__probe__")
+                logger.info("Job store: redis")
+                return _store
+            except Exception as exc:
+                logger.warning("Redis job store unavailable (%s); using memory", exc)
+        _store = _MemoryJobStore()
+        logger.info("Job store: memory")
+        return _store
+
+
+def _thread_pool() -> ThreadPoolExecutor:
+    global _pool
+    if _pool is None:
+        workers = int(os.getenv("SINCOR_QUEUE_WORKERS", "4"))
+        _pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="sincor-q")
+    return _pool
+
+
+def register_handler(kind: str, fn: Handler) -> None:
+    _handlers[kind] = fn
+
+
+def get_handler(kind: str) -> Optional[Handler]:
+    if kind in _handlers:
+        return _handlers[kind]
+    try:
+        import sincor2.async_tasks  # noqa: F401 — registers handlers on import
+    except Exception as exc:
+        logger.debug("async_tasks import skipped: %s", exc)
+    return _handlers.get(kind)
+
+
+def current_backend() -> str:
+    global _backend_cached
+    if _backend_cached is None:
+        _backend_cached = detect_backend()
+    return _backend_cached
+
+
+def reset_backend_cache() -> None:
+    global _backend_cached
+    _backend_cached = None
+
+
+def put_job(job: Job) -> None:
+    job.updated_at = _now()
+    _job_store().put(job)
+
+
+def get_job(job_id: str) -> Optional[Job]:
+    return _job_store().get(job_id)
+
+
+def list_jobs(limit: int = 50) -> List[Job]:
+    return _job_store().list_recent(limit)
+
+
+def update_job(job_id: str, **fields: Any) -> Optional[Job]:
+    job = get_job(job_id)
+    if not job:
+        return None
+    for key, value in fields.items():
+        setattr(job, key, value)
+    put_job(job)
+    return job
+
+
+def run_job(job_id: str) -> Job:
+    """Execute a queued job. Called by Celery workers and the thread pool."""
+    job = get_job(job_id)
+    if not job:
+        raise RuntimeError(f"job {job_id} not found")
+    if job.state in _TERMINAL:
+        return job
+    update_job(job_id, state=RUNNING, progress=5)
+    handler = get_handler(job.kind)
+    if handler is None:
+        update_job(job_id, state=FAILED, error=f"no handler for kind '{job.kind}'")
+        raise RuntimeError(f"no handler for kind '{job.kind}'")
+    try:
+        result = handler(job.payload or {}, job_id)
+        updated = update_job(job_id, state=COMPLETED, result=result, progress=100, error=None)
+        return updated or job
+    except Exception as exc:
+        logger.exception("Job %s (%s) failed", job_id, job.kind)
+        update_job(job_id, state=FAILED, error=str(exc), progress=100)
+        raise
+
+
+def enqueue(kind: str, payload: Optional[Dict[str, Any]] = None, *, job_id: Optional[str] = None) -> Job:
+    """
+    Accept a job and return immediately (except eager/test).
+
+    Never blocks the gunicorn worker on the real work.
+    """
+    job = Job(
+        id=job_id or str(uuid.uuid4()),
+        kind=kind,
+        state=QUEUED,
+        payload=payload or {},
+        created_at=_now(),
+        updated_at=_now(),
+    )
+    put_job(job)
+    backend = current_backend()
+    logger.info("Enqueue %s kind=%s backend=%s", job.id, kind, backend)
+
+    if backend == "eager":
+        run_job(job.id)
+        return get_job(job.id) or job
+
+    if backend == "celery":
+        try:
+            from sincor2.async_tasks import execute_job
+
+            async_result = execute_job.delay(job.id)
+            update_job(job.id, celery_id=async_result.id)
+            return get_job(job.id) or job
+        except Exception as exc:
+            logger.warning("Celery delay failed (%s); falling back to thread", exc)
+
+    _thread_pool().submit(_safe_run, job.id)
+    return job
+
+
+def _safe_run(job_id: str) -> None:
+    try:
+        run_job(job_id)
+    except Exception:
+        pass
+
+
+def accepted_payload(job: Job) -> Dict[str, Any]:
+    body = job.to_public_dict()
+    body["accepted"] = True
+    return body
+
+
+def queue_health() -> Dict[str, Any]:
+    backend = current_backend()
+    detail = backend
+    redis_url = bool((os.getenv("REDIS_URL") or os.getenv("REDIS_PRIVATE_URL") or "").strip())
+    return {
+        "backend": backend,
+        "eager": backend == "eager",
+        "redis": redis_url,
+        "handlers": sorted(_handlers.keys()),
+        "detail": detail,
+    }
+
+
+def register_flask_routes(app: Any) -> None:
+    """Attach GET /api/tasks and GET /api/tasks/<id> onto a Flask app."""
+
+    @app.route("/api/tasks", methods=["GET"])
+    def _list_queue_jobs():
+        from flask import jsonify, request
+
+        try:
+            limit = min(int(request.args.get("limit") or 50), 200)
+        except (TypeError, ValueError):
+            limit = 50
+        return jsonify({
+            "backend": current_backend(),
+            "tasks": [j.to_public_dict() for j in list_jobs(limit)],
+        })
+
+    @app.route("/api/tasks/<job_id>", methods=["GET"])
+    def _get_queue_job(job_id: str):
+        from flask import jsonify
+
+        job = get_job(job_id)
+        if not job:
+            return jsonify({"error": "not_found", "task_id": job_id}), 404
+        return jsonify(job.to_public_dict())

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -3,6 +3,7 @@ import os
 # Set test env before any sincor2 modules import (app.py calls create_app at import time).
 os.environ.setdefault("FLASK_ENV", "test")
 os.environ.setdefault("ENVIRONMENT", "test")
+os.environ.setdefault("SINCOR_TASK_QUEUE", "eager")
 os.environ.setdefault("SECRET_KEY", "test-secret-key-with-32-char-minimum-ok")
 os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret-key-32-char-minimum-ok")
 os.environ.setdefault("ADMIN_USERNAME", "admin")
@@ -27,6 +28,7 @@ class MockStripeCheckout:
 def env_defaults(monkeypatch):
     monkeypatch.setenv("FLASK_ENV", "test")
     monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("SINCOR_TASK_QUEUE", "eager")
     monkeypatch.setenv("SECRET_KEY", "test-secret-key-with-32-char-minimum-ok")
     monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-32-char-minimum-ok")
     monkeypatch.setenv("ADMIN_USERNAME", "admin")

--- a/tests/pytest/test_a2a_streaming.py
+++ b/tests/pytest/test_a2a_streaming.py
@@ -1,0 +1,135 @@
+"""Real A2A message/stream SSE — token chunks, not a single dumped blob."""
+from __future__ import annotations
+
+import json
+
+
+def _sse_payloads(response) -> list:
+    text = response.get_data(as_text=True)
+    events = []
+    for line in text.splitlines():
+        if line.startswith("data: "):
+            events.append(json.loads(line[6:]))
+    return events
+
+
+def test_stream_is_event_stream(client):
+    resp = client.post(
+        "/api/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "message/stream",
+            "params": {
+                "skillId": "lead-enrichment",
+                "callerId": "stream-caller",
+                "message": {
+                    "role": "user",
+                    "parts": [{"text": "Stream this enrichment for Acme"}],
+                },
+            },
+        },
+    )
+    assert resp.status_code == 200
+    assert "text/event-stream" in (resp.mimetype or resp.content_type)
+
+
+def test_stream_emits_status_then_token_chunks(client):
+    resp = client.post(
+        "/api/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "stream-1",
+            "method": "message/stream",
+            "params": {
+                "skillId": "content-blog",
+                "callerId": "stream-caller-2",
+                "message": {
+                    "role": "user",
+                    "parts": [{"text": "Write a short outline about CRM sync automation for sales ops teams"}],
+                },
+            },
+        },
+    )
+    events = _sse_payloads(resp)
+    assert len(events) >= 4
+
+    kinds = []
+    for ev in events:
+        result = ev.get("result") or {}
+        kinds.append(result.get("kind") or "")
+
+    assert "status-update" in kinds
+    assert "artifact-update" in kinds
+
+    statuses = [
+        (ev.get("result") or {}).get("status", {}).get("state")
+        or (ev.get("result") or {}).get("taskStatus", {}).get("status", {}).get("state")
+        for ev in events
+        if (ev.get("result") or {}).get("kind") == "status-update"
+        or (ev.get("result") or {}).get("taskStatus")
+    ]
+    assert "submitted" in statuses
+    assert "working" in statuses
+    assert "completed" in statuses
+
+    artifacts = [
+        ev for ev in events
+        if (ev.get("result") or {}).get("kind") == "artifact-update"
+        or (ev.get("result") or {}).get("taskArtifact")
+    ]
+    # Must be more than a single blob — that's the whole bug.
+    token_events = [a for a in artifacts if not (a.get("result") or {}).get("lastChunk")]
+    if not token_events:
+        token_events = [
+            a for a in artifacts
+            if not ((a.get("result") or {}).get("taskArtifact") or {}).get("lastChunk")
+        ]
+    assert len(token_events) >= 2, f"expected token chunks, got {len(token_events)}: {artifacts!r}"
+
+    last = artifacts[-1].get("result") or {}
+    assert last.get("lastChunk") is True or (last.get("taskArtifact") or {}).get("lastChunk") is True
+
+    finals = [
+        (ev.get("result") or {}).get("final")
+        or ((ev.get("result") or {}).get("taskStatus") or {}).get("final")
+        for ev in events
+    ]
+    assert True in finals
+
+
+def test_stream_error_on_empty_input(client):
+    resp = client.post(
+        "/api/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "message/stream",
+            "params": {
+                "skillId": "lead-enrichment",
+                "message": {"role": "user", "parts": [{"text": ""}]},
+            },
+        },
+    )
+    events = _sse_payloads(resp)
+    assert events
+    assert "error" in events[0]
+
+
+def test_dispatch_stream_chunks_stub(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    from sincor2.a2a_integration import A2ATask, TaskState, _dispatch_to_swarm_stream, _now
+
+    task = A2ATask(
+        id="t-stream",
+        context_id="c-stream",
+        skill_id="lead-enrichment",
+        input_text="Hello from the streaming unit test — please chunk this generously.",
+        caller_id="unit",
+        state=TaskState.WORKING,
+        created_at=_now(),
+        updated_at=_now(),
+    )
+    pieces = list(_dispatch_to_swarm_stream(task))
+    assert len(pieces) >= 2
+    assert any("lead-enrichment" in p or "SINCOR" in p or "Hello" in p for p in pieces)

--- a/tests/pytest/test_async_queue.py
+++ b/tests/pytest/test_async_queue.py
@@ -1,0 +1,148 @@
+"""Async task queue — 202 + poll, eager/thread backends, no Redis required."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def queue_mod(monkeypatch):
+    monkeypatch.setenv("SINCOR_TASK_QUEUE", "eager")
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("CELERY_BROKER_URL", raising=False)
+    from sincor2 import task_queue
+
+    task_queue.reset_backend_cache()
+    yield task_queue
+    task_queue.reset_backend_cache()
+
+
+def test_eager_enqueue_runs_inline(queue_mod):
+    def handler(payload, job_id):
+        return {"echo": payload.get("n"), "job": job_id}
+
+    queue_mod.register_handler("test.echo", handler)
+    job = queue_mod.enqueue("test.echo", {"n": 7})
+    assert job.state == queue_mod.COMPLETED
+    assert job.result["echo"] == 7
+    assert job.result["job"] == job.id
+
+
+def test_thread_enqueue_returns_before_finish(queue_mod, monkeypatch):
+    import threading
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def handler(payload, job_id):
+        started.set()
+        release.wait(timeout=2)
+        return {"ok": True}
+
+    monkeypatch.setenv("SINCOR_TASK_QUEUE", "thread")
+    queue_mod.reset_backend_cache()
+    queue_mod.register_handler("test.block", handler)
+    job = queue_mod.enqueue("test.block", {})
+    assert job.state in (queue_mod.QUEUED, queue_mod.RUNNING)
+    assert started.wait(timeout=2)
+    still = queue_mod.get_job(job.id)
+    assert still.state == queue_mod.RUNNING
+    release.set()
+    for _ in range(50):
+        done = queue_mod.get_job(job.id)
+        if done and done.state == queue_mod.COMPLETED:
+            break
+        import time
+        time.sleep(0.02)
+    assert queue_mod.get_job(job.id).state == queue_mod.COMPLETED
+
+
+def test_accepted_payload_shape(queue_mod):
+    queue_mod.register_handler("test.noop", lambda p, j: {"ok": True})
+    job = queue_mod.enqueue("test.noop", {})
+    body = queue_mod.accepted_payload(job)
+    assert body["accepted"] is True
+    assert body["task_id"] == job.id
+    assert body["poll_url"] == f"/api/tasks/{job.id}"
+    assert body["status"] in (queue_mod.COMPLETED, queue_mod.QUEUED, queue_mod.RUNNING)
+
+
+def test_poll_routes(client, queue_mod):
+    queue_mod.register_handler("test.poll", lambda p, j: {"v": 1})
+    job = queue_mod.enqueue("test.poll", {})
+    resp = client.get(f"/api/tasks/{job.id}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["task_id"] == job.id
+    assert data["status"] == "completed"
+    assert data["result"]["v"] == 1
+
+    missing = client.get("/api/tasks/does-not-exist")
+    assert missing.status_code == 404
+
+
+def test_rest_a2a_send_returns_202(client):
+    resp = client.post(
+        "/api/a2a/tasks/send",
+        json={
+            "method": "message/send",
+            "params": {
+                "skillId": "lead-enrichment",
+                "callerId": "queue-test-caller",
+                "message": {
+                    "role": "user",
+                    "parts": [{"text": "Enrich Globex"}],
+                },
+            },
+        },
+    )
+    assert resp.status_code == 202
+    data = resp.get_json()
+    assert data.get("accepted") is True
+    assert data.get("task_id")
+    task = data.get("result") or {}
+    assert task.get("id") == data["task_id"]
+    # Eager test env still settles the A2A task before return.
+    state = (task.get("status") or {}).get("state")
+    assert state in ("completed", "working", "submitted")
+
+
+def test_jsonrpc_send_stays_http_200(client):
+    resp = client.post(
+        "/api/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "message/send",
+            "params": {
+                "skillId": "lead-enrichment",
+                "callerId": "queue-jsonrpc-caller",
+                "message": {"role": "user", "parts": [{"text": "ping"}]},
+            },
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body.get("result", {}).get("id")
+
+
+def test_chunk_text_yields_multiple_pieces():
+    from sincor2.llm_stream import chunk_text
+
+    text = "alpha bravo charlie delta echo foxtrot golf hotel india"
+    pieces = list(chunk_text(text, size=12))
+    assert len(pieces) >= 3
+    assert " ".join(pieces) == text
+
+
+def test_claude_client_exposes_stream_sync():
+    from sincor2.cortecs_core import ClaudeClient
+
+    assert hasattr(ClaudeClient, "stream_sync")
+
+
+def test_queue_health_reports_backend(queue_mod):
+    health = queue_mod.queue_health()
+    assert health["backend"] in ("eager", "thread", "celery")
+    assert "handlers" in health


### PR DESCRIPTION
## Why

Gunicorn runs a single **sync** worker with a **180s timeout**. A2A dispatch, content generation, and webbuilder phases ran on the request thread — they blocked the worker and 504'd the site. `message/stream` waited for a full swarm string and dumped one artifact blob, so A2A clients never saw tokens.

## What

- Celery + Redis queue (`sincor2.task_queue`) with a **thread-pool fallback** when Redis is down, and **eager** mode in `FLASK_ENV=test` so existing settlement tests still complete inline.
- Long endpoints return **202 Accepted** + `task_id`; poll `GET /api/tasks/<id>`.
  - `POST /api/a2a/tasks/send`
  - `POST /admin/content/generate`
  - `POST /api/webbuilder/projects/<id>/run|rebuild`
- JSON-RPC `message/send` stays HTTP 200 (spec) but **enqueues** instead of blocking.
- Real SSE for `message/stream`: `status-update` submitted → working → `artifact-update` chunks (`append` / `lastChunk`) from Anthropic `client.messages.stream()` / `text_stream`, then `completed` `final=true`. Streaming stays on the HTTP socket on purpose.
- Register **A2ARouter on `mvp_app`** (production gunicorn entry) and drop the static `/.well-known/agent.json` handler so discovery is live.
- Procfile `worker`, docker-compose Redis + worker, health check `task_queue` backend.

## Deploy

1. Set `REDIS_URL` and `A2A_TASK_STORE=redis`.
2. Add a Railway worker service: `celery -A sincor2.celery_app.celery worker --loglevel=info -Q sincor.long`.
3. Without Redis, the thread pool still returns 202 (keep `workers = 1`).

See `docs/ASYNC_TASK_QUEUE.md`.

## Tests

- `tests/pytest/test_async_queue.py`
- `tests/pytest/test_a2a_streaming.py`