### PR TITLE
Contract-Net Vickrey market (cosine invite, sealed second-price, ε-greedy juniors)

### DIFF
--- a/docs/architecture/contract_net.md
+++ b/docs/architecture/contract_net.md
@@ -1,0 +1,63 @@
+# Contract-Net Task Market
+
+Additive market path beside the existing first-price `BiddingEngine.run_auction`.
+Nothing in this package mutates the first-price scoring weights, TaskMarket
+award loop, or `/api/marketplace` routes.
+
+## Why
+
+Broadcasting every task to the full swarm and asking each agent to draft an LLM
+bid burns tokens before work starts. Incumbents then win every first-price
+round, so juniors never build merit.
+
+## Mechanism
+
+1. **Phase 1 — cosine invite.** Task requirements and agent skills are hashed
+   into 64-d Keccak bag-of-tokens vectors. Only the top `invite_k` (3–5)
+   agents are invited. Tokens saved = `(n − k) × 800`.
+2. **Phase 2 — sealed Vickrey reverse auction.** Invited agents submit one
+   EIP-712 signed bid. Lowest valid price wins and is paid the second-lowest
+   valid price. No counter-bids. Dominant strategy is to bid true minimum
+   margin.
+3. **ε-greedy junior reservation.** `epsilon ∈ [0.10, 0.15]` (default 0.12)
+   of auctions invite **only** juniors (`is_junior` or `tasks_completed < 3`).
+   Those invites carry a 2× eval-token subsidy. If the junior pool is empty
+   the auction falls back to the full ranking so the market never stalls.
+
+## EIP-712 domain (Base)
+
+| Field | Value |
+| --- | --- |
+| name | `SINCOR Contract-Net` |
+| version | `1` |
+| chainId | `8453` |
+| verifyingContract | `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac` (treasury) |
+
+Primary type `Bid`: `auctionId bytes32`, `taskId string`, `agent address`,
+`price uint256` (micro-AXM), `estimatedTokens uint256`, `nonce uint256`,
+`deadline uint256`.
+
+Signatures: secp256k1 via `eth_account` when a key is present, otherwise
+HMAC-SHA256 over the typed-data digest (demo roster).
+
+## API
+
+Prefix `/api/contract-net`.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/health` | Domain + k + ε |
+| GET | `/roster` | Demo swarm |
+| GET | `/tasks` | Demo task board |
+| GET | `/stats` | Aggregate junior share / tokens saved |
+| GET | `/history` | Recent awards |
+| POST | `/auctions` | One sealed round |
+| POST | `/simulate` | Batch rounds |
+
+## Integration
+
+- `marketplace.contract_net.ContractNetEngine` is the library.
+- `BiddingEngine.run_vickrey_auction` is a thin additive wrapper; `run_auction`
+  is unchanged.
+- Flask registers `contract_net_bp` inside `create_app()` in a try/except so a
+  missing module cannot take down the rest of the app.

--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -6,6 +6,22 @@ Transition scaffolding for A2A marketplace mechanics.
 - Agent Card discoverability surfaces
 - Capability indexing, matching, and ranking
 - Marketplace policy and trust/reputation logic
+- Contract-Net Vickrey path (`marketplace/contract_net`) — cosine invite,
+  sealed second-price auctions, ε-greedy junior reservation
+
+## Contract-Net (additive)
+
+The first-price scoring engine in `src/sincor2/bidding_engine.py` is unchanged.
+New work goes through `ContractNetEngine`:
+
+1. Hash skill/requirement tokens into 64-d vectors and invite only the top 3–5
+   cosine matches. Uninvited agents never draft an LLM bid.
+2. Invited agents submit one EIP-712 sealed bid. Lowest price wins and is paid
+   the second price (Vickrey reverse auction).
+3. 10–15% of auctions (`epsilon=0.12`) are reserved for junior / newly spawned
+   agents with a 2× eval-token subsidy.
+
+HTTP: `/api/contract-net/*`. Design notes: `docs/architecture/contract_net.md`.
 
 ## Transition role
 This domain expands interoperability and service discovery so more agents can transact with higher confidence and lower integration friction.

--- a/marketplace/__init__.py
+++ b/marketplace/__init__.py
@@ -4,11 +4,14 @@ from .discovery import CapabilityMatcher, DiscoveryIndex
 from .registry import AgentCardRecord, AgentCardRegistry
 from .reputation import ReputationEngine
 from .settlement import SettlementCoordinator, SettlementQuote, SettlementRecord
+from .contract_net import ContractNetConfig, ContractNetEngine
 
 __all__ = [
     'AgentCardRecord',
     'AgentCardRegistry',
     'CapabilityMatcher',
+    'ContractNetConfig',
+    'ContractNetEngine',
     'DiscoveryIndex',
     'ReputationEngine',
     'SettlementCoordinator',

--- a/marketplace/contract_net/__init__.py
+++ b/marketplace/contract_net/__init__.py
@@ -1,0 +1,40 @@
+"""Contract-Net task market: cosine invite, Vickrey sealed bids, ε-greedy juniors."""
+
+from .engine import ContractNetEngine, make_auction_id, profiles_from_dicts, task_from_dict
+from .filter import filter_swarm, score_agents
+from .keccak import keccak256, keccak256_hex
+from .roster import demo_roster, demo_tasks
+from .types import (
+    AgentProfile,
+    Award,
+    ContractNetConfig,
+    FilterResult,
+    Invite,
+    SealedBid,
+    TaskSpec,
+)
+from .vickrey import clear_vickrey
+from .vectors import cosine_similarity, embed_tokens
+
+__all__ = [
+    "AgentProfile",
+    "Award",
+    "ContractNetConfig",
+    "ContractNetEngine",
+    "FilterResult",
+    "Invite",
+    "SealedBid",
+    "TaskSpec",
+    "clear_vickrey",
+    "cosine_similarity",
+    "demo_roster",
+    "demo_tasks",
+    "embed_tokens",
+    "filter_swarm",
+    "keccak256",
+    "keccak256_hex",
+    "make_auction_id",
+    "profiles_from_dicts",
+    "score_agents",
+    "task_from_dict",
+]

--- a/marketplace/contract_net/eip712.py
+++ b/marketplace/contract_net/eip712.py
@@ -1,0 +1,289 @@
+"""EIP-712 typed Bid payloads with secp256k1 or HMAC-SHA256 signatures.
+
+The digest is the canonical Ethereum typed-data hash:
+
+    keccak256("\\x19\\x01" || domainSeparator || structHash)
+
+``eth_account`` signs that digest when a secp256k1 key is present. The HMAC
+path is a portable fallback used by the demo roster and environments that
+cannot load ``eth_account``. Both schemes bind the same digest, so a bid
+cannot be replayed across auctions or domains.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from typing import Any, Dict, Optional, Tuple
+
+from .keccak import keccak256
+from .types import ContractNetConfig, SigType
+
+EIP712_DOMAIN_TYPE = (
+    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+)
+BID_TYPE = (
+    "Bid(bytes32 auctionId,string taskId,address agent,"
+    "uint256 price,uint256 estimatedTokens,uint256 nonce,uint256 deadline)"
+)
+
+EIP712_DOMAIN_TYPEHASH = keccak256(EIP712_DOMAIN_TYPE.encode("ascii"))
+BID_TYPEHASH = keccak256(BID_TYPE.encode("ascii"))
+
+
+def _strip0x(value: str) -> str:
+    value = value.strip()
+    if value.startswith(("0x", "0X")):
+        return value[2:]
+    return value
+
+
+def to_hex(data: bytes) -> str:
+    return "0x" + data.hex()
+
+
+def encode_uint256(value: int) -> bytes:
+    if value < 0 or value >= 1 << 256:
+        raise ValueError("uint256 out of range")
+    return int(value).to_bytes(32, "big")
+
+
+def encode_address(addr: str) -> bytes:
+    raw = _strip0x(addr)
+    if len(raw) != 40:
+        raise ValueError(f"address must be 20 bytes, got {addr!r}")
+    try:
+        body = bytes.fromhex(raw)
+    except ValueError as exc:
+        raise ValueError(f"invalid address {addr!r}") from exc
+    return body.rjust(32, b"\x00")
+
+
+def encode_bytes32(value: str | bytes) -> bytes:
+    if isinstance(value, bytes):
+        raw = value
+    else:
+        raw = bytes.fromhex(_strip0x(value))
+    if len(raw) != 32:
+        raise ValueError("bytes32 must be 32 bytes")
+    return raw
+
+
+def checksum_address(addr: str) -> str:
+    """EIP-55 checksum."""
+    hex_addr = _strip0x(addr).lower()
+    if len(hex_addr) != 40:
+        raise ValueError("address must be 20 bytes")
+    hashed = keccak256(hex_addr.encode("ascii")).hex()
+    out = ["0x"]
+    for i, ch in enumerate(hex_addr):
+        if ch.isalpha() and int(hashed[i], 16) >= 8:
+            out.append(ch.upper())
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+
+def demo_wallet(agent_id: str) -> str:
+    digest = keccak256(b"sincor-cn/" + agent_id.encode("utf-8"))
+    return checksum_address("0x" + digest[:20].hex())
+
+
+def demo_signing_secret(agent_id: str) -> str:
+    return keccak256(b"sincor-cn-key/" + agent_id.encode("utf-8")).hex()
+
+
+def domain_separator(config: ContractNetConfig) -> bytes:
+    return keccak256(
+        EIP712_DOMAIN_TYPEHASH
+        + keccak256(config.domain_name.encode("utf-8"))
+        + keccak256(config.domain_version.encode("utf-8"))
+        + encode_uint256(config.chain_id)
+        + encode_address(config.verifying_contract)
+    )
+
+
+def struct_hash(
+    *,
+    auction_id: str,
+    task_id: str,
+    agent: str,
+    price: int,
+    estimated_tokens: int,
+    nonce: int,
+    deadline: int,
+) -> bytes:
+    return keccak256(
+        BID_TYPEHASH
+        + encode_bytes32(auction_id)
+        + keccak256(task_id.encode("utf-8"))
+        + encode_address(agent)
+        + encode_uint256(price)
+        + encode_uint256(estimated_tokens)
+        + encode_uint256(nonce)
+        + encode_uint256(deadline)
+    )
+
+
+def typed_data_digest(
+    config: ContractNetConfig,
+    *,
+    auction_id: str,
+    task_id: str,
+    agent: str,
+    price: int,
+    estimated_tokens: int,
+    nonce: int,
+    deadline: int,
+) -> bytes:
+    return keccak256(
+        b"\x19\x01"
+        + domain_separator(config)
+        + struct_hash(
+            auction_id=auction_id,
+            task_id=task_id,
+            agent=agent,
+            price=price,
+            estimated_tokens=estimated_tokens,
+            nonce=nonce,
+            deadline=deadline,
+        )
+    )
+
+
+def typed_data_payload(
+    config: ContractNetConfig,
+    *,
+    auction_id: str,
+    task_id: str,
+    agent: str,
+    price: int,
+    estimated_tokens: int,
+    nonce: int,
+    deadline: int,
+) -> Dict[str, Any]:
+    return {
+        "types": {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+            "Bid": [
+                {"name": "auctionId", "type": "bytes32"},
+                {"name": "taskId", "type": "string"},
+                {"name": "agent", "type": "address"},
+                {"name": "price", "type": "uint256"},
+                {"name": "estimatedTokens", "type": "uint256"},
+                {"name": "nonce", "type": "uint256"},
+                {"name": "deadline", "type": "uint256"},
+            ],
+        },
+        "primaryType": "Bid",
+        "domain": {
+            "name": config.domain_name,
+            "version": config.domain_version,
+            "chainId": config.chain_id,
+            "verifyingContract": config.verifying_contract,
+        },
+        "message": {
+            "auctionId": auction_id if auction_id.startswith("0x") else "0x" + auction_id,
+            "taskId": task_id,
+            "agent": agent,
+            "price": str(price),
+            "estimatedTokens": str(estimated_tokens),
+            "nonce": str(nonce),
+            "deadline": str(deadline),
+        },
+    }
+
+
+def _secret_bytes(secret: str) -> bytes:
+    raw = _strip0x(secret)
+    try:
+        if len(raw) % 2 == 0 and raw:
+            return bytes.fromhex(raw)
+    except ValueError:
+        pass
+    return keccak256(secret.encode("utf-8"))
+
+
+def sign_hmac(digest: bytes, secret: str) -> str:
+    mac = hmac.new(_secret_bytes(secret), digest, hashlib.sha256).digest()
+    return to_hex(mac)
+
+
+def verify_hmac(digest: bytes, signature: str, secret: str) -> bool:
+    expected = bytes.fromhex(_strip0x(sign_hmac(digest, secret)))
+    got = bytes.fromhex(_strip0x(signature))
+    if len(expected) != len(got):
+        return False
+    return hmac.compare_digest(expected, got)
+
+
+def _sign_secp256k1(digest: bytes, private_key: str) -> Optional[str]:
+    try:
+        from eth_account import Account
+    except Exception:
+        return None
+    key = private_key if private_key.startswith("0x") else "0x" + private_key
+    try:
+        signed = Account.from_key(key).unsafe_sign_hash(digest)
+    except Exception:
+        return None
+    sig = signed.signature.hex()
+    return sig if sig.startswith("0x") else "0x" + sig
+
+
+def _recover_secp256k1(digest: bytes, signature: str) -> Optional[str]:
+    try:
+        from eth_account import Account
+    except Exception:
+        return None
+    try:
+        recovered = Account._recover_hash(digest, signature=signature)  # noqa: SLF001
+    except Exception:
+        try:
+            recovered = Account.recover_message  # type: ignore[attr-defined]
+            recovered = Account._recover_hash(digest, signature=signature)  # noqa: SLF001
+        except Exception:
+            return None
+    return recovered
+
+
+def sign_digest(
+    digest: bytes,
+    *,
+    private_key: str = "",
+    signing_secret: str = "",
+) -> Tuple[str, str]:
+    """Return (signature, sig_type). Prefers secp256k1 when a key is usable."""
+    if private_key:
+        sig = _sign_secp256k1(digest, private_key)
+        if sig:
+            return sig, SigType.SECP256K1.value
+    if not signing_secret:
+        raise ValueError("signing_secret required when secp256k1 is unavailable")
+    return sign_hmac(digest, signing_secret), SigType.HMAC.value
+
+
+def verify_digest(
+    digest: bytes,
+    signature: str,
+    *,
+    sig_type: str,
+    expected_address: str = "",
+    signing_secret: str = "",
+) -> bool:
+    if sig_type == SigType.SECP256K1.value:
+        recovered = _recover_secp256k1(digest, signature)
+        if recovered is None:
+            return False
+        return recovered.lower() == expected_address.lower()
+    if sig_type == SigType.HMAC.value:
+        if not signing_secret:
+            return False
+        return verify_hmac(digest, signature, signing_secret)
+    return False

--- a/marketplace/contract_net/engine.py
+++ b/marketplace/contract_net/engine.py
@@ -1,0 +1,318 @@
+"""Contract-Net orchestrator: cosine invite → sealed Vickrey → ε-greedy juniors.
+
+This module is additive. It does not replace ``sincor2.bidding_engine.BiddingEngine.run_auction``.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from .eip712 import (
+    demo_signing_secret,
+    sign_digest,
+    to_hex,
+    typed_data_digest,
+    typed_data_payload,
+    verify_digest,
+)
+from .filter import filter_swarm
+from .keccak import keccak256
+from .types import (
+    AgentProfile,
+    Award,
+    AuctionPhase,
+    ContractNetConfig,
+    FilterResult,
+    SealedBid,
+    TaskSpec,
+)
+from .vickrey import clear_vickrey
+
+
+def make_auction_id(task_id: str, salt: str = "") -> str:
+    material = f"{task_id}|{salt or uuid.uuid4().hex}".encode("utf-8")
+    return to_hex(keccak256(material))
+
+
+@dataclass
+class AuctionRecord:
+    auction_id: str
+    task: TaskSpec
+    filter: FilterResult
+    award: Award
+    created_at: int
+
+
+class ContractNetEngine:
+    """In-process sealed-bid market. Thread-hostile on purpose — one process loop."""
+
+    def __init__(self, config: Optional[ContractNetConfig] = None) -> None:
+        self.config = config or ContractNetConfig()
+        self._history: List[AuctionRecord] = []
+        self._nonces: Dict[str, int] = {}
+
+    def next_nonce(self, agent_id: str) -> int:
+        value = self._nonces.get(agent_id, 0) + 1
+        self._nonces[agent_id] = value
+        return value
+
+    def history(self) -> List[AuctionRecord]:
+        return list(self._history)
+
+    def stats(self) -> Dict[str, float | int]:
+        records = self._history
+        n = len(records)
+        if n == 0:
+            return {
+                "auctions": 0,
+                "junior_reserved": 0,
+                "junior_wins": 0,
+                "junior_win_rate": 0.0,
+                "tokens_saved": 0,
+                "llm_calls_avoided": 0,
+                "mean_invite_k": 0.0,
+            }
+        junior_reserved = sum(1 for row in records if row.award.junior_reserved)
+        junior_wins = sum(1 for row in records if row.award.junior_winner)
+        return {
+            "auctions": n,
+            "junior_reserved": junior_reserved,
+            "junior_wins": junior_wins,
+            "junior_win_rate": junior_wins / n,
+            "tokens_saved": sum(row.award.tokens_saved for row in records),
+            "llm_calls_avoided": sum(row.award.llm_calls_avoided for row in records),
+            "mean_invite_k": sum(len(row.filter.invited) for row in records) / n,
+        }
+
+    def draft_bid(
+        self,
+        *,
+        auction_id: str,
+        task: TaskSpec,
+        agent: AgentProfile,
+        now: Optional[int] = None,
+        price: Optional[int] = None,
+    ) -> SealedBid:
+        now = int(now if now is not None else time.time())
+        nonce = self.next_nonce(agent.agent_id)
+        deadline = now + self.config.bid_ttl_seconds
+        bid_price = int(price if price is not None else agent.true_min_price)
+        digest = typed_data_digest(
+            self.config,
+            auction_id=auction_id,
+            task_id=task.task_id,
+            agent=agent.wallet,
+            price=bid_price,
+            estimated_tokens=agent.estimated_tokens,
+            nonce=nonce,
+            deadline=deadline,
+        )
+        secret = agent.signing_secret or demo_signing_secret(agent.agent_id)
+        signature, sig_type = sign_digest(
+            digest, private_key=agent.private_key, signing_secret=secret
+        )
+        bid = SealedBid(
+            auction_id=auction_id,
+            task_id=task.task_id,
+            agent_id=agent.agent_id,
+            agent_wallet=agent.wallet,
+            price=bid_price,
+            estimated_tokens=agent.estimated_tokens,
+            nonce=nonce,
+            deadline=deadline,
+            digest=to_hex(digest),
+            signature=signature,
+            sig_type=sig_type,
+            typed_data=typed_data_payload(
+                self.config,
+                auction_id=auction_id,
+                task_id=task.task_id,
+                agent=agent.wallet,
+                price=bid_price,
+                estimated_tokens=agent.estimated_tokens,
+                nonce=nonce,
+                deadline=deadline,
+            ),
+            submitted_at=now,
+        )
+        self._validate_bid(bid, task, agent, now=now, signing_secret=secret)
+        return bid
+
+    def _validate_bid(
+        self,
+        bid: SealedBid,
+        task: TaskSpec,
+        agent: Optional[AgentProfile] = None,
+        *,
+        now: int,
+        signing_secret: str = "",
+    ) -> None:
+        if bid.price <= 0:
+            bid.valid = False
+            bid.reject_reason = "non_positive_price"
+            return
+        if bid.price > task.max_price:
+            bid.valid = False
+            bid.reject_reason = "over_max_price"
+            return
+        if bid.deadline < now:
+            bid.valid = False
+            bid.reject_reason = "expired"
+            return
+        secret = signing_secret
+        if not secret and agent is not None:
+            secret = agent.signing_secret or demo_signing_secret(agent.agent_id)
+        digest = bytes.fromhex(bid.digest[2:] if bid.digest.startswith("0x") else bid.digest)
+        expected = typed_data_digest(
+            self.config,
+            auction_id=bid.auction_id,
+            task_id=bid.task_id,
+            agent=bid.agent_wallet,
+            price=bid.price,
+            estimated_tokens=bid.estimated_tokens,
+            nonce=bid.nonce,
+            deadline=bid.deadline,
+        )
+        if digest != expected:
+            bid.valid = False
+            bid.reject_reason = "digest_mismatch"
+            return
+        if not verify_digest(
+            digest,
+            bid.signature,
+            sig_type=bid.sig_type,
+            expected_address=bid.agent_wallet,
+            signing_secret=secret,
+        ):
+            bid.valid = False
+            bid.reject_reason = "bad_signature"
+
+    def run(
+        self,
+        task: TaskSpec,
+        agents: Sequence[AgentProfile],
+        *,
+        seed: Optional[int] = None,
+        force_junior: Optional[bool] = None,
+        now: Optional[int] = None,
+        shade: Optional[Dict[str, float]] = None,
+    ) -> Award:
+        """Run one sealed round.
+
+        ``shade`` maps agent_id → multiplier on true_min_price so tests can
+        prove that overbidding cannot improve payoff under Vickrey.
+        """
+        import random
+
+        rng = random.Random(seed)
+        now = int(now if now is not None else time.time())
+        auction_id = make_auction_id(task.task_id, salt=f"{seed}-{now}")
+        filtered = filter_swarm(
+            task, agents, self.config, rng=rng, force_junior=force_junior
+        )
+        by_id = {agent.agent_id: agent for agent in agents}
+        bids: List[SealedBid] = []
+        shade = shade or {}
+        for invite in filtered.invited:
+            agent = by_id[invite.agent_id]
+            multiplier = float(shade.get(agent.agent_id, 1.0))
+            price = int(round(agent.true_min_price * multiplier))
+            bids.append(
+                self.draft_bid(
+                    auction_id=auction_id,
+                    task=task,
+                    agent=agent,
+                    now=now,
+                    price=price,
+                )
+            )
+        award = clear_vickrey(
+            auction_id=auction_id,
+            task_id=task.task_id,
+            bids=bids,
+            invites=filtered.invited,
+            junior_reserved=filtered.junior_reserved,
+            llm_calls_avoided=filtered.llm_calls_avoided,
+            tokens_saved=filtered.tokens_saved,
+        )
+        if award.phase == AuctionPhase.FAILED.value:
+            award.phase = AuctionPhase.FAILED.value
+        self._history.append(
+            AuctionRecord(
+                auction_id=auction_id,
+                task=task,
+                filter=filtered,
+                award=award,
+                created_at=now,
+            )
+        )
+        return award
+
+    def run_many(
+        self,
+        tasks: Sequence[TaskSpec],
+        agents: Sequence[AgentProfile],
+        *,
+        rounds: int = 40,
+        seed: int = 7,
+    ) -> List[Award]:
+        awards: List[Award] = []
+        n_tasks = len(tasks)
+        if n_tasks == 0:
+            return awards
+        for i in range(rounds):
+            task = tasks[i % n_tasks]
+            awards.append(self.run(task, agents, seed=seed + i))
+        return awards
+
+
+def profiles_from_dicts(rows: Iterable[Dict]) -> List[AgentProfile]:
+    agents: List[AgentProfile] = []
+    for row in rows:
+        agent_id = str(row.get("agent_id") or row.get("id") or "")
+        skills_raw = row.get("skills") or row.get("skills_required") or ()
+        if isinstance(skills_raw, str):
+            skills = tuple(part.strip() for part in skills_raw.split(",") if part.strip())
+        else:
+            skills = tuple(str(item) for item in skills_raw)
+        wallet = str(row.get("wallet") or "")
+        if not wallet and agent_id:
+            from .eip712 import demo_wallet
+
+            wallet = demo_wallet(agent_id)
+        agents.append(
+            AgentProfile(
+                agent_id=agent_id,
+                name=str(row.get("name") or agent_id),
+                skills=skills,
+                wallet=wallet,
+                tasks_completed=int(row.get("tasks_completed") or 0),
+                success_rate=float(row.get("success_rate") or 0.5),
+                true_min_price=int(row.get("true_min_price") or row.get("price") or 1_000_000),
+                estimated_tokens=int(row.get("estimated_tokens") or row.get("estimated_cost_tokens") or 400),
+                is_junior=bool(row.get("is_junior", False)),
+                signing_secret=str(row.get("signing_secret") or demo_signing_secret(agent_id)),
+                private_key=str(row.get("private_key") or ""),
+            )
+        )
+    return agents
+
+
+def task_from_dict(row: Dict) -> TaskSpec:
+    req = row.get("requirements") or row.get("skills_required") or ()
+    if isinstance(req, str):
+        requirements = tuple(part.strip() for part in req.split(",") if part.strip())
+    else:
+        requirements = tuple(str(item) for item in req)
+    return TaskSpec(
+        task_id=str(row.get("task_id") or row.get("id") or "task"),
+        goal=str(row.get("goal") or row.get("description") or ""),
+        requirements=requirements,
+        budget_tokens=int(row.get("budget_tokens") or 1000),
+        max_price=int(row.get("max_price") or 2_000_000),
+        created_at=int(row.get("created_at") or 0),
+        payer=str(row.get("payer") or TaskSpec.__dataclass_fields__["payer"].default),
+    )

--- a/marketplace/contract_net/filter.py
+++ b/marketplace/contract_net/filter.py
@@ -1,0 +1,131 @@
+"""Two-phase heuristic filter: cosine pre-rank, invite only top-k.
+
+Uninvited agents never draft an LLM bid. Tokens saved are counted as
+``(swarm_size - invite_k) * eval_tokens_per_bid``.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Optional, Sequence
+
+from .types import (
+    AgentProfile,
+    ContractNetConfig,
+    FilterResult,
+    Invite,
+    ScoredAgent,
+    TaskSpec,
+    clamp_invite_k,
+    is_junior_agent,
+)
+from .vectors import cosine_similarity, embed_tokens
+
+
+def _jaccard(left: Sequence[str], right: Sequence[str]) -> float:
+    a = {token.lower() for token in left if token}
+    b = {token.lower() for token in right if token}
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def score_agents(
+    task: TaskSpec,
+    agents: Sequence[AgentProfile],
+    config: ContractNetConfig,
+) -> list[ScoredAgent]:
+    task_tokens = task.requirement_tokens()
+    task_vec = embed_tokens(task_tokens, dim=config.vector_dim)
+    scored: list[ScoredAgent] = []
+    for agent in agents:
+        skills = agent.skill_tokens()
+        cosine = cosine_similarity(task_vec, embed_tokens(skills, dim=config.vector_dim))
+        # Exact skill overlap is the product signal; hashed cosine breaks ties
+        # and still ranks near-synonyms that do not share a token.
+        match = 0.55 * cosine + 0.45 * _jaccard(task_tokens, skills)
+        scored.append(
+            ScoredAgent(
+                agent=agent,
+                cosine=match,
+                junior=is_junior_agent(agent, config.junior_task_threshold),
+            )
+        )
+    scored.sort(key=lambda row: (-row.cosine, row.agent.agent_id))
+    return scored
+
+
+def invite_agents(
+    scored: Sequence[ScoredAgent],
+    config: ContractNetConfig,
+    *,
+    rng: random.Random,
+    force_junior: Optional[bool] = None,
+) -> tuple[list[Invite], bool]:
+    invite_k = clamp_invite_k(config.invite_k)
+    junior_reserved = rng.random() < config.epsilon if force_junior is None else force_junior
+
+    above_floor = [row for row in scored if row.cosine >= config.cosine_floor]
+    universe = above_floor or list(scored)
+
+    if junior_reserved:
+        junior_pool = [row for row in universe if row.junior]
+        if junior_pool:
+            pool = junior_pool
+        else:
+            junior_reserved = False
+            pool = universe
+    else:
+        pool = universe
+
+    selected = list(pool[: min(invite_k, len(pool))])
+    invites: list[Invite] = []
+    for row in selected:
+        subsidy = 0
+        if junior_reserved and row.junior:
+            subsidy = int(
+                round(config.eval_tokens_per_bid * (config.junior_subsidy_multiplier - 1.0))
+            )
+        reason = (
+            "junior-reserved cosine match"
+            if junior_reserved and row.junior
+            else "top-k cosine match"
+        )
+        invites.append(
+            Invite(
+                agent_id=row.agent.agent_id,
+                name=row.agent.name,
+                cosine=row.cosine,
+                junior=row.junior,
+                llm_invited=True,
+                reason=reason,
+                subsidy_tokens=subsidy,
+            )
+        )
+    return invites, junior_reserved
+
+
+def filter_swarm(
+    task: TaskSpec,
+    agents: Sequence[AgentProfile],
+    config: ContractNetConfig,
+    *,
+    rng: Optional[random.Random] = None,
+    force_junior: Optional[bool] = None,
+) -> FilterResult:
+    rng = rng or random.Random()
+    scored = score_agents(task, agents, config)
+    invites, junior_reserved = invite_agents(
+        scored, config, rng=rng, force_junior=force_junior
+    )
+    invited_n = len(invites)
+    swarm_n = len(agents)
+    avoided = max(0, swarm_n - invited_n)
+    return FilterResult(
+        ranked=list(scored),
+        invited=invites,
+        junior_reserved=junior_reserved,
+        pool_size=swarm_n,
+        llm_calls_avoided=avoided,
+        tokens_saved=avoided * config.eval_tokens_per_bid,
+    )

--- a/marketplace/contract_net/keccak.py
+++ b/marketplace/contract_net/keccak.py
@@ -1,0 +1,110 @@
+"""Keccak-256 as used by Ethereum (not NIST SHA3-256).
+
+Canonical fixture:
+
+    keccak256(b\"\") ==
+        c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+_ROUNDS = 24
+_RC = (
+    0x0000000000000001,
+    0x0000000000008082,
+    0x800000000000808A,
+    0x8000000080008000,
+    0x000000000000808B,
+    0x0000000080000001,
+    0x8000000080008081,
+    0x8000000000008009,
+    0x000000000000008A,
+    0x0000000000000088,
+    0x0000000080008009,
+    0x000000008000000A,
+    0x000000008000808B,
+    0x800000000000008B,
+    0x8000000000008089,
+    0x8000000000008003,
+    0x8000000000008002,
+    0x8000000000000080,
+    0x000000000000800A,
+    0x800000008000000A,
+    0x8000000080008081,
+    0x8000000000008080,
+    0x0000000080000001,
+    0x8000000080008008,
+)
+# rho offsets indexed [x][y]
+_ROT = (
+    (0, 36, 3, 41, 18),
+    (1, 44, 10, 45, 2),
+    (62, 6, 43, 15, 61),
+    (28, 55, 25, 21, 56),
+    (27, 20, 39, 8, 14),
+)
+_MASK = 0xFFFFFFFFFFFFFFFF
+_RATE = 136  # 1088-bit rate for Keccak-256
+
+
+def _rotl64(value: int, shift: int) -> int:
+    shift &= 63
+    return ((value << shift) | (value >> (64 - shift))) & _MASK
+
+
+def _keccak_f(state: list[int]) -> None:
+    for round_index in range(_ROUNDS):
+        c = [state[x] ^ state[x + 5] ^ state[x + 10] ^ state[x + 15] ^ state[x + 20] for x in range(5)]
+        d = [c[(x - 1) % 5] ^ _rotl64(c[(x + 1) % 5], 1) for x in range(5)]
+        for x in range(5):
+            for y in range(5):
+                state[x + 5 * y] ^= d[x]
+
+        b = [0] * 25
+        for x in range(5):
+            for y in range(5):
+                b[y + 5 * ((2 * x + 3 * y) % 5)] = _rotl64(state[x + 5 * y], _ROT[x][y])
+
+        for y in range(5):
+            lane = [b[x + 5 * y] for x in range(5)]
+            for x in range(5):
+                state[x + 5 * y] = (lane[x] ^ ((~lane[(x + 1) % 5]) & lane[(x + 2) % 5])) & _MASK
+
+        state[0] ^= _RC[round_index]
+
+
+def keccak256(data: bytes) -> bytes:
+    """Return the 32-byte Keccak-256 digest of *data*."""
+    if not isinstance(data, (bytes, bytearray)):
+        raise TypeError("keccak256 expects bytes")
+    state = [0] * 25
+    offset = 0
+    length = len(data)
+    while length - offset >= _RATE:
+        for i in range(_RATE):
+            state[i >> 3] ^= data[offset + i] << ((i & 7) << 3)
+        _keccak_f(state)
+        offset += _RATE
+
+    block = bytearray(data[offset:])
+    block.append(0x01)
+    block.extend(b"\x00" * (_RATE - len(block)))
+    block[_RATE - 1] |= 0x80
+    for i in range(_RATE):
+        state[i >> 3] ^= block[i] << ((i & 7) << 3)
+    _keccak_f(state)
+
+    out = bytearray()
+    for lane in state[:4]:
+        out.extend(int(lane).to_bytes(8, "little"))
+    return bytes(out)
+
+
+def keccak256_hex(data: bytes) -> str:
+    return "0x" + keccak256(data).hex()
+
+
+def keccak256_many(chunks: Iterable[bytes]) -> bytes:
+    return keccak256(b"".join(chunks))

--- a/marketplace/contract_net/roster.py
+++ b/marketplace/contract_net/roster.py
@@ -1,0 +1,219 @@
+"""Canonical demo swarm used by tests, the Flask sandbox, and the operator console.
+
+Prices are true minimum margins in micro-AXM. Under Vickrey the dominant
+strategy is to bid this number in a single sealed pass.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from .eip712 import demo_signing_secret, demo_wallet
+from .types import AgentProfile, MICRO_AXM, TaskSpec
+
+
+def _agent(
+    agent_id: str,
+    name: str,
+    skills: tuple[str, ...],
+    *,
+    tasks_completed: int,
+    success_rate: float,
+    axm: float,
+    estimated_tokens: int,
+    is_junior: bool = False,
+) -> AgentProfile:
+    return AgentProfile(
+        agent_id=agent_id,
+        name=name,
+        skills=skills,
+        wallet=demo_wallet(agent_id),
+        tasks_completed=tasks_completed,
+        success_rate=success_rate,
+        true_min_price=int(round(axm * MICRO_AXM)),
+        estimated_tokens=estimated_tokens,
+        is_junior=is_junior or tasks_completed < 3,
+        signing_secret=demo_signing_secret(agent_id),
+    )
+
+
+def demo_roster() -> List[AgentProfile]:
+    return [
+        _agent(
+            "atlas-scout",
+            "Atlas Scout",
+            ("prospect", "scrape", "research", "monitor", "validate"),
+            tasks_completed=48,
+            success_rate=0.91,
+            axm=1.20,
+            estimated_tokens=520,
+        ),
+        _agent(
+            "helix-synth",
+            "Helix Synthesizer",
+            ("summarize", "analyze", "curate", "dedup", "deconflict", "research"),
+            tasks_completed=36,
+            success_rate=0.88,
+            axm=1.10,
+            estimated_tokens=480,
+        ),
+        _agent(
+            "forge-builder",
+            "Forge Builder",
+            ("develop", "automate", "deploy", "test", "debug"),
+            tasks_completed=52,
+            success_rate=0.86,
+            axm=1.40,
+            estimated_tokens=640,
+        ),
+        _agent(
+            "pact-negotiator",
+            "Pact Negotiator",
+            ("outreach", "negotiate", "present", "close", "persuade"),
+            tasks_completed=29,
+            success_rate=0.84,
+            axm=1.35,
+            estimated_tokens=410,
+        ),
+        _agent(
+            "vault-auditor",
+            "Vault Auditor",
+            ("evaluate", "verify", "investigate", "report", "certify"),
+            tasks_completed=41,
+            success_rate=0.93,
+            axm=1.25,
+            estimated_tokens=390,
+        ),
+        _agent(
+            "nova-director",
+            "Nova Director",
+            ("prioritize", "coordinate", "allocate", "plan", "decide"),
+            tasks_completed=60,
+            success_rate=0.90,
+            axm=1.60,
+            estimated_tokens=360,
+        ),
+        _agent(
+            "ledger-ops",
+            "Ledger Ops",
+            ("settlement", "treasury", "monitor", "report"),
+            tasks_completed=22,
+            success_rate=0.81,
+            axm=1.05,
+            estimated_tokens=430,
+        ),
+        _agent(
+            "spark-scout",
+            "Spark Scout",
+            ("prospect", "scrape", "research"),
+            tasks_completed=1,
+            success_rate=0.62,
+            axm=0.85,
+            estimated_tokens=540,
+            is_junior=True,
+        ),
+        _agent(
+            "ember-builder",
+            "Ember Builder",
+            ("develop", "test", "debug"),
+            tasks_completed=0,
+            success_rate=0.50,
+            axm=0.90,
+            estimated_tokens=610,
+            is_junior=True,
+        ),
+        _agent(
+            "moss-caretaker",
+            "Moss Caretaker",
+            ("clean", "label", "organize", "maintain", "backup"),
+            tasks_completed=2,
+            success_rate=0.71,
+            axm=0.70,
+            estimated_tokens=280,
+            is_junior=True,
+        ),
+        _agent(
+            "wick-analyst",
+            "Wick Analyst",
+            ("analyze", "research", "report", "summarize"),
+            tasks_completed=1,
+            success_rate=0.58,
+            axm=0.80,
+            estimated_tokens=450,
+            is_junior=True,
+        ),
+        _agent(
+            "hatch-ops",
+            "Hatch Ops",
+            ("automate", "deploy", "monitor", "backup"),
+            tasks_completed=0,
+            success_rate=0.50,
+            axm=0.95,
+            estimated_tokens=500,
+            is_junior=True,
+        ),
+        _agent(
+            "sapling-legal",
+            "Sapling Legal",
+            ("evaluate", "verify", "certify", "policy"),
+            tasks_completed=2,
+            success_rate=0.66,
+            axm=0.88,
+            estimated_tokens=370,
+            is_junior=True,
+        ),
+    ]
+
+
+def demo_tasks() -> List[TaskSpec]:
+    return [
+        TaskSpec(
+            task_id="cn-map-competitors",
+            goal="Map competitor pricing for enterprise A2A listings",
+            requirements=("research", "scrape", "analyze"),
+            budget_tokens=1800,
+            max_price=2_000_000,
+        ),
+        TaskSpec(
+            task_id="cn-ship-webhook",
+            goal="Ship the settlement webhook and tests",
+            requirements=("develop", "test", "deploy"),
+            budget_tokens=2400,
+            max_price=2_200_000,
+        ),
+        TaskSpec(
+            task_id="cn-outreach-sequence",
+            goal="Draft outreach sequence for staked agents",
+            requirements=("outreach", "persuade", "present"),
+            budget_tokens=1200,
+            max_price=1_800_000,
+        ),
+        TaskSpec(
+            task_id="cn-memory-backup",
+            goal="Nightly backup and label of memory shards",
+            requirements=("backup", "label", "maintain"),
+            budget_tokens=900,
+            max_price=1_200_000,
+        ),
+        TaskSpec(
+            task_id="cn-eip712-certify",
+            goal="Certify the EIP-712 bid domain against the treasury",
+            requirements=("evaluate", "verify", "certify"),
+            budget_tokens=1100,
+            max_price=1_600_000,
+        ),
+        TaskSpec(
+            task_id="cn-route-plan",
+            goal="Prioritize the week’s routing queue and allocate juniors",
+            requirements=("prioritize", "allocate", "coordinate"),
+            budget_tokens=800,
+            max_price=2_000_000,
+        ),
+    ]
+
+
+def task_by_id(task_id: str) -> TaskSpec:
+    for task in demo_tasks():
+        if task.task_id == task_id:
+            return task
+    raise KeyError(task_id)

--- a/marketplace/contract_net/types.py
+++ b/marketplace/contract_net/types.py
@@ -1,0 +1,194 @@
+"""Dataclasses for the Contract-Net task market.
+
+Integer prices are micro-AXM (1_000_000 = 1 AXM) to avoid float rounding in
+the Vickrey clearing step.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+VECTOR_DIM = 64
+MICRO_AXM = 1_000_000
+BASE_CHAIN_ID = 8453
+# Domain verifying contract: platform treasury (canonical, Base).
+# The market does not move funds itself; this binds typed-data to the chain.
+DEFAULT_VERIFYING_CONTRACT = "0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac"
+DOMAIN_NAME = "SINCOR Contract-Net"
+DOMAIN_VERSION = "1"
+
+EMPTY_KECCAK = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+
+_STOP = {
+    "a", "an", "and", "the", "of", "for", "to", "in", "on", "at", "by", "or",
+    "with", "from", "into", "over", "under", "than", "then", "that", "this",
+    "its", "it", "is", "are", "be", "as", "vs", "via",
+}
+
+
+class AuctionPhase(str, Enum):
+    FILTER = "filter"
+    INVITE = "invite"
+    SEALED = "sealed"
+    CLEARED = "cleared"
+    FAILED = "failed"
+
+
+class SigType(str, Enum):
+    SECP256K1 = "eip712-secp256k1"
+    HMAC = "eip712-hmac-sha256"
+
+
+@dataclass(frozen=True)
+class ContractNetConfig:
+    """Tunable market parameters. Defaults match the product spec."""
+
+    invite_k: int = 4  # top 3–5 skill matches are invited
+    invite_k_min: int = 3
+    invite_k_max: int = 5
+    cosine_floor: float = 0.02
+    epsilon: float = 0.12  # 12% of auctions reserved for juniors (10–15% band)
+    junior_task_threshold: int = 3
+    junior_subsidy_multiplier: float = 2.0
+    eval_tokens_per_bid: int = 800  # assumed LLM tokens per unfiltered bid draft
+    chain_id: int = BASE_CHAIN_ID
+    verifying_contract: str = DEFAULT_VERIFYING_CONTRACT
+    domain_name: str = DOMAIN_NAME
+    domain_version: str = DOMAIN_VERSION
+    vector_dim: int = VECTOR_DIM
+    bid_ttl_seconds: int = 120
+
+    def __post_init__(self) -> None:
+        if not (self.invite_k_min <= self.invite_k <= self.invite_k_max):
+            raise ValueError(
+                f"invite_k must be in [{self.invite_k_min}, {self.invite_k_max}], got {self.invite_k}"
+            )
+        if not (0.10 <= self.epsilon <= 0.15):
+            raise ValueError(f"epsilon must be in [0.10, 0.15], got {self.epsilon}")
+        if self.vector_dim <= 0:
+            raise ValueError("vector_dim must be positive")
+
+
+@dataclass
+class AgentProfile:
+    """Market participant used by the filter and auction."""
+
+    agent_id: str
+    name: str
+    skills: Tuple[str, ...]
+    wallet: str
+    tasks_completed: int = 0
+    success_rate: float = 0.5
+    # True minimum margin the agent would bid under Vickrey (micro-AXM).
+    true_min_price: int = 1_000_000
+    estimated_tokens: int = 400
+    is_junior: bool = False
+    spawned_at: str = ""
+    signing_secret: str = ""  # hex; HMAC path / deterministic demo key
+    private_key: str = ""  # hex secp256k1; optional
+
+    def skill_tokens(self) -> Tuple[str, ...]:
+        return tuple(token.lower() for token in self.skills if token)
+
+
+@dataclass
+class TaskSpec:
+    task_id: str
+    goal: str
+    requirements: Tuple[str, ...]
+    budget_tokens: int
+    max_price: int
+    created_at: int = 0
+    payer: str = DEFAULT_VERIFYING_CONTRACT
+
+    def requirement_tokens(self) -> Tuple[str, ...]:
+        tokens = [token.lower() for token in self.requirements if token]
+        return tuple(token for token in tokens if token and token not in _STOP and len(token) > 1)
+
+
+@dataclass
+class ScoredAgent:
+    agent: AgentProfile
+    cosine: float
+    junior: bool
+
+
+@dataclass
+class Invite:
+    agent_id: str
+    name: str
+    cosine: float
+    junior: bool
+    llm_invited: bool
+    reason: str
+    subsidy_tokens: int = 0
+
+
+@dataclass
+class FilterResult:
+    ranked: List[ScoredAgent]
+    invited: List[Invite]
+    junior_reserved: bool
+    pool_size: int
+    llm_calls_avoided: int
+    tokens_saved: int
+
+
+@dataclass
+class SealedBid:
+    auction_id: str
+    task_id: str
+    agent_id: str
+    agent_wallet: str
+    price: int
+    estimated_tokens: int
+    nonce: int
+    deadline: int
+    digest: str
+    signature: str
+    sig_type: str
+    typed_data: Dict[str, Any] = field(default_factory=dict)
+    submitted_at: int = 0
+    valid: bool = True
+    reject_reason: str = ""
+
+
+@dataclass
+class Award:
+    auction_id: str
+    task_id: str
+    winner_id: str
+    winner_wallet: str
+    winner_bid_price: int
+    clearing_price: int  # second price; what the winner is paid
+    savings_vs_first_price: int
+    mechanism: str
+    junior_reserved: bool
+    junior_winner: bool
+    invites: List[Invite]
+    bids: List[SealedBid]
+    llm_calls_avoided: int
+    tokens_saved: int
+    valid_bid_count: int
+    rejected_bid_count: int
+    phase: str = AuctionPhase.CLEARED.value
+    error: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["invites"] = [asdict(invite) for invite in self.invites]
+        payload["bids"] = [asdict(bid) for bid in self.bids]
+        return payload
+
+
+def clamp_invite_k(value: int) -> int:
+    return max(3, min(5, int(value)))
+
+
+def is_junior_agent(agent: AgentProfile, threshold: int) -> bool:
+    if agent.is_junior:
+        return True
+    return agent.tasks_completed < threshold

--- a/marketplace/contract_net/vectors.py
+++ b/marketplace/contract_net/vectors.py
@@ -1,0 +1,67 @@
+"""Deterministic 64-d hashed bag-of-tokens embeddings.
+
+Phase-1 filtering is intentionally LLM-free: each skill or requirement token is
+Keccak-hashed into a fixed-width vector, then cosine similarity ranks agents.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence, Tuple
+
+from .keccak import keccak256
+from .types import VECTOR_DIM
+
+
+def embed_tokens(tokens: Sequence[str], dim: int = VECTOR_DIM) -> Tuple[float, ...]:
+    """Hash-bag embedding. Identical token sets produce identical unit vectors.
+
+    Each token is expanded with Keccak into ``dim`` independent 32-bit
+    projections so unrelated skill sets stay near-orthogonal.
+    """
+    if dim <= 0:
+        raise ValueError("dim must be positive")
+    vec = [0.0] * dim
+    seen = False
+    for raw in tokens:
+        token = " ".join(str(raw).strip().lower().split())
+        if not token:
+            continue
+        seen = True
+        need = dim * 4
+        buf = bytearray()
+        counter = 0
+        encoded = token.encode("utf-8")
+        while len(buf) < need:
+            buf.extend(keccak256(encoded + counter.to_bytes(4, "big")))
+            counter += 1
+        for i in range(dim):
+            raw_u = int.from_bytes(buf[i * 4 : i * 4 + 4], "big")
+            vec[i] += (raw_u / 2147483648.0) - 1.0
+    if not seen:
+        return tuple(vec)
+    mag = math.sqrt(sum(x * x for x in vec))
+    if mag < 1e-12:
+        return tuple(vec)
+    return tuple(x / mag for x in vec)
+
+
+def cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+    if len(left) != len(right):
+        raise ValueError("vector length mismatch")
+    dot = 0.0
+    n_left = 0.0
+    n_right = 0.0
+    for a, b in zip(left, right):
+        dot += a * b
+        n_left += a * a
+        n_right += b * b
+    denom = math.sqrt(n_left) * math.sqrt(n_right)
+    if denom < 1e-12:
+        return 0.0
+    value = dot / denom
+    if value > 1.0:
+        return 1.0
+    if value < -1.0:
+        return -1.0
+    return value

--- a/marketplace/contract_net/vickrey.py
+++ b/marketplace/contract_net/vickrey.py
@@ -1,0 +1,103 @@
+"""Sealed-bid Vickrey reverse auction.
+
+Lowest valid price wins. The winner is paid the second-lowest valid price
+(or their own price if they were the only valid bid). No iterative
+counter-bids: one signed envelope per agent.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from .types import Award, AuctionPhase, Invite, SealedBid
+
+
+def sort_valid_bids(bids: Sequence[SealedBid]) -> List[SealedBid]:
+    valid = [bid for bid in bids if bid.valid]
+    valid.sort(key=lambda bid: (bid.price, bid.agent_id))
+    return valid
+
+
+def clear_vickrey(
+    *,
+    auction_id: str,
+    task_id: str,
+    bids: Sequence[SealedBid],
+    invites: Sequence[Invite],
+    junior_reserved: bool,
+    llm_calls_avoided: int,
+    tokens_saved: int,
+    invited_ids: Optional[Iterable[str]] = None,
+) -> Award:
+    invited = set(invited_ids) if invited_ids is not None else {row.agent_id for row in invites}
+    checked: List[SealedBid] = []
+    seen: set[str] = set()
+    for bid in bids:
+        if bid.agent_id in seen:
+            bid.valid = False
+            bid.reject_reason = bid.reject_reason or "duplicate_bid"
+        seen.add(bid.agent_id)
+        if bid.agent_id not in invited:
+            bid.valid = False
+            bid.reject_reason = bid.reject_reason or "not_invited"
+        checked.append(bid)
+
+    valid = sort_valid_bids(checked)
+    rejected = sum(1 for bid in checked if not bid.valid)
+
+    if not valid:
+        return Award(
+            auction_id=auction_id,
+            task_id=task_id,
+            winner_id="",
+            winner_wallet="",
+            winner_bid_price=0,
+            clearing_price=0,
+            savings_vs_first_price=0,
+            mechanism="vickrey-second-price",
+            junior_reserved=junior_reserved,
+            junior_winner=False,
+            invites=list(invites),
+            bids=list(checked),
+            llm_calls_avoided=llm_calls_avoided,
+            tokens_saved=tokens_saved,
+            valid_bid_count=0,
+            rejected_bid_count=rejected,
+            phase=AuctionPhase.FAILED.value,
+            error="no_valid_bids",
+        )
+
+    winner = valid[0]
+    clearing = valid[1].price if len(valid) > 1 else winner.price
+    rent = clearing - winner.price
+    junior_ids = {row.agent_id for row in invites if row.junior}
+
+    return Award(
+        auction_id=auction_id,
+        task_id=task_id,
+        winner_id=winner.agent_id,
+        winner_wallet=winner.agent_wallet,
+        winner_bid_price=winner.price,
+        clearing_price=clearing,
+        savings_vs_first_price=rent,
+        mechanism="vickrey-second-price",
+        junior_reserved=junior_reserved,
+        junior_winner=winner.agent_id in junior_ids,
+        invites=list(invites),
+        bids=list(checked),
+        llm_calls_avoided=llm_calls_avoided,
+        tokens_saved=tokens_saved,
+        valid_bid_count=len(valid),
+        rejected_bid_count=rejected,
+        phase=AuctionPhase.CLEARED.value,
+    )
+
+
+def vickrey_truthful_prices(prices: Sequence[int]) -> Tuple[int, int, int]:
+    """Return (winner_index_in_sorted, winner_price, clearing_price)."""
+    ordered = sorted(prices)
+    if not ordered:
+        raise ValueError("no prices")
+    winner_price = ordered[0]
+    clearing = ordered[1] if len(ordered) > 1 else ordered[0]
+    return 0, winner_price, clearing

--- a/src/sincor2/app.py
+++ b/src/sincor2/app.py
@@ -1367,6 +1367,11 @@ def create_app():
     except Exception as e:
         print(f"Marketplace blueprint not available: {e}")
     try:
+        from sincor2.blueprints.contract_net import contract_net_bp
+        app.register_blueprint(contract_net_bp)
+    except Exception as e:
+        print(f"Contract-Net blueprint not available: {e}")
+    try:
         from sincor2.blueprints.payments import payments_bp
         app.register_blueprint(payments_bp)
     except Exception as e:

--- a/src/sincor2/bidding_engine.py
+++ b/src/sincor2/bidding_engine.py
@@ -401,6 +401,48 @@ class BiddingEngine:
             return AuctionResult(task_id=task_id, ok=False, error="market_exception",
                                  )
 
+    def run_vickrey_auction(
+        self,
+        task: Dict[str, Any],
+        agents: List[Dict[str, Any]],
+        *,
+        seed: Optional[int] = None,
+        invite_k: int = 4,
+        epsilon: float = 0.12,
+        force_junior: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Additive Vickrey Contract-Net path.
+
+        Does **not** replace ``run_auction``. Failures return ``{"ok": False}``
+        so the first-price market loop is unaffected.
+        """
+        try:
+            from marketplace.contract_net.engine import (
+                ContractNetEngine,
+                profiles_from_dicts,
+                task_from_dict,
+            )
+            from marketplace.contract_net.types import ContractNetConfig, clamp_invite_k
+
+            k = clamp_invite_k(int(invite_k))
+            eps = min(0.15, max(0.10, float(epsilon)))
+            engine = ContractNetEngine(ContractNetConfig(invite_k=k, epsilon=eps))
+            spec = task_from_dict(task)
+            roster = profiles_from_dicts(agents)
+            award = engine.run(spec, roster, seed=seed, force_junior=force_junior)
+            payload = award.to_dict()
+            payload["ok"] = award.phase != "failed"
+            return payload
+        except Exception:
+            tb = traceback.format_exc()
+            logger.error("[BIDDING] run_vickrey_auction crashed\n%s", tb)
+            return {
+                "ok": False,
+                "error": "vickrey_exception",
+                "detail": tb[:200],
+                "task_id": str(task.get("task_id", "")),
+            }
+
 
 # ---------------------------------------------------------------------------
 # Module-level singleton (lazy, thread-safe)

--- a/src/sincor2/blueprints/contract_net.py
+++ b/src/sincor2/blueprints/contract_net.py
@@ -1,0 +1,171 @@
+"""Additive Contract-Net API. Does not replace /api/marketplace first-price routes."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from flask import Blueprint, current_app, jsonify, request
+
+from marketplace.contract_net import (
+    ContractNetConfig,
+    ContractNetEngine,
+    demo_roster,
+    demo_tasks,
+    task_from_dict,
+)
+from marketplace.contract_net.types import clamp_invite_k
+
+logger = logging.getLogger(__name__)
+
+contract_net_bp = Blueprint("contract_net", __name__, url_prefix="/api/contract-net")
+
+
+def _engine() -> ContractNetEngine:
+    platform = current_app.extensions.get("sincor_platform") or {}
+    engine = platform.get("contract_net")
+    if engine is None:
+        engine = ContractNetEngine()
+        platform = dict(platform)
+        platform["contract_net"] = engine
+        current_app.extensions["sincor_platform"] = platform
+    return engine
+
+
+def _config_from_body(body: Dict[str, Any]) -> Optional[ContractNetConfig]:
+    if not any(key in body for key in ("invite_k", "epsilon", "eval_tokens_per_bid")):
+        return None
+    invite_k = clamp_invite_k(int(body.get("invite_k", 4)))
+    epsilon = float(body.get("epsilon", 0.12))
+    epsilon = min(0.15, max(0.10, epsilon))
+    return ContractNetConfig(invite_k=invite_k, epsilon=epsilon)
+
+
+@contract_net_bp.get("/health")
+def health():
+    engine = _engine()
+    return jsonify(
+        {
+            "ok": True,
+            "mechanism": "vickrey-second-price",
+            "invite_k": engine.config.invite_k,
+            "epsilon": engine.config.epsilon,
+            "chain_id": engine.config.chain_id,
+            "verifying_contract": engine.config.verifying_contract,
+            "domain": {
+                "name": engine.config.domain_name,
+                "version": engine.config.domain_version,
+            },
+        }
+    )
+
+
+@contract_net_bp.get("/roster")
+def roster():
+    agents = [
+        {
+            "agent_id": agent.agent_id,
+            "name": agent.name,
+            "skills": list(agent.skills),
+            "wallet": agent.wallet,
+            "tasks_completed": agent.tasks_completed,
+            "success_rate": agent.success_rate,
+            "true_min_price": agent.true_min_price,
+            "is_junior": agent.is_junior or agent.tasks_completed < 3,
+        }
+        for agent in demo_roster()
+    ]
+    return jsonify({"agents": agents, "count": len(agents)})
+
+
+@contract_net_bp.get("/tasks")
+def tasks():
+    payload = [
+        {
+            "task_id": task.task_id,
+            "goal": task.goal,
+            "requirements": list(task.requirements),
+            "budget_tokens": task.budget_tokens,
+            "max_price": task.max_price,
+        }
+        for task in demo_tasks()
+    ]
+    return jsonify({"tasks": payload, "count": len(payload)})
+
+
+@contract_net_bp.get("/stats")
+def stats():
+    return jsonify(_engine().stats())
+
+
+@contract_net_bp.get("/history")
+def history():
+    limit = min(int(request.args.get("limit", 25)), 100)
+    records = _engine().history()[-limit:]
+    return jsonify(
+        {
+            "auctions": [record.award.to_dict() for record in records],
+            "count": len(records),
+        }
+    )
+
+
+@contract_net_bp.post("/auctions")
+def run_auction():
+    """Run one cosine-filtered Vickrey round over the demo roster (or supplied agents)."""
+    body = request.get_json(silent=True) or {}
+    extra_config = _config_from_body(body)
+    engine = _engine()
+    if extra_config is not None:
+        engine = ContractNetEngine(extra_config)
+
+    task_payload = body.get("task") or {}
+    if body.get("task_id") and not task_payload:
+        try:
+            from marketplace.contract_net.roster import task_by_id
+
+            task = task_by_id(str(body["task_id"]))
+        except KeyError:
+            return jsonify({"error": f"unknown task_id {body.get('task_id')!r}"}), 404
+    elif task_payload:
+        task = task_from_dict(task_payload)
+    else:
+        task = demo_tasks()[0]
+
+    seed = body.get("seed")
+    if seed is not None:
+        seed = int(seed)
+    force_junior = body.get("force_junior")
+    if force_junior is not None:
+        force_junior = bool(force_junior)
+
+    award = engine.run(
+        task,
+        demo_roster(),
+        seed=seed,
+        force_junior=force_junior,
+    )
+    # Keep the app-level engine history in sync when we spun a one-off config.
+    if extra_config is not None:
+        app_engine = _engine()
+        app_engine._history.append(engine.history()[-1])  # noqa: SLF001
+    return jsonify(award.to_dict())
+
+
+@contract_net_bp.post("/simulate")
+def simulate():
+    body = request.get_json(silent=True) or {}
+    rounds = min(int(body.get("rounds", 40)), 200)
+    seed = int(body.get("seed", 7))
+    extra_config = _config_from_body(body)
+    engine = ContractNetEngine(extra_config or _engine().config)
+    awards = engine.run_many(demo_tasks(), demo_roster(), rounds=rounds, seed=seed)
+    app_engine = _engine()
+    app_engine._history.extend(engine.history())  # noqa: SLF001
+    return jsonify(
+        {
+            "rounds": rounds,
+            "stats": engine.stats(),
+            "awards": [award.to_dict() for award in awards[-10:]],
+        }
+    )

--- a/src/sincor2/platform_bootstrap.py
+++ b/src/sincor2/platform_bootstrap.py
@@ -74,6 +74,12 @@ def bootstrap_platform(app: Flask) -> Dict[str, Any]:
         "skill_vertical_map": dict(SKILL_VERTICAL_MAP),
         "registered_cards": registered,
     }
+    try:
+        from marketplace.contract_net import ContractNetEngine
+
+        platform_state["contract_net"] = ContractNetEngine()
+    except Exception as err:
+        logger.warning("Contract-Net engine not attached: %s", err)
     app.extensions["sincor_platform"] = platform_state
 
     _extend_a2a_skills_from_registry(registry)

--- a/tests/pytest/test_contract_net.py
+++ b/tests/pytest/test_contract_net.py
@@ -1,0 +1,305 @@
+"""Contract-Net: cosine invite, Vickrey second-price, ε-greedy juniors.
+
+Isolated unit tests — they do not import BiddingEngine.run_auction so the
+first-price path stays untouched.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if "marketplace" not in sys.modules:
+    pkg = types.ModuleType("marketplace")
+    pkg.__path__ = [str(ROOT / "marketplace")]
+    sys.modules["marketplace"] = pkg
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from marketplace.contract_net.eip712 import (  # noqa: E402
+    demo_signing_secret,
+    sign_hmac,
+    typed_data_digest,
+    verify_hmac,
+)
+from marketplace.contract_net.engine import ContractNetEngine  # noqa: E402
+from marketplace.contract_net.filter import filter_swarm  # noqa: E402
+from marketplace.contract_net.keccak import keccak256, keccak256_hex  # noqa: E402
+from marketplace.contract_net.roster import demo_roster, demo_tasks  # noqa: E402
+from marketplace.contract_net.types import ContractNetConfig, TaskSpec  # noqa: E402
+from marketplace.contract_net.vectors import cosine_similarity, embed_tokens  # noqa: E402
+from marketplace.contract_net.vickrey import clear_vickrey, sort_valid_bids  # noqa: E402
+from marketplace.contract_net.types import Invite, SealedBid  # noqa: E402
+
+
+EMPTY_KECCAK = "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+
+
+def test_keccak_empty_and_abc():
+    assert keccak256(b"").hex() == EMPTY_KECCAK
+    assert keccak256(b"abc").hex() == "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"
+    assert keccak256_hex(b"").startswith("0x")
+
+
+def test_embed_identical_tokens_cosine_one():
+    left = embed_tokens(("research", "scrape", "analyze"))
+    right = embed_tokens(("research", "scrape", "analyze"))
+    assert cosine_similarity(left, right) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_embed_disjoint_tokens_lower_cosine():
+    close = cosine_similarity(
+        embed_tokens(("research", "scrape", "analyze")),
+        embed_tokens(("research", "analyze")),
+    )
+    far = cosine_similarity(
+        embed_tokens(("research", "scrape", "analyze")),
+        embed_tokens(("backup", "label", "maintain")),
+    )
+    assert close > far
+
+
+def test_invite_k_is_between_three_and_five():
+    roster = demo_roster()
+    task = demo_tasks()[0]
+    config = ContractNetConfig(invite_k=4)
+    result = filter_swarm(task, roster, config, rng=random.Random(1), force_junior=False)
+    assert 3 <= len(result.invited) <= 5
+    assert result.tokens_saved == (len(roster) - len(result.invited)) * config.eval_tokens_per_bid
+    assert result.llm_calls_avoided == len(roster) - len(result.invited)
+
+
+def test_invite_k_rejects_out_of_band():
+    with pytest.raises(ValueError):
+        ContractNetConfig(invite_k=2)
+    with pytest.raises(ValueError):
+        ContractNetConfig(epsilon=0.2)
+
+
+def test_vickrey_lowest_wins_paid_second():
+    engine = ContractNetEngine(ContractNetConfig(invite_k=4, epsilon=0.12))
+    roster = demo_roster()
+    task = demo_tasks()[1]  # develop / test / deploy
+    award = engine.run(task, roster, seed=11, force_junior=False)
+    valid = [bid for bid in award.bids if bid.valid]
+    ordered = sorted(valid, key=lambda bid: (bid.price, bid.agent_id))
+    assert award.winner_id == ordered[0].agent_id
+    assert award.winner_bid_price == ordered[0].price
+    if len(ordered) > 1:
+        assert award.clearing_price == ordered[1].price
+        assert award.clearing_price >= award.winner_bid_price
+        assert award.savings_vs_first_price == ordered[1].price - ordered[0].price
+    assert len(award.invites) <= 5
+    assert all(bid.agent_id in {row.agent_id for row in award.invites} for bid in award.bids)
+
+
+def test_hmac_signature_roundtrip():
+    config = ContractNetConfig()
+    digest = typed_data_digest(
+        config,
+        auction_id="0x" + "ab" * 32,
+        task_id="cn-test",
+        agent="0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac",
+        price=1_000_000,
+        estimated_tokens=400,
+        nonce=1,
+        deadline=1_700_000_000,
+    )
+    secret = demo_signing_secret("atlas-scout")
+    sig = sign_hmac(digest, secret)
+    assert verify_hmac(digest, sig, secret)
+    assert not verify_hmac(digest, sig, demo_signing_secret("other"))
+
+
+def test_bad_signature_is_rejected():
+    engine = ContractNetEngine()
+    roster = demo_roster()
+    task = demo_tasks()[0]
+    award = engine.run(task, roster, seed=3, force_junior=False)
+    bid = award.bids[0]
+    bid.signature = "0x" + "00" * 32
+    bid.valid = True
+    bid.reject_reason = ""
+    engine._validate_bid(bid, task, now=bid.submitted_at, signing_secret=demo_signing_secret(bid.agent_id))
+    assert bid.valid is False
+    assert bid.reject_reason == "bad_signature"
+
+
+def test_over_max_price_rejected():
+    engine = ContractNetEngine()
+    roster = demo_roster()
+    task = TaskSpec(
+        task_id="tiny-budget",
+        goal="Cheap scrape",
+        requirements=("scrape",),
+        budget_tokens=100,
+        max_price=100,
+    )
+    award = engine.run(task, roster, seed=2, force_junior=False)
+    assert award.phase == "failed" or all(bid.price <= 100 or not bid.valid for bid in award.bids)
+
+
+def test_uninvited_bid_rejected():
+    invites = [
+        Invite(
+            agent_id="atlas-scout",
+            name="Atlas Scout",
+            cosine=0.9,
+            junior=False,
+            llm_invited=True,
+            reason="top-k",
+        )
+    ]
+    outsider = SealedBid(
+        auction_id="0x" + "11" * 32,
+        task_id="t",
+        agent_id="forge-builder",
+        agent_wallet="0x" + "22" * 20,
+        price=1,
+        estimated_tokens=1,
+        nonce=1,
+        deadline=9_999_999_999,
+        digest="0x" + "33" * 32,
+        signature="0x" + "44" * 32,
+        sig_type="eip712-hmac-sha256",
+    )
+    award = clear_vickrey(
+        auction_id=outsider.auction_id,
+        task_id="t",
+        bids=[outsider],
+        invites=invites,
+        junior_reserved=False,
+        llm_calls_avoided=0,
+        tokens_saved=0,
+    )
+    assert award.phase == "failed"
+    assert award.bids[0].reject_reason == "not_invited"
+
+
+def test_junior_reserved_pool_excludes_incumbents():
+    roster = demo_roster()
+    task = demo_tasks()[0]
+    engine = ContractNetEngine()
+    award = engine.run(task, roster, seed=0, force_junior=True)
+    assert award.junior_reserved is True
+    assert all(invite.junior for invite in award.invites)
+    if award.winner_id:
+        assert award.junior_winner is True
+
+
+def test_junior_fallback_when_no_juniors():
+    incumbents = [agent for agent in demo_roster() if agent.tasks_completed >= 3]
+    task = demo_tasks()[0]
+    result = filter_swarm(
+        task,
+        incumbents,
+        ContractNetConfig(),
+        rng=random.Random(0),
+        force_junior=True,
+    )
+    assert result.junior_reserved is False
+    assert result.invited
+    assert not all(invite.junior for invite in result.invited)
+
+
+def test_epsilon_band_over_many_auctions():
+    engine = ContractNetEngine(ContractNetConfig(epsilon=0.12, invite_k=4))
+    roster = demo_roster()
+    tasks = demo_tasks()
+    awards = engine.run_many(tasks, roster, rounds=80, seed=21)
+    reserved = sum(1 for award in awards if award.junior_reserved)
+    rate = reserved / len(awards)
+    assert 0.04 <= rate <= 0.22  # binomial noise around 0.12
+    stats = engine.stats()
+    assert stats["tokens_saved"] > 0
+    assert stats["auctions"] == 80
+
+
+def test_shading_cannot_steal_vickrey_win():
+    """Bidding above true min cannot improve the payoff versus truthful bidding."""
+    roster = demo_roster()
+    task = demo_tasks()[4]
+    honest = ContractNetEngine()
+    shaded = ContractNetEngine()
+    honest_award = honest.run(task, roster, seed=5, force_junior=False)
+    winner = honest_award.winner_id
+    assert winner
+    # Winner shades up 25% — still wins (Vickrey) or loses; never paid more profitably
+    shade_award = shaded.run(
+        task, roster, seed=5, force_junior=False, shade={winner: 1.25}
+    )
+    honest_profit = honest_award.clearing_price - honest_award.winner_bid_price
+    if shade_award.winner_id == winner:
+        shade_profit = shade_award.clearing_price - shade_award.winner_bid_price
+        assert shade_profit <= honest_profit + 1  # integer micro-AXM
+    # If they lose, profit is zero which is worse.
+
+
+def test_single_valid_bid_paid_own_price():
+    bid = SealedBid(
+        auction_id="0x" + "aa" * 32,
+        task_id="solo",
+        agent_id="moss-caretaker",
+        agent_wallet="0x" + "bb" * 20,
+        price=700_000,
+        estimated_tokens=280,
+        nonce=1,
+        deadline=9_999_999_999,
+        digest="0x" + "cc" * 32,
+        signature="0x" + "dd" * 32,
+        sig_type="eip712-hmac-sha256",
+    )
+    invite = Invite(
+        agent_id="moss-caretaker",
+        name="Moss",
+        cosine=0.5,
+        junior=True,
+        llm_invited=True,
+        reason="solo",
+    )
+    award = clear_vickrey(
+        auction_id=bid.auction_id,
+        task_id="solo",
+        bids=[bid],
+        invites=[invite],
+        junior_reserved=True,
+        llm_calls_avoided=12,
+        tokens_saved=9600,
+    )
+    assert award.winner_id == "moss-caretaker"
+    assert award.clearing_price == 700_000
+    assert award.savings_vs_first_price == 0
+
+
+def test_sort_valid_bids_tie_breaks_on_agent_id():
+    def _bid(agent_id: str) -> SealedBid:
+        return SealedBid(
+            auction_id="0x" + "11" * 32,
+            task_id="t",
+            agent_id=agent_id,
+            agent_wallet="0x" + "22" * 20,
+            price=1_000_000,
+            estimated_tokens=1,
+            nonce=1,
+            deadline=1,
+            digest="0x00",
+            signature="0x00",
+            sig_type="eip712-hmac-sha256",
+        )
+
+    ordered = sort_valid_bids([_bid("zeta"), _bid("alpha"), _bid("mu")])
+    assert [bid.agent_id for bid in ordered] == ["alpha", "mu", "zeta"]
+
+
+def test_research_task_prefers_research_agents():
+    roster = demo_roster()
+    task = demo_tasks()[0]
+    result = filter_swarm(task, roster, ContractNetConfig(), rng=random.Random(9), force_junior=False)
+    invited_ids = {row.agent_id for row in result.invited}
+    assert invited_ids & {"atlas-scout", "helix-synth", "spark-scout", "wick-analyst"}
+    assert "moss-caretaker" not in invited_ids

--- a/tests/pytest/test_contract_net.py
+++ b/tests/pytest/test_contract_net.py
@@ -14,12 +14,15 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
-if "marketplace" not in sys.modules:
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+# Isolated checkouts may lack discovery.py. Do not stub marketplace when the
+# real package is present — that would break sibling tests that import it.
+if not (ROOT / "marketplace" / "discovery.py").exists() and "marketplace" not in sys.modules:
     pkg = types.ModuleType("marketplace")
     pkg.__path__ = [str(ROOT / "marketplace")]
     sys.modules["marketplace"] = pkg
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+
 
 from marketplace.contract_net.eip712 import (  # noqa: E402
     demo_signing_secret,


### PR DESCRIPTION
## Summary

Additive Contract-Net path beside the existing first-price `BiddingEngine.run_auction`. Nothing in this PR changes first-price weights, TaskMarket award, or `/api/marketplace` routes.

1. **Two-phase heuristic filter.** Task requirements and agent skills hash into 64-d Keccak vectors. Only the top `invite_k` (3–5) agents are invited. Tokens saved = `(n − k) × 800`. Uninvited agents never draft an LLM bid.
2. **Sealed Vickrey reverse auction.** One EIP-712 signed bid per invited agent. Lowest valid price wins and is paid the second-lowest price. Dominant strategy is true minimum margin — no iterative counter-bids.
3. **ε-greedy junior reservation.** `epsilon = 0.12` (clamped 10–15%) of auctions invite only juniors (`is_junior` or `tasks_completed < 3`) with a 2× eval-token subsidy. Empty junior pool falls back to the full ranking so the market never stalls.

## EIP-712 domain (Base)

- name `SINCOR Contract-Net` / version `1`
- chainId `8453`
- verifyingContract `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac` (treasury)
- HMAC-SHA256 over the typed-data digest for the demo roster; secp256k1 via `eth_account` when a key is present

## API

`/api/contract-net/{health,roster,tasks,stats,history,auctions,simulate}`

`BiddingEngine.run_vickrey_auction` is a thin additive wrapper. `run_auction` is untouched.

## Tests

`tests/pytest/test_contract_net.py` covers keccak fixtures, invite-k band, tokens saved, Vickrey second price, HMAC round-trip, junior reservation/fallback, and that shading above true min cannot improve payoff.

## Docs

`docs/architecture/contract_net.md`