### PR TITLE
fix(a2a): keep probation tasks open until the first bid

### DIFF
--- a/src/sincor2/a2a_inbound.py
+++ b/src/sincor2/a2a_inbound.py
@@ -418,7 +418,8 @@ def create_task(skill: str, tags: Optional[List[str]] = None, bounty_axm: float 
             "requires_merit": bounty >= MERIT_THRESHOLD_AXM,
             "state": "open",
             "created_at": ts,
-            "auction_closes_at": ts + AUCTION_WINDOW_MS,
+            # Stay open until the first bid, then a 500ms clearing window.
+            "auction_closes_at": None,
             "assigned_to": None,
             "winner_score": None,
             "winning_bid_axm": None,
@@ -439,9 +440,6 @@ def create_task(skill: str, tags: Optional[List[str]] = None, bounty_axm: float 
             "auction_closes_at": snapshot["auction_closes_at"],
         },
     )
-    timer = threading.Timer(AUCTION_WINDOW_MS / 1000.0, lambda: close_auction(task_id))
-    timer.daemon = True
-    timer.start()
     return snapshot
 
 
@@ -493,9 +491,18 @@ def place_bid(
         }
         fabric.bids[bid_id] = bid
         task["state"] = "auction"
+        if task.get("auction_closes_at") is None:
+            task["auction_closes_at"] = ts + AUCTION_WINDOW_MS
+            start_timer = True
+        else:
+            start_timer = False
         snapshot = dict(bid)
         tags = list(task.get("tags") or [])
     fabric.publish("bid.received", tags, snapshot)
+    if start_timer:
+        timer = threading.Timer(AUCTION_WINDOW_MS / 1000.0, lambda: close_auction(task_id))
+        timer.daemon = True
+        timer.start()
     return snapshot
 
 
@@ -508,7 +515,10 @@ def close_auction(task_id: str) -> Optional[Dict[str, Any]]:
             return None
         if task["state"] not in ("open", "auction"):
             return dict(task)
-        if ts < int(task.get("auction_closes_at") or 0):
+        closes_at = task.get("auction_closes_at")
+        if closes_at is None:
+            return dict(task)
+        if ts < int(closes_at):
             return dict(task)
         candidates = [b for b in fabric.bids.values() if b.get("task_id") == task_id]
         if not candidates:

--- a/tests/pytest/test_a2a_inbound.py
+++ b/tests/pytest/test_a2a_inbound.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import time
 
 import pytest
 from flask import Flask
@@ -244,6 +243,14 @@ def test_docs_a2a(client):
     assert b"SINCOR inbound A2A" in response.data
 
 
+def test_seeded_tasks_stay_open_until_first_bid(client):
+    directory = client.get("/v1/a2a/directory").get_json()
+    assert directory["kpis"]["probation_open"] >= 16
+    open_tasks = [t for t in directory["tasks"] if t["state"] == "open"]
+    assert open_tasks
+    assert all(t.get("auction_closes_at") is None for t in open_tasks)
+
+
 def test_close_auction_assigns_lowest_composite(client):
     client.post("/v1/a2a/register", json={
         "agent_id": "fast",
@@ -267,9 +274,7 @@ def test_close_auction_assigns_lowest_composite(client):
     client.post("/v1/a2a/bids", json={
         "task_id": task["task_id"], "agent_id": "fast", "bid_axm": 1.1, "estimated_seconds": 30,
     })
-    # Force the 500ms window closed.
     assigned = close_auction(task["task_id"])
-    # Window may still be open — jump it.
     if assigned and assigned.get("state") != "assigned":
         from sincor2.a2a_inbound import get_fabric
 


### PR DESCRIPTION
Follow-up to #190. Seeded <5 AXM micro-tasks were expiring in 500ms with an empty roster, so `/health` showed `probation_open: 0` right after deploy.

Tasks now stay `open` until the first bid, then the 500ms contract-net window starts. 13 tests pass.