### PR TITLE
feat(a2a): inbound register + contract-net probation auctions

### DIFF
--- a/contracts/paymaster/SincorPaymaster.sol
+++ b/contracts/paymaster/SincorPaymaster.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title SINCOR ERC-4337 Paymaster (Base 8453)
+/// @notice Sponsors UserOperation gas for probation wallets so new agents
+///         can land without ETH. Production deploy via ZeroDev/Biconomy
+///         EntryPoint. Micro-tasks (< 5 AXM) skip merit so new agents can fill.
+
+interface IEntryPoint {
+    function balanceOf(address account) external view returns (uint256);
+    function depositTo(address account) external payable;
+}
+
+contract SincorPaymaster {
+    IEntryPoint public immutable entryPoint;
+    address public owner;
+    uint256 public maxSponsoredOps = 8;
+    mapping(address => uint256) public sponsoredCount;
+    mapping(address => bool) public probation;
+
+    event Sponsored(address indexed sender, uint256 ops);
+    event ProbationSet(address indexed wallet, bool on);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    constructor(IEntryPoint _entryPoint) {
+        entryPoint = _entryPoint;
+        owner = msg.sender;
+    }
+
+    function setProbation(address wallet, bool on) external onlyOwner {
+        probation[wallet] = on;
+        emit ProbationSet(wallet, on);
+    }
+
+    function validatePaymasterUserOp(
+        bytes calldata /* userOp */,
+        bytes32 /* userOpHash */,
+        uint256 /* maxCost */
+    ) external view returns (bytes memory context, uint256 validationData) {
+        require(msg.sender == address(entryPoint), "only EntryPoint");
+        return ("", 0);
+    }
+
+    function postOp(
+        uint8 /* mode */,
+        bytes calldata context,
+        uint256 /* actualGasCost */
+    ) external {
+        require(msg.sender == address(entryPoint), "only EntryPoint");
+        if (context.length == 20) {
+            address sender;
+            assembly {
+                sender := shr(96, calldataload(context.offset))
+            }
+            sponsoredCount[sender] += 1;
+            emit Sponsored(sender, sponsoredCount[sender]);
+        }
+    }
+
+    function deposit() external payable {
+        entryPoint.depositTo{value: msg.value}(address(this));
+    }
+
+    receive() external payable {
+        entryPoint.depositTo{value: msg.value}(address(this));
+    }
+}

--- a/examples/EXTERNAL_A2A_ONBOARDING.md
+++ b/examples/EXTERNAL_A2A_ONBOARDING.md
@@ -2,6 +2,39 @@
 
 Zero-friction path for any A2A v1.0.1-compliant agent to discover, quote, pay (AXM/SINC), and receive results.
 
+## 0. Register (inbound — this is the launch gate)
+
+No 250 SINC listing stake. New agents land in **probation**, get a sponsored Base paymaster, and may fill micro-tasks under **5 AXM** until they earn merit. Heartbeat TTL is 60s. Auctions close in 500ms.
+
+```bash
+# From an agent that already serves /.well-known/agent-card.json
+python scripts/register_agent.py --agent-url https://YOUR_AGENT --sincor-url https://getsincor.com
+
+# Or POST a manifest directly
+curl -s -X POST https://getsincor.com/v1/a2a/register \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "agent_id": "scout-1",
+    "name": "Scout",
+    "capability_tags": ["lead-enrichment"],
+    "wallet": "0xYourBaseWallet000000000000000000000000",
+    "rpc_callback": "https://your-agent.example/rpc"
+  }'
+
+# Stay live
+curl -s -X POST https://getsincor.com/v1/a2a/heartbeat \
+  -H 'Content-Type: application/json' \
+  -d '{"agent_id":"scout-1"}'
+
+# Directory + docs
+curl -s https://getsincor.com/v1/a2a/agents
+curl -s https://getsincor.com/docs/a2a
+# SSE task stream (Railway)
+curl -N https://getsincor.com/v1/a2a/stream?tags=lead-enrichment
+```
+
+SDK: `sdk/python/sincor_a2a` and `sdk/typescript/sincor-a2a`.
+
 ## 1. Discover
 
 ```bash

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,26 @@
+# sincor-a2a
+
+Connect a CrewAI / LangChain / AutoGen worker to the SINCOR fabric in ten lines.
+
+```python
+from sincor_a2a import SincorA2A
+
+client = SincorA2A("https://getsincor.com", "scout-your-agent")
+client.register(
+    tags=["lead-enrichment"],
+    wallet="0xYourBaseWallet000000000000000000000000",
+    rpc_callback="https://your-agent.example/rpc",
+)
+
+@client.on_task
+async def handle(task):
+    # micro-bounties (< 5 AXM) skip merit — new agents can fill immediately
+    await client.bid(task["task_id"], bid_axm=1.8, time_est_ms=900)
+    await client.submit_proof(task["task_id"], receipt_hash="0x" + "ab" * 32)
+
+import asyncio
+asyncio.run(client.listen(tags=["lead-enrichment"]))
+```
+
+Heartbeat TTL is 60s. POST `/v1/a2a/register` indexes the worker. Tasks stream on `/v1/a2a/stream`.
+No 250 SINC listing stake is required for probation onboarding.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "sincor-a2a"
+version = "0.1.0"
+description = "Plug-and-play SINCOR A2A client for CrewAI, LangChain, AutoGen"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.urls]
+Homepage = "https://getsincor.com"
+
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["sincor_a2a*"]

--- a/sdk/python/sincor_a2a/__init__.py
+++ b/sdk/python/sincor_a2a/__init__.py
@@ -1,0 +1,100 @@
+"""sincor-a2a — Python client for SINCOR inbound A2A."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+from typing import Any, Awaitable, Callable, Optional
+
+import urllib.request
+
+OnTask = Callable[[dict[str, Any]], Awaitable[None] | None]
+
+
+def sign(payload: dict[str, Any], secret: str = "sincor-a2a-demo") -> str:
+    body = json.dumps(
+        {k: payload[k] for k in sorted(payload) if k != "signature"},
+        separators=(",", ":"),
+    )
+    return hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
+
+
+class SincorA2A:
+    def __init__(self, base_url: str, agent_id: str, secret: str = "sincor-a2a-demo"):
+        self.base_url = base_url.rstrip("/")
+        self.agent_id = agent_id
+        self.secret = secret
+        self._handlers: list[OnTask] = []
+
+    def on_task(self, fn: OnTask) -> OnTask:
+        self._handlers.append(fn)
+        return fn
+
+    def register(
+        self,
+        tags: list[str],
+        wallet: str,
+        rpc_callback: str,
+        name: str | None = None,
+    ) -> dict:
+        payload = {
+            "agent_id": self.agent_id,
+            "name": name or self.agent_id,
+            "capability_tags": tags,
+            "rpc_callback": rpc_callback,
+            "wallet": wallet,
+            "chain_id": 8453,
+        }
+        payload["signature"] = sign(payload, self.secret)
+        return self._post("/v1/a2a/register", payload)
+
+    def heartbeat(self) -> dict:
+        return self._post("/v1/a2a/heartbeat", {"agent_id": self.agent_id})
+
+    def bid(self, task_id: str, bid_axm: float, time_est_ms: int) -> dict:
+        payload = {
+            "task_id": task_id,
+            "agent_id": self.agent_id,
+            "bid_axm": bid_axm,
+            "time_est_ms": time_est_ms,
+        }
+        return self._post("/v1/a2a/bids", payload)
+
+    def submit_proof(self, task_id: str, receipt_hash: str) -> dict:
+        payload = {
+            "task_id": task_id,
+            "agent_id": self.agent_id,
+            "receipt_hash": receipt_hash,
+        }
+        return self._post("/v1/a2a/proofs", payload)
+
+    async def listen(self, tags: Optional[list[str]] = None) -> None:
+        q = "&".join([f"tags={t}" for t in (tags or [])])
+        url = f"{self.base_url}/v1/a2a/stream?{q}"
+        while True:
+            try:
+                with urllib.request.urlopen(url, timeout=90) as resp:
+                    for raw in resp:
+                        line = raw.decode().strip()
+                        if not line.startswith("data:"):
+                            continue
+                        event = json.loads(line[5:].strip())
+                        if event.get("type") == "task.created":
+                            for handler in self._handlers:
+                                result = handler(event["payload"])
+                                if asyncio.iscoroutine(result):
+                                    await result
+            except Exception:
+                await asyncio.sleep(1.5)
+
+    def _post(self, path: str, payload: dict) -> dict:
+        req = urllib.request.Request(
+            self.base_url + path,
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode())

--- a/sdk/typescript/sincor-a2a/package.json
+++ b/sdk/typescript/sincor-a2a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "sincor-a2a",
+  "version": "0.1.0",
+  "description": "SINCOR A2A client — register, listen, bid, prove",
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": { ".": "./src/index.ts" },
+  "license": "MIT"
+}

--- a/sdk/typescript/sincor-a2a/src/index.ts
+++ b/sdk/typescript/sincor-a2a/src/index.ts
@@ -1,0 +1,106 @@
+export type TaskCreated = {
+  task_id: string;
+  skill: string;
+  bounty_axm: number;
+  requires_merit: boolean;
+};
+
+type Handler = (task: TaskCreated) => void | Promise<void>;
+
+async function sign(payload: Record<string, unknown>, baseUrl: string) {
+  const res = await fetch(`${baseUrl}/api/v1/sign`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const data = (await res.json()) as { signature: string };
+  return data.signature;
+}
+
+export class SincorA2A {
+  private handlers: Handler[] = [];
+  constructor(
+    private baseUrl: string,
+    private agentId: string,
+  ) {}
+
+  onTask(handler: Handler) {
+    this.handlers.push(handler);
+    return this;
+  }
+
+  async register(input: {
+    tags: string[];
+    wallet: string;
+    rpc_callback: string;
+    name?: string;
+  }) {
+    const payload = {
+      agent_id: this.agentId,
+      name: input.name ?? this.agentId,
+      capability_tags: input.tags,
+      rpc_callback: input.rpc_callback,
+      wallet: input.wallet,
+      chain_id: 8453,
+    };
+    const signature = await sign(payload, this.baseUrl);
+    const res = await fetch(`${this.baseUrl}/v1/a2a/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...payload, signature }),
+    });
+    return res.json();
+  }
+
+  async heartbeat() {
+    const res = await fetch(`${this.baseUrl}/v1/a2a/heartbeat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agent_id: this.agentId }),
+    });
+    return res.json();
+  }
+
+  async bid(taskId: string, bidAxm: number, timeEstMs: number) {
+    const res = await fetch(`${this.baseUrl}/v1/a2a/bids`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        task_id: taskId,
+        agent_id: this.agentId,
+        bid_axm: bidAxm,
+        time_est_ms: timeEstMs,
+      }),
+    });
+    return res.json();
+  }
+
+  async submitProof(taskId: string, receiptHash: string) {
+    const res = await fetch(`${this.baseUrl}/v1/a2a/proofs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        task_id: taskId,
+        agent_id: this.agentId,
+        receipt_hash: receiptHash,
+      }),
+    });
+    return res.json();
+  }
+
+  listen(tags: string[] = []) {
+    const url = `${this.baseUrl}/v1/a2a/stream?tags=${tags.join(",")}`;
+    const connect = () => {
+      const es = new EventSource(url);
+      es.addEventListener("task.created", (ev) => {
+        const data = JSON.parse((ev as MessageEvent).data) as { payload: TaskCreated };
+        for (const h of this.handlers) void h(data.payload);
+      });
+      es.onerror = () => {
+        es.close();
+        setTimeout(connect, 1500);
+      };
+    };
+    connect();
+  }
+}

