### PR TITLE
P0-4/5/6 evidence: live A2A+dashboard, forge build/test + Slither medium-clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,9 +99,10 @@ Thumbs.db
 .next/
 out/
 
-# ============================================================================
-# Temporary Files
-# ============================================================================
+# Foundry 1.8 solar preprocessor (must never be committed)
+foundry-pp/
+onchain/foundry-pp/
+
 *.tmp
 *.temp
 *.bak

--- a/docs/A2A_PRODUCTION_CHECKLIST.md
+++ b/docs/A2A_PRODUCTION_CHECKLIST.md
@@ -1,0 +1,53 @@
+# A2A production checklist
+
+Live platform: `https://getsincor.com`  
+Gunicorn entry: `sincor2.mvp_app:app`  
+Wiring: `register_a2a(app)` in `src/sincor2/a2a_bootstrap.py` (idempotent; owns discovery).
+
+## Canonical addresses (do not substitute)
+
+| Role | Address |
+|---|---|
+| AXM (sole new settlement) | `0x4c3fb66f14fbaa2088c9ae91017ba770da53715a` |
+| Treasury | `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac` |
+| SINC (8-dec residual) | `0xe1D836087F6573b665d25CE088793E916D7892f8` |
+
+**Stale — never use:** `0xfF7aF6ffca25A9DC0FC990d998AcF24Cc60b7822` (dead PumpClawToken).
+
+## Discovery smoke (must be 200)
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' https://getsincor.com/.well-known/agent-card.json
+curl -sS -o /dev/null -w '%{http_code}\n' https://getsincor.com/.well-known/agent.json
+curl -sS -o /dev/null -w '%{http_code}\n' https://getsincor.com/api/a2a/agents
+curl -sS https://getsincor.com/api/a2a/quote?skill_id=lead-enrichment
+```
+
+Verified 2026-08-29 ~13:05 UTC: all four **200**. Quote `axiom_contract` = canonical AXM.
+
+Unknown skill: `/api/a2a/quote` without `skill_id` must not 404 (JSON-RPC / 400 is acceptable).
+
+## Railway env (required)
+
+```
+A2A_PRIMARY_TOKEN=AXIOM
+AXIOM_CONTRACT_ADDRESS=0x4c3fb66f14fbaa2088c9ae91017ba770da53715a
+TREASURY_ADDRESS=0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac
+PLATFORM_URL=https://getsincor.com
+BASE_RPC_URL=
+A2A_TASK_STORE=redis
+REDIS_URL=
+```
+
+Never set `EXECUTE_LIVE=1` in committed files.
+
+## Do not list on external A2A directories until
+
+1. Discovery 200 (done).
+2. Quote exposes `treasury_fee_split` / `platform_fee_*` (P0-2, still open — #188 / #139).
+3. Settlement success records `record_platform_fee_inflow(..., projected=False, tx_hash=...)`.
+4. Non-AXM quotes rejected on the canonical contract.
+
+## External caller
+
+`examples/external_agent_registration.sh` and `examples/EXTERNAL_A2A_ONBOARDING.md`.

--- a/onchain/foundry.lock
+++ b/onchain/foundry.lock
@@ -1,0 +1,26 @@
+{
+  "lib/forge-std": {
+    "tag": {
+      "name": "v1.9.7",
+      "rev": "77041d2ce690e692d6e03cc812b57d1ddaa4d505"
+    }
+  },
+  "lib/openzeppelin-contracts": {
+    "tag": {
+      "name": "v5.5.0",
+      "rev": "fcbae5394ae8ad52d8e580a3477db99814b9d565"
+    }
+  },
+  "lib/permit2": {
+    "rev": "cc56ad0f3439c502c246fc5cfcc3db92bb8b7219"
+  },
+  "lib/uniswap-hooks": {
+    "rev": "26dc8e53f812a1ca390d470342adb6cd8c3286ad"
+  },
+  "lib/v4-core": {
+    "rev": "d153b048868a60c2403a3ef5b2301bb247884d46"
+  },
+  "lib/v4-periphery": {
+    "rev": "7ebd04b161745b75ed0c24ba2df3bc7c25f65606"
+  }
+}

--- a/onchain/foundry.toml
+++ b/onchain/foundry.toml
@@ -11,6 +11,9 @@ via_ir = true
 evm_version = "cancun"
 gas_reports = ["SincBondingCurve", "SincLimitOrderHook", "SincGenesisNFT"]
 fs_permissions = [{ access = "read-write", path = "./deployments" }]
+# Foundry 1.8 solar preprocessor (dynamic test linking) emits virtual
+# foundry-pp/* sources that crytic-compile 0.4.2 / Slither 0.11.6 cannot parse.
+dynamic_test_linking = false
 
 [fuzz]
 runs = 1000

--- a/onchain/src/fluid/SincFluidAdapter.sol
+++ b/onchain/src/fluid/SincFluidAdapter.sol
@@ -221,9 +221,12 @@ contract SincFluidAdapter is ReentrancyGuard, Pausable {
     {
         address v = smartVault;
         if (v == address(0)) revert VaultNotSet();
-        (nftIdOut,,) = IFluidVaultT1(v).operate(nftId, newCol, newDebt, to == address(0) ? treasury : to);
+        int256 colOut;
+        int256 debtOut;
+        (nftIdOut, colOut, debtOut) =
+            IFluidVaultT1(v).operate(nftId, newCol, newDebt, to == address(0) ? treasury : to);
         if (nftId == 0) lastNftId = nftIdOut;
-        emit VaultOperated(v, nftIdOut, newCol, newDebt, to);
+        emit VaultOperated(v, nftIdOut, colOut, debtOut, to);
     }
 
     /// @notice Forward a deployDex request. WILL REVERT until Fluid governance grants

--- a/onchain/src/morpho/SincChainlinkOracle.sol
+++ b/onchain/src/morpho/SincChainlinkOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.26;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
@@ -61,9 +61,10 @@ contract SincChainlinkOracle is Ownable, Pausable, IOracle {
                 : _manualPrice;
         }
 
-        (, int256 answer,, uint256 updatedAt, uint80 answeredInRound) = feed.latestRoundData();
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            feed.latestRoundData();
         if (answer <= 0) revert InvalidPrice();
-        if (answeredInRound == 0) revert InvalidRound();
+        if (startedAt == 0 || answeredInRound == 0 || answeredInRound < roundId) revert InvalidRound();
         if (block.timestamp - updatedAt > maxStaleness) revert StalePrice();
 
         uint256 raw = uint256(answer);
@@ -90,8 +91,8 @@ contract SincChainlinkOracle is Ownable, Pausable, IOracle {
     /// @notice Manual price update (Morpho-scaled). Only usable while useManual = true.
     /// @param newPrice Morpho-scaled value (e.g. 1.5e34 for $1.50)
     function updateManualPrice(uint256 newPrice) external onlyOwner whenNotPaused {
-        uint256 floorScaled = PRICE_FLOOR_8DEC * SCALE_FACTOR;
-        if (newPrice < floorScaled) revert PriceBelowFloor();
+        uint256 floorScaledValue = PRICE_FLOOR_8DEC * SCALE_FACTOR;
+        if (newPrice < floorScaledValue) revert PriceBelowFloor();
         _manualPrice = newPrice;
         _manualTimestamp = block.timestamp;
         emit PriceUpdated(newPrice, block.timestamp);

--- a/onchain/src/morpho/SincMorphoSetup.sol
+++ b/onchain/src/morpho/SincMorphoSetup.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.26;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -41,7 +41,7 @@ contract SincMorphoSetup is Ownable {
     }
 
     /// @notice Create a Morpho market with SINC as collateral
-    function createMarket(address loanToken, address irm, uint256 lltv) external onlyOwner returns (bytes32 marketId) {
+    function createMarket(address loanToken, address irm, uint256 lltv) public onlyOwner returns (bytes32 marketId) {
         IMorpho.MarketParams memory params = IMorpho.MarketParams({
             loanToken: loanToken,
             collateralToken: address(SINC),

--- a/onchain/src/morpho/SincStaking.sol
+++ b/onchain/src/morpho/SincStaking.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.26;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/onchain/test/SincFluidAdapter.t.sol
+++ b/onchain/test/SincFluidAdapter.t.sol
@@ -103,6 +103,8 @@ contract SincFluidAdapterTest is Test {
     }
 
     function testFuzz_supplyDex(uint64 sincAmt, uint64 usdcAmt) public {
+        sincAmt = uint64(bound(sincAmt, 0, 1_000_000e8));
+        usdcAmt = uint64(bound(usdcAmt, 0, 1_000_000e6));
         vm.assume(sincAmt > 0 || usdcAmt > 0);
         vm.startPrank(user);
         uint256 shares = adapter.supplyToDex(sincAmt, usdcAmt, 0);

--- a/scripts/onchain_hygiene.sh
+++ b/scripts/onchain_hygiene.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # P0-6: local on-chain compile/test + Slither. Never sets EXECUTE_LIVE.
 # GitHub Actions billing is locked (ci.yml / onchain-ci.yml stay workflow_dispatch).
-# Run this on a machine with Foundry. Exits 0 if tools are missing (signal, not theater).
+# Missing tools → skip that step with a signal, not a fake green.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT/onchain"
@@ -11,23 +11,65 @@ if ! command -v forge >/dev/null 2>&1; then
   exit 0
 fi
 
-if [ ! -d lib/forge-std ] && [ ! -d lib/v4-core ]; then
-  echo "onchain/lib not vendored — attempting pinned forge install"
-  forge install foundry-rs/forge-std@v1.9.7 --no-commit || true
-  forge install OpenZeppelin/openzeppelin-contracts@v5.5.0 --no-commit || true
+install_pinned() {
+  # Exact pins from DEPLOYING.md / .github/workflows/onchain-ci.yml
+  forge install foundry-rs/forge-std@v1.9.7 --no-commit
+  forge install OpenZeppelin/openzeppelin-contracts@v5.5.0 --no-commit
+  forge install Uniswap/v4-core@d153b048868a60c2403a3ef5b2301bb247884d46 --no-commit
+  forge install Uniswap/v4-periphery@7ebd04b161745b75ed0c24ba2df3bc7c25f65606 --no-commit
+  forge install Uniswap/permit2@cc56ad0f3439c502c246fc5cfcc3db92bb8b7219 --no-commit
+  forge install OpenZeppelin/uniswap-hooks@26dc8e53f812a1ca390d470342adb6cd8c3286ad --no-commit
+}
+
+if [ ! -d lib/forge-std ] || [ ! -d lib/v4-core ] || [ ! -d lib/openzeppelin-contracts ]; then
+  echo "onchain/lib incomplete — installing pinned Foundry deps"
+  install_pinned
 fi
+
+export BASE_RPC_URL="${BASE_RPC_URL:-https://base-rpc.publicnode.com}"
 
 echo "== forge build =="
 forge build --sizes
 
-echo "== forge test (no IntegrationTest) =="
-forge test -vvv --no-match-contract IntegrationTest
+echo "== forge test unit =="
+# Graduation + LimitOrderHook suites fork Base in setUp even without "Fork" in the name.
+# Invariant + IntegrationTest + *Fork* are opt-in (need RPC / longer runtime).
+forge test -vvv \
+  --no-match-contract "ForkTest|Fork|IntegrationTest|GraduationTest|SincLimitOrderHookTest|SincLimitOrderHookAntiSandwichTest" \
+  --no-match-path "test/invariant/*"
 
-if command -v slither >/dev/null 2>&1; then
-  echo "== slither =="
-  slither . --config-file slither.config.json
-else
+if ! command -v slither >/dev/null 2>&1; then
   echo "slither not installed — skip (pip install slither-analyzer)"
+  echo "onchain hygiene OK (forge only)"
+  exit 0
 fi
+
+echo "== slither (Foundry 1.8 build-info shim) =="
+# crytic-compile 0.4.2 expects Hardhat-style *.output.json with an "output" key.
+# Foundry 1.8 also writes a small index JSON without "output" — drop it.
+# dynamic_test_linking must stay false in foundry.toml or foundry-pp/* virtual
+# sources appear and Slither 0.11.6 cannot parse them.
+forge build --build-info --deny never --skip ./test/** ./script/** --force
+python3 - <<'PY'
+import json
+from pathlib import Path
+bi = Path("out/build-info")
+if not bi.is_dir():
+    raise SystemExit("no out/build-info after forge build --build-info")
+for p in list(bi.iterdir()):
+    if not p.name.endswith(".json"):
+        continue
+    if p.name.endswith(".output.json"):
+        p.unlink()
+        continue
+    data = json.loads(p.read_text())
+    if "output" not in data:
+        p.unlink()
+        continue
+    dest = p.with_name(p.stem + ".output.json")
+    dest.write_bytes(p.read_bytes())
+print("slither build-info shim ready")
+PY
+slither . --config-file slither.config.json --ignore-compile
 
 echo "onchain hygiene OK"

--- a/tests/pytest/test_mvp_p0_456.py
+++ b/tests/pytest/test_mvp_p0_456.py
@@ -116,6 +116,32 @@ def test_dashboard_paid_no_fabricated_metrics(mvp_client):
     assert "—" in html
 
 
+def test_legacy_mock_dashboards_not_on_mvp_app(mvp_client):
+    """gunicorn sincor2.mvp_app:app must not serve app.py mock telemetry dashboards."""
+    for path in ("/professional", "/executive", "/admin-dashboard", "/consciousness-transfer"):
+        r = mvp_client.get(path, follow_redirects=False)
+        assert r.status_code == 404, path
+
+
+def test_a2a_quote_canonical_axm(mvp_client):
+    r = mvp_client.get("/api/a2a/quote?skill_id=lead-enrichment")
+    assert r.status_code == 200
+    data = r.get_json()
+    axm = (data.get("axiom_contract") or data.get("axm_contract") or "").lower()
+    assert axm == "0x4c3fb66f14fbaa2088c9ae91017ba770da53715a"
+
+
+def test_morpho_pragma_matches_pinned_solc():
+    """Morpho sources must compile under foundry.toml solc 0.8.26 (not ^0.8.28)."""
+    morpho = ROOT / "onchain" / "src" / "morpho"
+    bad = []
+    for path in morpho.glob("*.sol"):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if "pragma solidity ^0.8.28" in text or "pragma solidity 0.8.28" in text:
+            bad.append(path.name)
+    assert not bad, f"morpho pragma 0.8.28 (foundry pins 0.8.26): {bad}"
+
+
 def test_execute_live_not_hardcoded_true():
     """Committed Python must never force EXECUTE_LIVE on (env-gated only)."""
     assign = re.compile(r"""(?:^|\n)\s*EXECUTE_LIVE\s*=\s*(True|1)\s*(?:#|$)""")


### PR DESCRIPTION
## P0 4 / 5 / 6 — closed with evidence (2026-08-29)

Primary KPI remains realized Treasury inflow to `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac`. This PR does not broadcast live txs. `EXECUTE_LIVE` stays env-gated.

### 4 — A2A discovery LIVE
getsincor.com (Railway) this cycle:
| Endpoint | Status |
|---|---|
| `GET /.well-known/agent-card.json` | **200** |
| `GET /.well-known/agent.json` | **200** |
| `GET /api/a2a/agents` | **200** |
| `GET /api/a2a/quote?skill_id=lead-enrichment` | **200** (`axiom_contract=0x4c3fb66f14fbaa2088c9ae91017ba770da53715a`) |

Wiring landed in #196. Stale #159 closed (wrong AXM `0xfF7aF6…`). Checklist: `docs/A2A_PRODUCTION_CHECKLIST.md`.

### 5 — Dashboard LIVE
- `GET /dashboard` → **302** `/login?next=/dashboard`
- Unpaid session → `/buy?reason=no_active_subscription`
- Paid view: real DB or explicit None. No 47/156/1247 sample telemetry.
- Dead mock `/professional` `/executive` `/admin-dashboard` **404** on `mvp_app`.

### 6 — forge + Slither (this PR)
Blockers that actually failed compile/test, now fixed:
- Morpho `pragma ^0.8.28` vs pinned solc **0.8.26**
- `SincMorphoSetup.createMarket` was `external` (internal call from `createSincUsdcMarket` undeclared)
- `testFuzz_supplyDex` unbounded vs minted balances
- Foundry 1.8 `dynamic_test_linking` emitted `foundry-pp/*` that Slither 0.11.6 / crytic-compile 0.4.2 cannot parse → **disabled**
- Hygiene script: Foundry 1.8 `*.output.json` shim

**Verified this cycle (Foundry 1.8.1, solc 0.8.26, Slither 0.11.6):**
```
forge build --sizes                          # OK
forge test (unit, no fork/invariant)         # 109 passed / 0 failed
slither . --config-file slither.config.json  # fail_on medium → exit 0
PYTHONPATH=src pytest tests/pytest/test_mvp_p0_456.py tests/pytest/test_a2a_smoke.py
# 28 passed
```

GitHub Actions billing still locked — `onchain-ci.yml` stays `workflow_dispatch`. Local `scripts/onchain_hygiene.sh` is the auditor gate until minutes are restored.

Supersedes compile-fix drafts #103 / #121 / #125. Related: #192 #196 #159 #132.