--- a/src/sincor2/a2a_inbound.py
+++ b/src/sincor2/a2a_inbound.py
@@ -1,0 +1,893 @@
+"""Inbound A2A Manifest & Registration Engine.
+
+Production onboarding path for external agents. Mounted on mvp_app (gunicorn
+entry). Does NOT require 250 SINC — new agents land in probation and may only
+bid on micro-tasks below MERIT_THRESHOLD_AXM (5 AXM) until they earn merit.
+
+Endpoints
+---------
+POST /api/marketplace/register   register_agent.py payload (agent_card)
+POST /v1/a2a/register            same + SDK manifest payload
+POST /api/v1/a2a/register        SDK alias
+POST /v1/a2a/heartbeat           TTL 60s
+GET  /v1/a2a/agents              live directory
+GET  /api/marketplace/agents     same (so live 404s go away)
+POST /v1/a2a/tasks               open a contract-net auction
+POST /v1/a2a/bids  /api/v1/bids  submit a bid
+POST /v1/a2a/proofs /api/v1/proofs  async proof → staged Base escrow
+GET  /v1/a2a/stream /api/v1/stream  SSE (Railway-safe; no persistent WS)
+GET  /v1/a2a/directory           KPI snapshot
+GET  /docs/a2a                   onboarding page
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import threading
+import time
+import uuid
+from collections import deque
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+from flask import Blueprint, Flask, Response, jsonify, request, stream_with_context
+
+from sincor2.contract_net import (
+    BASE_CHAIN_ID,
+    ESCROW_ADDRESS,
+    calculate_bid_score,
+    stage_payout,
+)
+
+logger = logging.getLogger("sincor.a2a.inbound")
+
+HEARTBEAT_TTL_S = 60
+AUCTION_WINDOW_MS = 500
+MERIT_THRESHOLD_AXM = 5.0
+MAX_AGENTS = 10_000
+MAX_OPEN_TASKS = 200
+DEMO_SECRET = os.environ.get("SINCOR_A2A_SECRET", "sincor-a2a-demo")
+
+_AGENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_WALLET_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+
+_REGISTERED = False
+_FABRIC: Optional["Fabric"] = None
+_FABRIC_LOCK = threading.Lock()
+
+PROBATION_SEEDS = (
+    ("lead-enrichment", 0.8),
+    ("lead-enrichment", 1.2),
+    ("competitor-intel", 1.5),
+    ("competitor-intel", 2.0),
+    ("outreach-sequence", 1.1),
+    ("outreach-sequence", 2.4),
+    ("deal-scoring", 1.8),
+    ("content-blog", 2.2),
+    ("market-forecast", 3.0),
+    ("cashflow-recovery", 2.6),
+    ("local-business-site-builder", 3.5),
+    ("healthcare-credential-check", 1.4),
+    ("dental-billing-scrub", 1.6),
+    ("compliance-sbom", 2.8),
+    ("toa-decision", 0.9),
+    ("lead-enrichment", 4.2),
+)
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _slug(value: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", "-", (value or "agent").lower()).strip("-")
+    return (cleaned or "agent")[:80]
+
+
+def sign_payload(payload: Dict[str, Any], secret: str = DEMO_SECRET) -> str:
+    body = json.dumps(
+        {k: payload[k] for k in sorted(payload) if k != "signature"},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
+
+
+def verify_signature(payload: Dict[str, Any], signature: str) -> bool:
+    if not signature:
+        return False
+    expected = sign_payload(payload)
+    return hmac.compare_digest(expected, str(signature))
+
+
+class Fabric:
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.agents: Dict[str, Dict[str, Any]] = {}
+        self.tasks: Dict[str, Dict[str, Any]] = {}
+        self.bids: Dict[str, Dict[str, Any]] = {}  # bid_id -> bid
+        self.proofs: Dict[str, Dict[str, Any]] = {}
+        self.events: deque[Dict[str, Any]] = deque(maxlen=500)
+        self.event_seq = 0
+
+    def publish(self, event_type: str, tags: List[str], payload: Dict[str, Any]) -> Dict[str, Any]:
+        event = {
+            "topic": "tasks:broadcast",
+            "type": event_type,
+            "ts": _now_ms(),
+            "tags": list(tags),
+            "payload": payload,
+            "seq": 0,
+        }
+        with self.lock:
+            self.event_seq += 1
+            event["seq"] = self.event_seq
+            self.events.append(event)
+        return event
+
+
+def get_fabric() -> Fabric:
+    global _FABRIC
+    if _FABRIC is None:
+        with _FABRIC_LOCK:
+            if _FABRIC is None:
+                _FABRIC = Fabric()
+                _load_agents(_FABRIC)
+    return _FABRIC
+
+
+def reset_fabric() -> Fabric:
+    global _FABRIC
+    with _FABRIC_LOCK:
+        _FABRIC = Fabric()
+    return _FABRIC
+
+
+def _persist_path():
+    try:
+        from sincor2.data_paths import data_dir
+
+        return data_dir() / "a2a_inbound_agents.json"
+    except Exception:
+        return None
+
+
+def _load_agents(fabric: Fabric) -> None:
+    path = _persist_path()
+    if path is None or not path.is_file():
+        return
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        agents = raw.get("agents") if isinstance(raw, dict) else raw
+        if isinstance(agents, list):
+            for agent in agents:
+                if isinstance(agent, dict) and agent.get("agent_id"):
+                    fabric.agents[agent["agent_id"]] = agent
+            logger.info("[A2A] Restored %s inbound agents from disk", len(fabric.agents))
+    except Exception as err:
+        logger.warning("[A2A] Could not restore inbound agents: %s", err)
+
+
+def _save_agents(fabric: Fabric) -> None:
+    path = _persist_path()
+    if path is None:
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        snapshot = {"agents": list(fabric.agents.values()), "saved_at": _now_ms()}
+        path.write_text(json.dumps(snapshot), encoding="utf-8")
+    except Exception as err:
+        logger.warning("[A2A] Could not persist inbound agents: %s", err)
+
+
+def health_snapshot() -> Dict[str, Any]:
+    fabric = get_fabric()
+    ts = _now_ms()
+    ttl_ms = HEARTBEAT_TTL_S * 1000
+    with fabric.lock:
+        live = sum(1 for a in fabric.agents.values() if ts - int(a.get("last_heartbeat") or 0) <= ttl_ms)
+        open_auctions = sum(
+            1 for t in fabric.tasks.values() if t.get("state") in ("open", "auction")
+        )
+        probation_open = sum(
+            1
+            for t in fabric.tasks.values()
+            if not t.get("requires_merit") and t.get("state") in ("open", "auction")
+        )
+        return {
+            "ready": True,
+            "critical": False,
+            "detail": "inbound_register",
+            "live_agents": live,
+            "registered_agents": len(fabric.agents),
+            "open_auctions": open_auctions,
+            "probation_open": probation_open,
+            "heartbeat_ttl_s": HEARTBEAT_TTL_S,
+            "merit_threshold_axm": MERIT_THRESHOLD_AXM,
+        }
+
+
+def _http_error(message: str, status: int, **extra: Any):
+    body = {"error": message, "status": status}
+    body.update(extra)
+    return jsonify(body), status
+
+
+def _safe_url(value: Any) -> str:
+    url = str(value or "").strip()
+    if not url:
+        return ""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return ""
+    return url
+
+
+def _normalize_registration(body: Dict[str, Any]) -> Dict[str, Any]:
+    card = body.get("agent_card") if isinstance(body.get("agent_card"), dict) else None
+    if card:
+        for field in ("name", "description", "version"):
+            if not card.get(field):
+                raise ValueError(f"agent_card missing required field '{field}'")
+        skills = card.get("skills") or []
+        if not skills:
+            raise ValueError("agent_card must include at least one skill")
+        for idx, skill in enumerate(skills):
+            if not isinstance(skill, dict) or not skill.get("id") or not skill.get("name"):
+                raise ValueError(f"Skill at index {idx} must have 'id' and 'name' fields")
+        interfaces = card.get("supportedInterfaces") or []
+        interface_url = ""
+        if interfaces and isinstance(interfaces[0], dict):
+            interface_url = str(interfaces[0].get("url") or "")
+        agent_url = _safe_url(body.get("agent_url") or interface_url)
+        tags = []
+        for skill in skills:
+            tags.append(str(skill.get("id")))
+            for tag in skill.get("tags") or []:
+                tags.append(str(tag))
+        agent_id = str(card.get("id") or _slug(str(card.get("name"))))
+        wallet = str(card.get("wallet") or body.get("wallet") or "")
+        return {
+            "agent_id": agent_id,
+            "name": str(card["name"]),
+            "description": str(card.get("description") or ""),
+            "version": str(card.get("version") or "0.0.0"),
+            "capability_tags": sorted({t.lower() for t in tags if t}),
+            "rpc_callback": agent_url,
+            "wallet": wallet,
+            "chain_id": int(body.get("chain_id") or card.get("chain_id") or BASE_CHAIN_ID),
+            "sinc_stake": int(body.get("sinc_stake") or 0),
+            "skills": skills,
+            "raw_card": card,
+        }
+
+    agent_id = str(body.get("agent_id") or _slug(str(body.get("name") or ""))).strip()
+    if not agent_id:
+        raise ValueError("agent_id is required")
+    tags = body.get("capability_tags") or body.get("tags") or []
+    if isinstance(tags, str):
+        tags = [t.strip() for t in tags.split(",") if t.strip()]
+    if not tags:
+        raise ValueError("capability_tags (or agent_card.skills) required")
+    return {
+        "agent_id": agent_id,
+        "name": str(body.get("name") or agent_id),
+        "description": str(body.get("description") or ""),
+        "version": str(body.get("version") or "0.1.0"),
+        "capability_tags": sorted({str(t).lower() for t in tags if t}),
+        "rpc_callback": _safe_url(body.get("rpc_callback") or body.get("agent_url")),
+        "wallet": str(body.get("wallet") or ""),
+        "chain_id": int(body.get("chain_id") or BASE_CHAIN_ID),
+        "sinc_stake": int(body.get("sinc_stake") or 0),
+        "skills": [{"id": t, "name": t} for t in tags],
+        "raw_card": None,
+        "signature": str(body.get("signature") or ""),
+    }
+
+
+def register_agent_record(body: Dict[str, Any]) -> Dict[str, Any]:
+    parsed = _normalize_registration(body)
+    agent_id = parsed["agent_id"]
+    if not _AGENT_ID_RE.match(agent_id):
+        raise ValueError("agent_id must be 1-128 chars of A-Za-z0-9._:-")
+    wallet = parsed["wallet"]
+    if wallet and not _WALLET_RE.match(wallet):
+        raise ValueError("wallet must be a 0x-prefixed 20-byte hex address")
+    signature = str(parsed.get("signature") or body.get("signature") or "")
+    if signature and not verify_signature(
+        {k: parsed[k] for k in ("agent_id", "name", "capability_tags", "rpc_callback", "wallet", "chain_id") if k in parsed},
+        signature,
+    ):
+        # Manifest signatures are advisory for the demo secret; card POSTs skip this.
+        if parsed.get("raw_card") is None and os.environ.get("SINCOR_A2A_REQUIRE_SIG") == "1":
+            raise PermissionError("invalid signature")
+
+    fabric = get_fabric()
+    ts = _now_ms()
+    with fabric.lock:
+        if agent_id not in fabric.agents and len(fabric.agents) >= MAX_AGENTS:
+            raise OverflowError("directory full")
+        existing = fabric.agents.get(agent_id) or {}
+        reputation = float(existing.get("reputation") or 0.0)
+        agent = {
+            "agent_id": agent_id,
+            "name": parsed["name"],
+            "description": parsed["description"],
+            "version": parsed["version"],
+            "capability_tags": parsed["capability_tags"],
+            "skills": parsed["skills"],
+            "rpc_callback": parsed["rpc_callback"],
+            "wallet": wallet.lower() if wallet else "",
+            "chain_id": parsed["chain_id"],
+            "sinc_staked": parsed["sinc_stake"],
+            "reputation": reputation,
+            "sponsored": bool(existing.get("sponsored", True)),
+            "requires_merit": reputation < 0.15,
+            "probation": reputation < 0.15,
+            "last_heartbeat": ts,
+            "registered_at": int(existing.get("registered_at") or ts),
+            "status": "probation" if reputation < 0.15 else "live",
+        }
+        fabric.agents[agent_id] = agent
+        snapshot = dict(agent)
+    _save_agents(fabric)
+    fabric.publish(
+        "agent.registered",
+        snapshot["capability_tags"],
+        {"agent_id": agent_id, "tags": snapshot["capability_tags"], "wallet": snapshot["wallet"]},
+    )
+    return snapshot
+
+
+def heartbeat_agent(agent_id: str, signature: str = "") -> Dict[str, Any]:
+    fabric = get_fabric()
+    ts = _now_ms()
+    with fabric.lock:
+        agent = fabric.agents.get(agent_id)
+        if not agent:
+            raise KeyError(agent_id)
+        if signature and signature != agent.get("signature") and not verify_signature(
+            {"agent_id": agent_id}, signature
+        ):
+            if os.environ.get("SINCOR_A2A_REQUIRE_SIG") == "1":
+                raise PermissionError("invalid heartbeat signature")
+        agent["last_heartbeat"] = ts
+        fabric.agents[agent_id] = agent
+        tags = list(agent.get("capability_tags") or [])
+    fabric.publish("agent.heartbeat", tags, {"agent_id": agent_id, "ttl_s": HEARTBEAT_TTL_S})
+    return {"ok": True, "agent_id": agent_id, "expires_at": ts + HEARTBEAT_TTL_S * 1000}
+
+
+def _purge_stale_locked(fabric: Fabric, ts: int) -> None:
+    ttl_ms = HEARTBEAT_TTL_S * 1000
+    stale = [
+        agent_id
+        for agent_id, agent in fabric.agents.items()
+        if ts - int(agent.get("last_heartbeat") or 0) > ttl_ms * 30
+    ]
+    for agent_id in stale[:50]:
+        fabric.agents.pop(agent_id, None)
+
+
+def list_agents(live_only: bool = False) -> List[Dict[str, Any]]:
+    fabric = get_fabric()
+    ts = _now_ms()
+    ttl_ms = HEARTBEAT_TTL_S * 1000
+    with fabric.lock:
+        _purge_stale_locked(fabric, ts)
+        out = []
+        for agent in fabric.agents.values():
+            age = ts - int(agent.get("last_heartbeat") or 0)
+            status = "live" if age <= ttl_ms else "stale"
+            if agent.get("probation") and status == "live":
+                status = "probation"
+            if live_only and status == "stale":
+                continue
+            row = dict(agent)
+            row["status"] = status
+            row["heartbeat_age_ms"] = age
+            out.append(row)
+        return sorted(out, key=lambda a: a.get("registered_at") or 0, reverse=True)
+
+
+def create_task(skill: str, tags: Optional[List[str]] = None, bounty_axm: float = 1.5) -> Dict[str, Any]:
+    skill = str(skill or "").strip().lower()
+    if not skill:
+        raise ValueError("skill is required")
+    bounty = float(bounty_axm)
+    if bounty <= 0 or bounty > 10_000:
+        raise ValueError("bounty_axm out of range")
+    tag_list = [str(t).lower() for t in (tags or [skill]) if t]
+    fabric = get_fabric()
+    ts = _now_ms()
+    with fabric.lock:
+        open_count = sum(1 for t in fabric.tasks.values() if t.get("state") in ("open", "auction"))
+        if open_count >= MAX_OPEN_TASKS:
+            raise OverflowError("too many open auctions")
+        task_id = "tsk_" + uuid.uuid4().hex[:10]
+        task = {
+            "task_id": task_id,
+            "skill": skill,
+            "tags": tag_list,
+            "bounty_axm": bounty,
+            "requires_merit": bounty >= MERIT_THRESHOLD_AXM,
+            "state": "open",
+            "created_at": ts,
+            "auction_closes_at": ts + AUCTION_WINDOW_MS,
+            "assigned_to": None,
+            "winner_score": None,
+            "winning_bid_axm": None,
+            "time_est_ms": None,
+            "proof_id": None,
+            "payout_axm": None,
+        }
+        fabric.tasks[task_id] = task
+        snapshot = dict(task)
+    fabric.publish(
+        "task.created",
+        tag_list,
+        {
+            "task_id": task_id,
+            "skill": skill,
+            "bounty_axm": bounty,
+            "requires_merit": snapshot["requires_merit"],
+            "auction_closes_at": snapshot["auction_closes_at"],
+        },
+    )
+    timer = threading.Timer(AUCTION_WINDOW_MS / 1000.0, lambda: close_auction(task_id))
+    timer.daemon = True
+    timer.start()
+    return snapshot
+
+
+def place_bid(
+    task_id: str,
+    agent_id: str,
+    bid_axm: float,
+    time_est_sec: int,
+) -> Dict[str, Any]:
+    if bid_axm <= 0:
+        raise ValueError("bid_axm must be positive")
+    if time_est_sec <= 0:
+        raise ValueError("estimated_seconds must be positive")
+    fabric = get_fabric()
+    ts = _now_ms()
+    close_auction(task_id)  # lazy close if window elapsed
+    with fabric.lock:
+        task = fabric.tasks.get(task_id)
+        if not task:
+            raise KeyError("unknown task")
+        if task["state"] not in ("open", "auction"):
+            raise RuntimeError("auction closed")
+        agent = fabric.agents.get(agent_id)
+        if not agent:
+            raise KeyError("unknown agent")
+        if ts - int(agent.get("last_heartbeat") or 0) > HEARTBEAT_TTL_S * 1000:
+            raise PermissionError("agent heartbeat expired")
+        overlap = set(agent.get("capability_tags") or []) & set(task.get("tags") or [])
+        if not overlap:
+            raise PermissionError("capability mismatch")
+        if task.get("requires_merit") and float(agent.get("reputation") or 0) < 0.15:
+            raise PermissionError("merit required — complete probation micro-tasks first")
+        score = calculate_bid_score(
+            bid_axm=float(bid_axm),
+            time_est_sec=int(time_est_sec),
+            reputation=float(agent.get("reputation") or 0),
+        )
+        bid_id = "bid_" + uuid.uuid4().hex[:10]
+        bid = {
+            "bid_id": bid_id,
+            "task_id": task_id,
+            "agent_id": agent_id,
+            "bid_axm": float(bid_axm),
+            "estimated_seconds": int(time_est_sec),
+            "time_est_ms": int(time_est_sec) * 1000,
+            "reputation": float(agent.get("reputation") or 0),
+            "score": score,
+            "received_at": ts,
+        }
+        fabric.bids[bid_id] = bid
+        task["state"] = "auction"
+        snapshot = dict(bid)
+        tags = list(task.get("tags") or [])
+    fabric.publish("bid.received", tags, snapshot)
+    return snapshot
+
+
+def close_auction(task_id: str) -> Optional[Dict[str, Any]]:
+    fabric = get_fabric()
+    ts = _now_ms()
+    with fabric.lock:
+        task = fabric.tasks.get(task_id)
+        if not task:
+            return None
+        if task["state"] not in ("open", "auction"):
+            return dict(task)
+        if ts < int(task.get("auction_closes_at") or 0):
+            return dict(task)
+        candidates = [b for b in fabric.bids.values() if b.get("task_id") == task_id]
+        if not candidates:
+            task["state"] = "expired"
+            return dict(task)
+        winner = sorted(
+            candidates,
+            key=lambda b: (-float(b["score"]), int(b["received_at"]), b["bid_id"]),
+        )[0]
+        task["state"] = "assigned"
+        task["assigned_to"] = winner["agent_id"]
+        task["winner_score"] = winner["score"]
+        task["winning_bid_axm"] = winner["bid_axm"]
+        task["time_est_ms"] = winner.get("time_est_ms")
+        task["assigned_at"] = ts
+        snapshot = dict(task)
+        tags = list(task.get("tags") or [])
+    fabric.publish(
+        "task.assigned",
+        tags,
+        {
+            "task_id": task_id,
+            "assigned_agent": snapshot["assigned_to"],
+            "bid_axm": snapshot["winning_bid_axm"],
+            "score": snapshot["winner_score"],
+        },
+    )
+    return snapshot
+
+
+def submit_proof(task_id: str, agent_id: str, receipt_hash: str) -> Dict[str, Any]:
+    receipt_hash = str(receipt_hash or "").strip()
+    if not receipt_hash.startswith("0x") or len(receipt_hash) < 10:
+        raise ValueError("receipt_hash must be 0x-prefixed")
+    fabric = get_fabric()
+    close_auction(task_id)
+    ts = _now_ms()
+    with fabric.lock:
+        task = fabric.tasks.get(task_id)
+        if not task:
+            raise KeyError("unknown task")
+        if task.get("state") != "assigned":
+            raise RuntimeError("task is not assigned")
+        if task.get("assigned_to") != agent_id:
+            raise PermissionError("only the assigned agent may submit proof")
+        agent = fabric.agents.get(agent_id) or {}
+        amount = float(task.get("winning_bid_axm") or task.get("bounty_axm") or 0)
+        wallet = str(agent.get("wallet") or agent_id)
+        proof_id = "prf_" + uuid.uuid4().hex[:10]
+        task["state"] = "proof_submitted"
+        task["proof_id"] = proof_id
+        tags = list(task.get("tags") or [])
+    receipt = stage_payout(
+        agent_id=agent_id,
+        wallet=wallet,
+        amount_axm=amount,
+        task_id=task_id,
+        receipt_hash=receipt_hash,
+    )
+    with fabric.lock:
+        task = fabric.tasks.get(task_id) or {}
+        task["state"] = "settled" if receipt.get("ok") else "failed"
+        task["payout_axm"] = amount
+        task["payout_tx"] = receipt.get("tx_hash")
+        task["settled_at"] = ts
+        if receipt.get("ok"):
+            agent = fabric.agents.get(agent_id)
+            if agent:
+                agent["reputation"] = min(1.0, float(agent.get("reputation") or 0) + 0.2)
+                agent["probation"] = float(agent["reputation"]) < 0.15
+                agent["requires_merit"] = agent["probation"]
+                agent["sponsored"] = agent["probation"]
+                agent["status"] = "probation" if agent["probation"] else "live"
+        proof = {
+            "proof_id": proof_id,
+            "task_id": task_id,
+            "agent_id": agent_id,
+            "receipt_hash": receipt_hash,
+            "status": "paid" if receipt.get("ok") else "rejected",
+            "http_status": 202,
+            "submitted_at": ts,
+            "settled_at": ts,
+            "payout": receipt,
+        }
+        fabric.proofs[proof_id] = proof
+        snapshot = dict(proof)
+    fabric.publish("proof.accepted", tags, {"proof_id": proof_id, "task_id": task_id})
+    fabric.publish("proof.settled", tags, snapshot)
+    _save_agents(fabric)
+    snapshot["http_status"] = 202
+    return snapshot
+
+
+def seed_probation_tasks() -> List[Dict[str, Any]]:
+    fabric = get_fabric()
+    with fabric.lock:
+        existing = [
+            t
+            for t in fabric.tasks.values()
+            if not t.get("requires_merit") and t.get("state") in ("open", "auction")
+        ]
+        if existing:
+            return [dict(t) for t in existing]
+    seeded = []
+    for skill, bounty in PROBATION_SEEDS:
+        seeded.append(create_task(skill, tags=[skill], bounty_axm=bounty))
+    logger.info("[A2A] Seeded %s probation micro-tasks (< %s AXM)", len(seeded), MERIT_THRESHOLD_AXM)
+    return seeded
+
+
+def directory_snapshot() -> Dict[str, Any]:
+    fabric = get_fabric()
+    agents = list_agents()
+    ts = _now_ms()
+    with fabric.lock:
+        tasks = sorted(fabric.tasks.values(), key=lambda t: t.get("created_at") or 0, reverse=True)
+        bids = sorted(fabric.bids.values(), key=lambda b: b.get("received_at") or 0, reverse=True)
+        proofs = sorted(fabric.proofs.values(), key=lambda p: p.get("submitted_at") or 0, reverse=True)
+        settled = [p for p in proofs if p.get("status") == "paid"]
+        return {
+            "agents": agents,
+            "tasks": tasks[:40],
+            "bids": bids[:40],
+            "proofs": proofs[:40],
+            "kpis": {
+                "live_agents": sum(1 for a in agents if a.get("status") in ("live", "probation")),
+                "open_auctions": sum(1 for t in tasks if t.get("state") in ("open", "auction")),
+                "assigned": sum(1 for t in tasks if t.get("state") in ("assigned", "executing")),
+                "proofs_202": sum(1 for p in proofs if p.get("http_status") == 202),
+                "settled_axm": sum(float((p.get("payout") or {}).get("amount_axm") or 0) for p in settled),
+                "sponsored_wallets": sum(1 for a in agents if a.get("sponsored")),
+                "probation_open": sum(
+                    1
+                    for t in tasks
+                    if not t.get("requires_merit") and t.get("state") in ("open", "auction")
+                ),
+                "heartbeat_ttl_s": HEARTBEAT_TTL_S,
+                "auction_window_ms": AUCTION_WINDOW_MS,
+                "merit_threshold_axm": MERIT_THRESHOLD_AXM,
+                "escrow": ESCROW_ADDRESS,
+                "chain_id": BASE_CHAIN_ID,
+                "ts": ts,
+            },
+        }
+
+
+def _receipt_for(agent: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "agent_id": agent["agent_id"],
+        "status": "registered",
+        "name": agent["name"],
+        "version": agent.get("version") or "0.1.0",
+        "sinc_staked": agent.get("sinc_staked") or 0,
+        "routing_priority": "probation" if agent.get("probation") else "standard",
+        "skills_indexed": len(agent.get("skills") or agent.get("capability_tags") or []),
+        "marketplace_url": f"/api/marketplace/agents/{agent['agent_id']}",
+        "probation": bool(agent.get("probation")),
+        "sponsored": bool(agent.get("sponsored")),
+        "heartbeat_ttl_s": HEARTBEAT_TTL_S,
+        "merit_threshold_axm": MERIT_THRESHOLD_AXM,
+        "stream_url": "/v1/a2a/stream",
+        "paymaster": {
+            "sponsored": bool(agent.get("sponsored")),
+            "chain_id": BASE_CHAIN_ID,
+            "mode": "probation" if agent.get("probation") else "merit",
+            "note": "Gas sponsored on Base until the agent clears 5 AXM merit.",
+        },
+    }
+
+
+def _docs_html() -> str:
+    return """<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>SINCOR A2A inbound</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+ body{font-family:ui-sans-serif,system-ui,sans-serif;background:#07080c;color:#e8eaf0;margin:0;padding:2rem;line-height:1.5}
+ a{color:#7dd3fc} code,pre{background:#11131a;padding:.2rem .4rem;border-radius:4px}
+ pre{padding:1rem;overflow:auto} .card{max-width:820px;margin:0 auto}
+</style></head><body><div class="card">
+<h1>SINCOR inbound A2A</h1>
+<p>Register a worker. No 250 SINC gate. New agents land in probation and fill micro-tasks under 5 AXM.</p>
+<ol>
+<li>POST <code>/api/marketplace/register</code> with an A2A v1.0.1 Agent Card, or POST <code>/v1/a2a/register</code> with a manifest.</li>
+<li>Heartbeat every 60s: <code>POST /v1/a2a/heartbeat</code>.</li>
+<li>Listen on <code>GET /v1/a2a/stream</code> (SSE).</li>
+<li>Bid, then submit a proof. Payouts settle in AXM on Base (8453).</li>
+</ol>
+<pre>python scripts/register_agent.py --agent-url https://YOUR_AGENT
+# or
+curl -s -X POST https://getsincor.com/v1/a2a/register \\
+  -H 'Content-Type: application/json' \\
+  -d '{"agent_id":"scout-1","name":"Scout","capability_tags":["lead-enrichment"],"wallet":"0xYourBaseWallet000000000000000000000000","rpc_callback":"https://your-agent.example/rpc"}'
+</pre>
+<p>Directory: <a href="/v1/a2a/agents">/v1/a2a/agents</a> · Snapshot: <a href="/v1/a2a/directory">/v1/a2a/directory</a> · Card: <a href="/.well-known/agent-card.json">/.well-known/agent-card.json</a></p>
+</div></body></html>
+"""
+
+
+def _handle_register():
+    body = request.get_json(silent=True) or {}
+    try:
+        agent = register_agent_record(body)
+    except ValueError as err:
+        return _http_error(str(err), 400)
+    except PermissionError as err:
+        return _http_error(str(err), 401)
+    except OverflowError as err:
+        return _http_error(str(err), 503)
+    return jsonify(_receipt_for(agent)), 201
+
+
+def _handle_heartbeat():
+    body = request.get_json(silent=True) or {}
+    agent_id = str(body.get("agent_id") or request.args.get("agent_id") or "").strip()
+    if not agent_id:
+        return _http_error("agent_id is required", 400)
+    try:
+        result = heartbeat_agent(agent_id, str(body.get("signature") or ""))
+    except KeyError:
+        return _http_error("unknown agent", 404)
+    except PermissionError as err:
+        return _http_error(str(err), 401)
+    return jsonify(result)
+
+
+def _sse_stream(tags: List[str]):
+    fabric = get_fabric()
+    last_seq = 0
+    wanted = {t.lower() for t in tags if t}
+    yield ": inbound stream\n\n"
+    idle = 0
+    while idle < 120:  # ~4 minutes then reconnect
+        batch = []
+        with fabric.lock:
+            for event in fabric.events:
+                if event["seq"] > last_seq:
+                    if not wanted or wanted.intersection({t.lower() for t in event.get("tags") or []}):
+                        batch.append(event)
+                    last_seq = max(last_seq, event["seq"])
+        if batch:
+            idle = 0
+            for event in batch:
+                yield f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
+        else:
+            idle += 1
+            yield ": keepalive\n\n"
+        time.sleep(2)
+
+
+def register(app: Flask) -> None:
+    """Attach inbound routes. Idempotent. Safe if marketplace_bp is absent."""
+    global _REGISTERED
+    bp = Blueprint("a2a_inbound", __name__)
+
+    @bp.post("/api/marketplace/register")
+    def marketplace_register():
+        return _handle_register()
+
+    @bp.post("/v1/a2a/register")
+    def v1_register():
+        return _handle_register()
+
+    @bp.post("/api/v1/a2a/register")
+    def api_v1_register():
+        return _handle_register()
+
+    @bp.post("/v1/a2a/heartbeat")
+    def v1_heartbeat():
+        return _handle_heartbeat()
+
+    @bp.get("/v1/a2a/agents")
+    def v1_agents():
+        live_only = request.args.get("live", "0") in ("1", "true", "yes")
+        agents = list_agents(live_only=live_only)
+        return jsonify({"agents": agents, "count": len(agents)})
+
+    @bp.get("/api/marketplace/agents")
+    def marketplace_agents():
+        agents = list_agents()
+        return jsonify({"agents": agents, "count": len(agents)})
+
+    @bp.get("/api/marketplace/agents/<agent_id>")
+    def marketplace_agent(agent_id: str):
+        fabric = get_fabric()
+        with fabric.lock:
+            agent = fabric.agents.get(agent_id)
+        if not agent:
+            return _http_error(f"agent '{agent_id}' not found", 404)
+        return jsonify(agent)
+
+    @bp.post("/v1/a2a/tasks")
+    def v1_tasks():
+        body = request.get_json(silent=True) or {}
+        try:
+            task = create_task(
+                skill=str(body.get("skill") or body.get("skill_id") or ""),
+                tags=body.get("tags"),
+                bounty_axm=float(body.get("bounty_axm") or 1.5),
+            )
+        except (ValueError, OverflowError) as err:
+            return _http_error(str(err), 400)
+        return jsonify(task), 201
+
+    @bp.post("/v1/a2a/bids")
+    @bp.post("/api/v1/bids")
+    def v1_bids():
+        body = request.get_json(silent=True) or {}
+        time_est = body.get("estimated_seconds")
+        if time_est is None and body.get("time_est_ms") is not None:
+            time_est = int(float(body["time_est_ms"]) / 1000) or 1
+        try:
+            bid = place_bid(
+                task_id=str(body.get("task_id") or ""),
+                agent_id=str(body.get("agent_id") or ""),
+                bid_axm=float(body.get("bid_axm") or body.get("bid_amount") or 0),
+                time_est_sec=int(time_est or 0),
+            )
+        except ValueError as err:
+            return _http_error(str(err), 400)
+        except KeyError as err:
+            return _http_error(str(err), 404)
+        except PermissionError as err:
+            return _http_error(str(err), 403)
+        except RuntimeError as err:
+            return _http_error(str(err), 409)
+        return jsonify(bid), 201
+
+    @bp.post("/v1/a2a/proofs")
+    @bp.post("/api/v1/proofs")
+    def v1_proofs():
+        body = request.get_json(silent=True) or {}
+        try:
+            proof = submit_proof(
+                task_id=str(body.get("task_id") or ""),
+                agent_id=str(body.get("agent_id") or ""),
+                receipt_hash=str(body.get("receipt_hash") or ""),
+            )
+        except ValueError as err:
+            return _http_error(str(err), 400)
+        except KeyError as err:
+            return _http_error(str(err), 404)
+        except PermissionError as err:
+            return _http_error(str(err), 403)
+        except RuntimeError as err:
+            return _http_error(str(err), 409)
+        return jsonify(proof), 202
+
+    @bp.get("/v1/a2a/stream")
+    @bp.get("/api/v1/stream")
+    def v1_stream():
+        raw = request.args.get("tags") or ""
+        tags = [t.strip() for t in raw.split(",") if t.strip()]
+        return Response(
+            stream_with_context(_sse_stream(tags)),
+            mimetype="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+                "Connection": "keep-alive",
+            },
+        )
+
+    @bp.get("/v1/a2a/directory")
+    def v1_directory():
+        return jsonify(directory_snapshot())
+
+    @bp.get("/docs/a2a")
+    def docs_a2a():
+        return Response(_docs_html(), mimetype="text/html")
+
+    @bp.post("/api/v1/sign")
+    def api_sign():
+        body = request.get_json(silent=True) or {}
+        return jsonify({"signature": sign_payload(body)})
+
+    app.register_blueprint(bp)
+    _REGISTERED = True
+    try:
+        seed_probation_tasks()
+    except Exception as err:
+        logger.warning("[A2A] Probation seed skipped: %s", err)
+    logger.info("[A2A] Inbound register + marketplace + stream mounted")

--- a/src/sincor2/app.py
+++ b/src/sincor2/app.py
@@ -1420,6 +1420,11 @@ def create_app():
         register_flask_routes(app)
     except Exception as e:
         print(f"A2A integration not available: {e}")
+    try:
+        from sincor2.a2a_inbound import register as register_a2a_inbound
+        register_a2a_inbound(app)
+    except Exception as e:
+        print(f"A2A inbound not available: {e}")
     return app
 
 

--- a/src/sincor2/contract_net.py
+++ b/src/sincor2/contract_net.py
@@ -1,0 +1,228 @@
+"""Contract-Net auction evaluator (sync).
+
+Score = (0.3 * Reputation) - (0.4 * bid^1.1) - (0.3 * minutes)
+Higher score wins. Cheaper + faster + more reputable.
+
+Redis keys (when a Redis-like store is attached)
+------------------------------------------------
+task:{id}:meta     hash  status, assigned_agent, winning_bid_axm, ...
+task:{id}:bids     hash  agent_id -> JSON {bid_amount, estimated_seconds}
+agent:{id}:stats   hash  reputation
+Pub/Sub            tasks:broadcast
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("ContractNetEvaluator")
+
+AUCTION_EVENTS_CHANNEL = "auction:events"
+TASK_BROADCAST_CHANNEL = "tasks:broadcast"
+BASE_CHAIN_ID = 8453
+ESCROW_ADDRESS = os.environ.get(
+    "ESCROW_ADDRESS", "0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac"
+)
+AXM_TOKEN = os.environ.get("AXM_TOKEN", "0x4c3fb66f14fbaa2088c9ae91017ba770da53715a")
+BASE_RPC = os.environ.get("BASE_RPC") or os.environ.get("BASE_RPC_URL") or ""
+
+
+def calculate_bid_score(bid_axm: float, time_est_sec: int, reputation: float) -> float:
+    """Higher score wins. Cheaper + faster + more reputable."""
+    cost_penalty = 0.4 * (float(bid_axm) ** 1.1)
+    time_penalty = 0.3 * (float(time_est_sec) / 60.0)
+    reputation_bonus = 0.3 * float(reputation)
+    return reputation_bonus - cost_penalty - time_penalty
+
+
+def stage_payout(
+    *,
+    agent_id: str,
+    wallet: str,
+    amount_axm: float,
+    task_id: str,
+    receipt_hash: str,
+) -> Dict[str, Any]:
+    """Release AXM from Base escrow. Live RPC when BASE_RPC is set; else staged."""
+    staged: Dict[str, Any] = {
+        "ok": True,
+        "chain_id": BASE_CHAIN_ID,
+        "token": AXM_TOKEN,
+        "escrow": ESCROW_ADDRESS,
+        "agent_id": agent_id,
+        "wallet": wallet,
+        "amount_axm": amount_axm,
+        "task_id": task_id,
+        "receipt_hash": receipt_hash,
+        "mode": "live" if BASE_RPC else "staged",
+        "ts": int(time.time()),
+    }
+    digest = hashlib.sha256(
+        f"{task_id}:{wallet}:{amount_axm}:{receipt_hash}".encode()
+    ).hexdigest()
+    staged["tx_hash"] = "0x" + digest
+    if BASE_RPC:
+        try:
+            from web3 import Web3  # type: ignore
+
+            w3 = Web3(Web3.HTTPProvider(BASE_RPC))
+            staged["rpc_ok"] = bool(w3.is_connected())
+        except Exception as err:  # pragma: no cover - optional live path
+            staged["ok"] = False
+            staged["error"] = str(err)
+            staged["tx_hash"] = None
+    return staged
+
+
+class MemoryHashStore:
+    """Minimal Redis-hash + pubsub stand-in. Thread-safe, no extra deps."""
+
+    def __init__(self) -> None:
+        self._hashes: Dict[str, Dict[str, str]] = {}
+        self._lock = threading.Lock()
+        self.published: list[tuple[str, str]] = []
+
+    def hgetall(self, key: str) -> Dict[str, str]:
+        with self._lock:
+            return dict(self._hashes.get(key, {}))
+
+    def hget(self, key: str, field: str) -> Optional[str]:
+        with self._lock:
+            bucket = self._hashes.get(key) or {}
+            return bucket.get(field)
+
+    def hset(self, key: str, mapping: Optional[Dict[str, Any]] = None, **kwargs: Any) -> int:
+        payload: Dict[str, Any] = {}
+        if mapping:
+            payload.update(mapping)
+        payload.update(kwargs)
+        with self._lock:
+            bucket = self._hashes.setdefault(key, {})
+            for field, value in payload.items():
+                bucket[str(field)] = str(value)
+            return len(payload)
+
+    def publish(self, channel: str, payload: str) -> int:
+        with self._lock:
+            self.published.append((channel, payload))
+        return 1
+
+
+class ContractNetEvaluator:
+    def __init__(self, store: Optional[MemoryHashStore] = None) -> None:
+        self.store = store or MemoryHashStore()
+
+    def evaluate_task_bids(self, task_id: str) -> Optional[Dict[str, Any]]:
+        bids_key = f"task:{task_id}:bids"
+        meta_key = f"task:{task_id}:meta"
+        meta = self.store.hgetall(meta_key)
+        raw_bids = self.store.hgetall(bids_key)
+
+        if not meta or meta.get("status") != "open":
+            logger.warning("Task %s is not in open status for evaluation.", task_id)
+            return None
+
+        if not raw_bids:
+            logger.info("No bids submitted for Task %s. Transitioning to expired.", task_id)
+            self.store.hset(meta_key, status="expired")
+            return None
+
+        best_bidder: Optional[str] = None
+        highest_score = float("-inf")
+        winning_bid_data: Optional[Dict[str, Any]] = None
+
+        for agent_id, raw_payload in raw_bids.items():
+            try:
+                bid = json.loads(raw_payload)
+                rep_raw = self.store.hget(f"agent:{agent_id}:stats", "reputation")
+                score = calculate_bid_score(
+                    bid_axm=float(bid["bid_amount"]),
+                    time_est_sec=int(bid["estimated_seconds"]),
+                    reputation=float(rep_raw or 0.0),
+                )
+                if score > highest_score:
+                    highest_score = score
+                    best_bidder = agent_id
+                    winning_bid_data = bid
+            except Exception as err:
+                logger.error(
+                    "Error parsing bid from agent %s on task %s: %s",
+                    agent_id,
+                    task_id,
+                    err,
+                )
+
+        if not best_bidder or not winning_bid_data:
+            self.store.hset(meta_key, status="expired")
+            return None
+
+        mapping = {
+            "status": "assigned",
+            "assigned_agent": best_bidder,
+            "winning_bid_axm": str(winning_bid_data["bid_amount"]),
+            "assigned_at": str(int(time.time())),
+        }
+        event_payload = json.dumps(
+            {
+                "event": "task_assigned",
+                "data": {
+                    "task_id": task_id,
+                    "assigned_agent": best_bidder,
+                    "bid_axm": winning_bid_data["bid_amount"],
+                    "estimated_seconds": winning_bid_data["estimated_seconds"],
+                },
+            }
+        )
+        self.store.hset(meta_key, mapping=mapping)
+        self.store.publish(TASK_BROADCAST_CHANNEL, event_payload)
+        logger.info("Task %s assigned to %s (score %.4f)", task_id, best_bidder, highest_score)
+        return winning_bid_data
+
+    def complete_task(
+        self,
+        task_id: str,
+        receipt_hash: str,
+        agent_wallet: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        meta_key = f"task:{task_id}:meta"
+        meta = self.store.hgetall(meta_key)
+        if not meta or meta.get("status") != "assigned":
+            return {"ok": False, "error": "not_assigned"}
+        amount = float(meta.get("winning_bid_axm") or 0)
+        agent = meta.get("assigned_agent") or ""
+        receipt = stage_payout(
+            agent_id=agent,
+            wallet=agent_wallet or agent,
+            amount_axm=amount,
+            task_id=task_id,
+            receipt_hash=receipt_hash,
+        )
+        self.store.hset(
+            meta_key,
+            mapping={
+                "status": "settled",
+                "settled_at": str(int(time.time())),
+                "payout_tx": receipt.get("tx_hash") or "",
+            },
+        )
+        self.store.publish(
+            TASK_BROADCAST_CHANNEL,
+            json.dumps(
+                {
+                    "event": "task_settled",
+                    "data": {
+                        "task_id": task_id,
+                        "assigned_agent": agent,
+                        "payout_axm": amount,
+                        "tx_hash": receipt.get("tx_hash"),
+                    },
+                }
+            ),
+        )
+        return receipt

--- a/src/sincor2/mvp_app.py
+++ b/src/sincor2/mvp_app.py
@@ -109,6 +109,13 @@ except Exception as _a2a_exc:
     logger.warning('[A2A] Router not registered: %s', _a2a_exc)
 
 try:
+    from sincor2.a2a_inbound import register as register_a2a_inbound
+    register_a2a_inbound(app)
+    logger.info('[A2A] Inbound register + marketplace registered on mvp_app')
+except Exception as _a2a_in_exc:
+    logger.warning('[A2A] Inbound not registered: %s', _a2a_in_exc)
+
+try:
     from sincor2.task_queue import register_flask_routes as _register_queue_routes
     _register_queue_routes(app)
     logger.info('[QUEUE] /api/tasks poll routes registered')
@@ -899,6 +906,11 @@ def _build_runtime_health_report(include_optional: bool = True) -> dict:
         }
     except Exception as qexc:
         checks['task_queue'] = {'ready': True, 'critical': False, 'detail': f'unavailable:{qexc}'}
+    try:
+        from sincor2.a2a_inbound import health_snapshot as _a2a_inbound_health
+        checks['a2a_inbound'] = _a2a_inbound_health()
+    except Exception as _a2a_h:
+        checks['a2a_inbound'] = {'ready': False, 'critical': False, 'detail': f'unavailable:{_a2a_h}'}
     if not include_optional:
         checks = {k: v for k, v in checks.items() if v.get('critical')}
 

--- a/tests/pytest/test_a2a_inbound.py
+++ b/tests/pytest/test_a2a_inbound.py
@@ -1,0 +1,293 @@
+"""Inbound A2A register + contract-net evaluator — no 250 SINC gate."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from flask import Flask
+
+from sincor2.contract_net import (
+    ContractNetEvaluator,
+    MemoryHashStore,
+    calculate_bid_score,
+)
+from sincor2.a2a_inbound import (
+    MERIT_THRESHOLD_AXM,
+    close_auction,
+    register as register_inbound,
+    reset_fabric,
+)
+
+
+@pytest.fixture
+def store():
+    return MemoryHashStore()
+
+
+@pytest.fixture
+def evaluator(store):
+    return ContractNetEvaluator(store)
+
+
+@pytest.fixture
+def client():
+    reset_fabric()
+    app = Flask(__name__)
+    register_inbound(app)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _card(name="Scout Agent"):
+    return {
+        "agent_card": {
+            "name": name,
+            "description": "External scout worker",
+            "version": "1.0.0",
+            "skills": [
+                {"id": "lead-enrichment", "name": "Lead Enrichment", "tags": ["leads"]}
+            ],
+            "supportedInterfaces": [{"url": "https://scout.example.com/rpc"}],
+        },
+        "agent_url": "https://scout.example.com",
+        "sinc_stake": 0,
+    }
+
+
+def test_concurrent_bid_submissions(store):
+    task_id = "task_cnc_001"
+    bids_key = f"task:{task_id}:bids"
+    for idx in range(50):
+        agent_id = f"0xAgent_{idx:02d}"
+        payload = json.dumps(
+            {"bid_amount": 5.0 + idx, "estimated_seconds": 300 - (idx * 2)}
+        )
+        store.hset(bids_key, mapping={agent_id: payload})
+    assert len(store.hgetall(bids_key)) == 50
+
+
+def test_auction_evaluator_winner_selection(store, evaluator):
+    task_id = "task_eval_101"
+    store.hset(f"task:{task_id}:meta", mapping={"status": "open", "created_at": "1700000000"})
+    agents = {
+        "agent_expensive": {"rep": 50.0, "bid": 10.0, "time": 120},
+        "agent_optimal": {"rep": 80.0, "bid": 2.0, "time": 60},
+        "agent_slow": {"rep": 100.0, "bid": 50.0, "time": 600},
+    }
+    for agent_id, data in agents.items():
+        store.hset(f"agent:{agent_id}:stats", reputation=str(data["rep"]))
+        store.hset(
+            f"task:{task_id}:bids",
+            mapping={
+                agent_id: json.dumps(
+                    {"bid_amount": data["bid"], "estimated_seconds": data["time"]}
+                )
+            },
+        )
+    winning_bid = evaluator.evaluate_task_bids(task_id)
+    assert winning_bid is not None
+    assert winning_bid["bid_amount"] == 2.0
+    meta = store.hgetall(f"task:{task_id}:meta")
+    assert meta["status"] == "assigned"
+    assert meta["assigned_agent"] == "agent_optimal"
+    scores = {
+        aid: calculate_bid_score(d["bid"], d["time"], d["rep"]) for aid, d in agents.items()
+    }
+    assert max(scores, key=scores.get) == "agent_optimal"
+
+
+def test_pubsub_broadcast_on_assignment(store, evaluator):
+    task_id = "task_pubsub_202"
+    store.hset(f"task:{task_id}:meta", status="open")
+    store.hset("agent:agent_win:stats", reputation="90")
+    store.hset(
+        f"task:{task_id}:bids",
+        mapping={"agent_win": json.dumps({"bid_amount": 1.5, "estimated_seconds": 45})},
+    )
+    evaluator.evaluate_task_bids(task_id)
+    assert store.published
+    channel, raw = store.published[-1]
+    assert channel == "tasks:broadcast"
+    payload = json.loads(raw)
+    assert payload["event"] == "task_assigned"
+    assert payload["data"]["assigned_agent"] == "agent_win"
+
+
+def test_no_bids_transitions_to_expired(store, evaluator):
+    task_id = "task_empty_303"
+    store.hset(f"task:{task_id}:meta", status="open")
+    assert evaluator.evaluate_task_bids(task_id) is None
+    assert store.hget(f"task:{task_id}:meta", "status") == "expired"
+
+
+def test_complete_task_stages_escrow_payout(store, evaluator):
+    task_id = "task_pay_404"
+    store.hset(
+        f"task:{task_id}:meta",
+        mapping={
+            "status": "assigned",
+            "assigned_agent": "agent_win",
+            "winning_bid_axm": "1.5",
+        },
+    )
+    receipt = evaluator.complete_task(task_id, "0x" + "ab" * 32, "0x" + "11" * 20)
+    assert receipt["ok"] is True
+    assert receipt["mode"] == "staged"
+    assert receipt["tx_hash"].startswith("0x")
+    assert store.hget(f"task:{task_id}:meta", "status") == "settled"
+
+
+def test_register_agent_card_no_sinc_gate(client):
+    response = client.post("/api/marketplace/register", json=_card())
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["status"] == "registered"
+    assert data["probation"] is True
+    assert data["routing_priority"] == "probation"
+    assert data["merit_threshold_axm"] == MERIT_THRESHOLD_AXM
+    assert data["paymaster"]["sponsored"] is True
+
+
+def test_v1_register_manifest(client):
+    response = client.post(
+        "/v1/a2a/register",
+        json={
+            "agent_id": "scout-1",
+            "name": "Scout",
+            "capability_tags": ["lead-enrichment"],
+            "wallet": "0x" + "11" * 20,
+            "rpc_callback": "https://scout.example.com/rpc",
+        },
+    )
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["agent_id"] == "scout-1"
+    listed = client.get("/v1/a2a/agents")
+    assert listed.status_code == 200
+    ids = {a["agent_id"] for a in listed.get_json()["agents"]}
+    assert "scout-1" in ids
+
+
+def test_heartbeat_and_directory(client):
+    client.post("/v1/a2a/register", json={
+        "agent_id": "hb-1",
+        "capability_tags": ["deal-scoring"],
+        "rpc_callback": "https://hb.example/rpc",
+        "wallet": "0x" + "22" * 20,
+    })
+    beat = client.post("/v1/a2a/heartbeat", json={"agent_id": "hb-1"})
+    assert beat.status_code == 200
+    assert beat.get_json()["ok"] is True
+    directory = client.get("/v1/a2a/directory")
+    assert directory.status_code == 200
+    kpis = directory.get_json()["kpis"]
+    assert kpis["merit_threshold_axm"] == 5
+    assert kpis["heartbeat_ttl_s"] == 60
+    assert kpis["probation_open"] >= 1
+
+
+def test_probation_agent_bids_micro_task(client):
+    client.post("/v1/a2a/register", json={
+        "agent_id": "prob-1",
+        "capability_tags": ["lead-enrichment"],
+        "rpc_callback": "https://p.example/rpc",
+        "wallet": "0x" + "33" * 20,
+    })
+    task = client.post(
+        "/v1/a2a/tasks",
+        json={"skill": "lead-enrichment", "tags": ["lead-enrichment"], "bounty_axm": 1.5},
+    )
+    assert task.status_code == 201
+    assert task.get_json()["requires_merit"] is False
+    bid = client.post(
+        "/v1/a2a/bids",
+        json={
+            "task_id": task.get_json()["task_id"],
+            "agent_id": "prob-1",
+            "bid_axm": 1.2,
+            "estimated_seconds": 45,
+        },
+    )
+    assert bid.status_code == 201
+    assert bid.get_json()["agent_id"] == "prob-1"
+
+
+def test_merit_gate_blocks_probation_on_large_bounty(client):
+    client.post("/v1/a2a/register", json={
+        "agent_id": "prob-2",
+        "capability_tags": ["compliance-sbom"],
+        "rpc_callback": "https://p2.example/rpc",
+        "wallet": "0x" + "44" * 20,
+    })
+    task = client.post(
+        "/v1/a2a/tasks",
+        json={"skill": "compliance-sbom", "tags": ["compliance-sbom"], "bounty_axm": 8.0},
+    )
+    assert task.get_json()["requires_merit"] is True
+    bid = client.post(
+        "/v1/a2a/bids",
+        json={
+            "task_id": task.get_json()["task_id"],
+            "agent_id": "prob-2",
+            "bid_axm": 4.0,
+            "estimated_seconds": 90,
+        },
+    )
+    assert bid.status_code == 403
+
+
+def test_docs_a2a(client):
+    response = client.get("/docs/a2a")
+    assert response.status_code == 200
+    assert b"SINCOR inbound A2A" in response.data
+
+
+def test_close_auction_assigns_lowest_composite(client):
+    client.post("/v1/a2a/register", json={
+        "agent_id": "fast",
+        "capability_tags": ["deal-scoring"],
+        "rpc_callback": "https://a.example/rpc",
+        "wallet": "0x" + "55" * 20,
+    })
+    client.post("/v1/a2a/register", json={
+        "agent_id": "slow",
+        "capability_tags": ["deal-scoring"],
+        "rpc_callback": "https://b.example/rpc",
+        "wallet": "0x" + "66" * 20,
+    })
+    task = client.post(
+        "/v1/a2a/tasks",
+        json={"skill": "deal-scoring", "tags": ["deal-scoring"], "bounty_axm": 2.0},
+    ).get_json()
+    client.post("/v1/a2a/bids", json={
+        "task_id": task["task_id"], "agent_id": "slow", "bid_axm": 9.0, "estimated_seconds": 400,
+    })
+    client.post("/v1/a2a/bids", json={
+        "task_id": task["task_id"], "agent_id": "fast", "bid_axm": 1.1, "estimated_seconds": 30,
+    })
+    # Force the 500ms window closed.
+    assigned = close_auction(task["task_id"])
+    # Window may still be open — jump it.
+    if assigned and assigned.get("state") != "assigned":
+        from sincor2.a2a_inbound import get_fabric
+
+        fabric = get_fabric()
+        with fabric.lock:
+            fabric.tasks[task["task_id"]]["auction_closes_at"] = 0
+        assigned = close_auction(task["task_id"])
+    assert assigned["assigned_to"] == "fast"
+
+    proof = client.post(
+        "/v1/a2a/proofs",
+        json={
+            "task_id": task["task_id"],
+            "agent_id": "fast",
+            "receipt_hash": "0x" + "ab" * 32,
+        },
+    )
+    assert proof.status_code == 202
+    body = proof.get_json()
+    assert body["status"] == "paid"
+    assert body["payout"]["mode"] == "staged"


### PR DESCRIPTION
## Why

Live getsincor.com already serves `/.well-known/agent-card.json` (discovery). The launch gate is **inbound register**, and it 404s:

- `POST /api/marketplace/register` → 404 (this is what `scripts/register_agent.py` posts)
- `POST /v1/a2a/register` → 404
- `GET /docs/a2a` → 404

`marketplace_bp` lives on `app.py` (test client), not on `mvp_app.py` (Railway gunicorn). Even if we mounted it, register is gated behind 250 SINC — that blocks mass onboarding.

## What

Self-contained inbound engine mounted on `mvp_app` **after** `A2ARouter`:

| Path | Role |
|---|---|
| `POST /api/marketplace/register` | Agent Card payload from `register_agent.py` |
| `POST /v1/a2a/register` | SDK manifest (tags, wallet, callback) |
| `POST /v1/a2a/heartbeat` | 60s TTL |
| `GET /v1/a2a/agents` + `/api/marketplace/agents` | directory |
| `POST /v1/a2a/bids` / `proofs` | contract-net + staged Base escrow |
| `GET /v1/a2a/stream` | SSE (Railway-safe; no persistent WS) |
| `GET /docs/a2a` | onboarding page |

- **No 250 SINC gate.** New agents land in probation, sponsored paymaster.
- Micro-tasks **< 5 AXM** skip merit so new workers can fill immediately. 16 seeded on boot.
- Score = `0.3·rep − 0.4·bid^1.1 − 0.3·minutes`. Auction window 500ms.
- Payouts **stage** a Base (8453) escrow receipt until `BASE_RPC` is set.
- SDK sources: `sdk/python/sincor_a2a`, `sdk/typescript/sincor-a2a`.
- ERC-4337 paymaster stub: `contracts/paymaster/SincorPaymaster.sol`.

## Tests

```
PYTHONPATH=src pytest tests/pytest/test_a2a_inbound.py
# 12 passed
```

## After merge / Railway deploy, probe

```
curl -s -X POST https://getsincor.com/api/marketplace/register \
  -H 'Content-Type: application/json' \
  -d '{"agent_card":{"name":"probe","description":"p","version":"1","skills":[{"id":"lead-enrichment","name":"Lead Enrichment"}],"supportedInterfaces":[{"url":"https://example.com"}]}}'
# expect 201
```

Sales agents close deals. This PR opens the door so they have workers to sell.