### PR TITLE
Fix operator dashboard Quick Actions 404s

### DIFF
--- a/src/sincor2/mvp_app.py
+++ b/src/sincor2/mvp_app.py
@@ -866,6 +866,10 @@ PRODUCT_CATALOG = {
         'type': 'subscription', 'agents': 42,
         'features': ['All 42 AI Agents', 'Dedicated success manager', '24/7 priority support', 'White-label options', 'Custom integrations']
     },
+    'Operator': {
+        'type': 'internal', 'agents': 42,
+        'features': ['Full swarm', 'Command center', 'Training vault', 'Operator console']
+    },
     'Business Intelligence Report': {
         'type': 'bi_report', 'pages': 20, 'delivery_days': 2,
         'sections': ['Executive Summary', 'Revenue Analysis', 'Growth Opportunities', 'Competitive Positioning', 'Recommendations']

--- a/src/sincor2/mvp_blueprints/billing.py
+++ b/src/sincor2/mvp_blueprints/billing.py
@@ -555,53 +555,55 @@ def admin_training_vault():
     """
     Render the training vault dashboard for logged-in customers.
     Shows tier-specific guides, videos, industry guides, and onboarding progress.
-    SECURITY: Requires a valid order token (order_id tied to email) or admin JWT.
-    Email alone is NOT sufficient � prevents trivial enumeration access.
+    SECURITY: Requires a valid order token (order_id tied to email) or an admin session.
+    Email alone is NOT sufficient — prevents trivial enumeration access.
     """
-    # Admin JWT bypass
-    if _check_admin_token(request):
-        customer_email = request.args.get('email') or request.args.get('customer_email')
-        if not customer_email or not validate_email(customer_email):
-            return render_template('error.html', code=400, title='Bad Request',
-                                 message="email parameter required for admin vault access."), 400
-    else:
-        # Customers must provide email + order_id (acts as an access token)
-        customer_email = request.args.get('email') or request.args.get('customer_email')
-        order_token = request.args.get('order_id', '').strip()
+    is_admin = _is_admin_session()
+    customer_email = request.args.get('email') or request.args.get('customer_email')
+    order_token = sanitize_string((request.args.get('order_id') or '').strip(), max_length=64)
 
+    if is_admin:
+        if customer_email and not validate_email(customer_email):
+            # Staff usernames are not customer emails — ignore them.
+            customer_email = None
+    else:
         if not customer_email or not validate_email(customer_email):
             return render_template('error.html', code=401, title='Authentication Required',
                                  message="Please log in to access your training vault."), 401
-
         if not order_token:
             return render_template('error.html', code=401, title='Authentication Required',
                                  message="Access token required. Check your confirmation email for your order link."), 401
 
-        # Sanitize order_token
-        order_token = sanitize_string(order_token, max_length=64)
-
-    # Fetch customer's orders from database
     db = get_db()
-
-    # If not admin, verify order_id belongs to this email (prevents email-only enumeration)
-    if not _check_admin_token(request):
-        rows = db.execute(
-            "SELECT * FROM orders WHERE customer_email=? AND order_id=? "
-            "AND product_name IN ('Starter', 'Professional', 'Enterprise') LIMIT 1",
-            (customer_email, order_token)
-        ).fetchone()
-    else:
+    rows = None
+    if is_admin and customer_email:
         rows = db.execute(
             "SELECT * FROM orders WHERE customer_email=? AND product_name IN ('Starter', 'Professional', 'Enterprise') "
             "ORDER BY created_at DESC LIMIT 1",
             (customer_email,)
         ).fetchone()
+    elif not is_admin:
+        rows = db.execute(
+            "SELECT * FROM orders WHERE customer_email=? AND order_id=? "
+            "AND product_name IN ('Starter', 'Professional', 'Enterprise') LIMIT 1",
+            (customer_email, order_token)
+        ).fetchone()
 
     if not rows:
-        return render_template('error.html', code=404, title='No Active Subscription',
-                             message="You don't have an active SINCOR subscription. Please purchase one to access training materials."), 404
+        if is_admin:
+            customer_email = customer_email or 'operator@getsincor.com'
+            order_data = {
+                'order_id': 'operator',
+                'customer_email': customer_email,
+                'product_name': 'Enterprise',
+                'created_at': datetime.utcnow().isoformat(),
+            }
+        else:
+            return render_template('error.html', code=404, title='No Active Subscription',
+                                 message="You don't have an active SINCOR subscription. Please purchase one to access training materials."), 404
+    else:
+        order_data = dict(rows)
 
-    order_data = dict(rows)
     product_name = order_data.get('product_name', 'Enterprise')
     tier_name = product_name if product_name in ['Starter', 'Professional', 'Enterprise'] else 'Enterprise'
     tier_slug = tier_name.lower()
@@ -626,7 +628,7 @@ def admin_training_vault():
         'TIER': tier_name,
         'TIER_SLUG': tier_slug,
         'CUSTOMER_EMAIL': customer_email,
-        'CUSTOMER_NAME': customer_email.split('@')[0].title(),
+        'CUSTOMER_NAME': (customer_email or 'operator').split('@')[0].title(),
         'AGENT_COUNT': agent_count,
         'PAGE_COUNT': {'Starter': 30, 'Professional': 60, 'Enterprise': 120}.get(tier_name, 30),
         'INTEGRATION_COUNT': {'Starter': 5, 'Professional': 15, 'Enterprise': 25}.get(tier_name, 5),
@@ -664,7 +666,7 @@ def download_guide(filename):
     req_email = validate_email(request.args.get('email', ''))
     req_order = sanitize_string(request.args.get('order_id', ''), max_length=64)
 
-    if not _check_admin_token(request):
+    if not _is_admin_session():
         if not req_email or not req_order:
             return jsonify({'error': 'Authentication required. Include email and order_id params.'}), 401
 

--- a/src/sincor2/mvp_blueprints/pages.py
+++ b/src/sincor2/mvp_blueprints/pages.py
@@ -88,7 +88,19 @@ def pricing():
 @bp.route('/docs')
 def docs():
     """Product documentation."""
-    return render_template('docs.html')
+    try:
+        return render_template('docs.html')
+    except Exception:
+        logger.exception('[DOCS] docs.html missing; falling back to whitepaper')
+        return render_template('whitepaper.html')
+
+
+@bp.route('/guides/<path:_slug>')
+@bp.route('/download/<path:_slug>')
+@bp.route('/view/<path:_slug>')
+def guides_alias(_slug):
+    """Legacy vault / email guide links land on docs instead of 404."""
+    return redirect('/docs')
 
 
 @bp.route('/dashboard')
@@ -96,7 +108,17 @@ def dashboard():
     """Customer dashboard — payment-gated. Real DB values or explicit None."""
     if _is_admin_session():
         email = _session_email() or (session.get('admin_username') or '')
-        return _render_honest_dashboard(email=email, order={'product_name': 'Operator', 'payment_status': 'verified', 'order_id': 'admin', 'created_at': ''}, profile={}, admin=True)
+        return _render_honest_dashboard(
+            email=email,
+            order={
+                'product_name': 'Operator',
+                'payment_status': 'verified',
+                'order_id': 'operator',
+                'created_at': datetime.utcnow().isoformat(),
+            },
+            profile={},
+            admin=True,
+        )
 
     email = _session_email()
     if not email:
@@ -128,8 +150,12 @@ def _render_honest_dashboard(*, email, order, profile, admin=False):
             if p.get('agents')
         }
     except Exception:
-        agent_counts = {'Starter': 10, 'Professional': 25, 'Enterprise': 42}
+        agent_counts = {'Starter': 10, 'Professional': 25, 'Enterprise': 42, 'Operator': 42}
+    agent_counts.setdefault('Operator', 42)
+    agent_counts.setdefault('Enterprise', 42)
     num_agents = int(PRODUCT_CATALOG.get(tier, {}).get('agents') or agent_counts.get(tier) or 0)
+    if admin and not num_agents:
+        num_agents = 42
 
     roster_names = [
         ('Scout Agent', 'Discovery', '🔍'),
@@ -234,6 +260,14 @@ def product_professional():
 def product_enterprise():
     """Enterprise plan landing page."""
     return render_template('product_enterprise.html')
+
+
+@bp.route('/products/operator')
+def product_operator():
+    """Operator is not a purchasable SKU — send staff to the swarm console."""
+    if _is_admin_session():
+        return redirect('/command-center')
+    return redirect('/login?next=/command-center')
 
 
 @bp.route('/media-packs')

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -228,7 +228,7 @@
     </a>
     <a class="nav-item" href="#agents">
       <svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6"/></svg>
-      Agents <span class="tag">{{ agents|length }}</span>
+      Agents <span class="tag">{{ num_agents }}</span>
     </a>
     <a class="nav-item" href="#activity">
       <svg viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></svg>
@@ -238,6 +238,22 @@
       <svg viewBox="0 0 24 24"><path d="M12 20V10M6 20v-6M18 20V6"/></svg>
       Usage
     </a>
+
+    {% if admin_view %}
+    <div class="nav-group">Operator</div>
+    <a class="nav-item" href="/admin">
+      <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Console
+    </a>
+    <a class="nav-item" href="/command-center">
+      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 8v4l3 2"/></svg>
+      Command Center
+    </a>
+    <a class="nav-item" href="/admin/training-vault">
+      <svg viewBox="0 0 24 24"><path d="M4 5h16M4 12h16M4 19h10"/></svg>
+      Training Vault
+    </a>
+    {% endif %}
 
     <div class="nav-group">Account</div>
     <a class="nav-item" href="/billing">
@@ -280,15 +296,15 @@
         </div>
       </div>
       <div class="top-actions">
-        <span class="live"><span class="dot"></span>{{ agents|length }} provisioned</span>
+        <span class="live"><span class="dot"></span>{{ num_agents }} provisioned</span>
         <div class="seg" id="range">
           <button data-r="24h">24H</button>
           <button data-r="7d" class="on">7D</button>
           <button data-r="30d">30D</button>
         </div>
-        <a class="btn btn-primary" href="/products/{{ tier|lower }}">
+        <a class="btn btn-primary" href="{% if admin_view %}/command-center{% else %}/products/{{ tier|lower }}{% endif %}">
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
-          Deploy Agent
+          {% if admin_view %}Open Swarm{% else %}Deploy Agent{% endif %}
         </a>
       </div>
     </div>
@@ -439,6 +455,18 @@
           <div class="card">
             <div class="card-h"><h3>Quick Actions</h3></div>
             <div class="qa">
+              {% if admin_view %}
+              <a href="/command-center">
+                <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 8v4l3 2"/></svg>Command Center
+              </a>
+              <a href="/admin/training-vault">
+                <svg viewBox="0 0 24 24"><path d="M4 5h16M4 12h16M4 19h10"/></svg>Training Vault
+              </a>
+              <a href="/docs"><svg viewBox="0 0 24 24"><path d="M4 4h11l5 5v11H4z"/><path d="M14 4v6h6"/></svg>Docs & API</a>
+              <a href="/contact"><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H8l-4 4V5a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2z"/></svg>Support</a>
+              <a href="/sinc"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M9 12h6"/></svg>SINC Token</a>
+              <a href="/admin"><svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>Console</a>
+              {% else %}
               <a href="/admin/training-vault{% if email %}?email={{ email }}{% endif %}{% if order_id %}&order_id={{ order_id }}{% endif %}">
                 <svg viewBox="0 0 24 24"><path d="M4 5h16M4 12h16M4 19h10"/></svg>Training Vault
               </a>
@@ -447,6 +475,7 @@
               <a href="/contact"><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H8l-4 4V5a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2z"/></svg>Support</a>
               <a href="/sinc"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M9 12h6"/></svg>SINC Token</a>
               <a href="#" class="danger" id="deleteData"><svg viewBox="0 0 24 24"><path d="M4 7h16M9 7V4h6v3M6 7l1 13h10l1-13"/></svg>Delete Data</a>
+              {% endif %}
             </div>
           </div>
         </aside>
@@ -512,6 +541,17 @@
   function toggle(open){ side.classList.toggle('open',open); scrim.classList.toggle('on',open); }
   if(mb) mb.addEventListener('click', function(){ toggle(!side.classList.contains('open')); });
   scrim.addEventListener('click', function(){ toggle(false); });
+
+  /* ---- hash tabs (overview / agents / activity / usage) ---- */
+  function markNav() {
+    var hash = (location.hash || '#overview');
+    document.querySelectorAll('.nav-item').forEach(function(el){
+      var href = el.getAttribute('href') || '';
+      if (href.charAt(0) === '#') el.classList.toggle('on', href === hash);
+    });
+  }
+  markNav();
+  window.addEventListener('hashchange', markNav);
 
   /* ---- GDPR delete ---- */
   var btn = document.getElementById('deleteData');

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Docs & API — SINCOR</title>
+  <meta name="description" content="SINCOR product documentation: dashboard, agents, billing, training vault, and A2A API.">
+  <link rel="icon" type="image/png" href="/static/sincor_favicon.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Sora:wght@600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    :root { --bg:#0a0e27; --surface:#0f1629; --elev:#161d33; --text:#f1f5f9; --muted:#94a3b8; --cyan:#06b6d4; --purple:#8b5cf6; --ok:#34d399; --border:rgba(139,92,246,.22); }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { background:var(--bg); color:var(--text); font-family:'Plus Jakarta Sans',sans-serif; line-height:1.65; }
+    a { color:var(--cyan); text-decoration:none; }
+    header { position:sticky; top:0; z-index:10; backdrop-filter:blur(12px); background:rgba(10,14,39,.9); border-bottom:1px solid var(--border); }
+    .bar { max-width:960px; margin:0 auto; padding:16px 20px; display:flex; align-items:center; justify-content:space-between; gap:16px; flex-wrap:wrap; }
+    .brand { color:var(--text); font-family:'Sora',sans-serif; font-weight:700; }
+    nav { display:flex; gap:8px; flex-wrap:wrap; }
+    nav a { min-height:40px; padding:8px 12px; border-radius:10px; color:var(--muted); font-weight:600; font-size:13px; }
+    nav a:hover { color:var(--text); background:rgba(255,255,255,.05); }
+    .wrap { max-width:960px; margin:0 auto; padding:36px 20px 80px; }
+    .kicker { font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:var(--cyan); font-weight:700; }
+    h1 { font-family:'Sora',sans-serif; font-size:clamp(1.8rem,4vw,2.6rem); letter-spacing:-.03em; margin:8px 0 12px; }
+    h2 { font-family:'Sora',sans-serif; font-size:1.25rem; margin:36px 0 12px; }
+    p, li { color:var(--muted); }
+    ul { margin:0 0 16px 20px; }
+    li { margin-bottom:8px; }
+    .lede { max-width:40rem; margin-bottom:28px; }
+    .grid { display:grid; gap:14px; }
+    @media (min-width:760px) { .grid { grid-template-columns:repeat(3,1fr); } }
+    .card { background:var(--surface); border:1px solid var(--border); border-radius:16px; padding:18px; color:var(--text); }
+    .card h3 { font-size:16px; margin-bottom:6px; }
+    .card p { font-size:13px; }
+    code, .mono { font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--cyan); }
+    .callout { background:rgba(6,182,212,.08); border:1px solid rgba(6,182,212,.28); border-radius:12px; padding:16px 18px; margin:20px 0; }
+    table { width:100%; border-collapse:collapse; margin:12px 0 20px; font-size:14px; }
+    th, td { border:1px solid var(--border); padding:10px 12px; text-align:left; }
+    th { background:rgba(139,92,246,.12); color:#c4b5fd; }
+    footer { text-align:center; padding:28px; color:var(--muted); font-size:13px; border-top:1px solid var(--border); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="bar">
+      <a class="brand" href="/">SINCOR</a>
+      <nav>
+        <a href="/dashboard">Dashboard</a>
+        <a href="/buy">Plans</a>
+        <a href="/sinc">SINC</a>
+        <a href="/contact">Support</a>
+      </nav>
+    </div>
+  </header>
+  <main class="wrap">
+    <p class="kicker">Product documentation</p>
+    <h1>Docs & API</h1>
+    <p class="lede">How to run the agent operations console, bill in SINC / AXM, and call the A2A surface. Nothing here is sample telemetry.</p>
+
+    <section class="grid">
+      <a class="card" href="#console"><h3>Operations console</h3><p>Dashboard, roster, activity, and operator tools.</p></a>
+      <a class="card" href="#billing"><h3>Billing</h3><p>SINC subscriptions and AXM intel on Base.</p></a>
+      <a class="card" href="#api"><h3>A2A API</h3><p>Agent cards, quotes, and inbound JSON-RPC.</p></a>
+    </section>
+
+    <h2 id="console">Operations console</h2>
+    <p>After a paid plan (or an operator session) the console lives at <a href="/dashboard">/dashboard</a>.</p>
+    <ul>
+      <li><strong>Overview</strong> — live KPIs stay blank until the swarm bus reports real numbers.</li>
+      <li><strong>Agents</strong> — roster sized to the plan: Starter 10, Professional 25, Enterprise / Operator 42.</li>
+      <li><strong>Activity</strong> — recorded agent actions. Empty until tasks actually run.</li>
+      <li><strong>Training Vault</strong> — guides for the active subscription. Operators open it without a customer order.</li>
+    </ul>
+    <div class="callout">Staff sign in at <a href="/login">/login</a>, then use <a href="/admin">/admin</a> and <a href="/command-center">/command-center</a> for the swarm feed. Deploy Agent on an operator session opens the command center, not a product SKU.</div>
+
+    <h2 id="plans">Plans</h2>
+    <table>
+      <thead><tr><th>Plan</th><th>Agents</th><th>Entry</th></tr></thead>
+      <tbody>
+        <tr><td>Starter</td><td>10</td><td><a href="/products/starter">/products/starter</a></td></tr>
+        <tr><td>Professional</td><td>25</td><td><a href="/products/professional">/products/professional</a></td></tr>
+        <tr><td>Enterprise</td><td>42</td><td><a href="/products/enterprise">/products/enterprise</a></td></tr>
+      </tbody>
+    </table>
+    <p>Checkout is wallet-native at <a href="/buy">/buy</a>. No Stripe or PayPal on the default path.</p>
+
+    <h2 id="billing">Billing</h2>
+    <ul>
+      <li><strong>SINC</strong> — monthly subscriptions. Curve and treasury at <a href="/sinc">/sinc</a>.</li>
+      <li><strong>AXM (AXIOM)</strong> — one-off intel and agent-to-agent settlement. See <a href="/axiom">/axiom</a>.</li>
+      <li><strong>Membership</strong> — <a href="/billing">/billing</a> for wallet-linked plan status.</li>
+    </ul>
+
+    <h2 id="api">A2A API</h2>
+    <p>Discovery and quotes are public. Execution still requires payment verification.</p>
+    <table>
+      <thead><tr><th>Path</th><th>What it returns</th></tr></thead>
+      <tbody>
+        <tr><td class="mono">/.well-known/agent-card.json</td><td>Canonical agent card + skills</td></tr>
+        <tr><td class="mono">/.well-known/agent.json</td><td>Legacy agent card</td></tr>
+        <tr><td class="mono">/api/a2a/agents</td><td>Registered agents</td></tr>
+        <tr><td class="mono">/api/a2a/quote?skill_id=…</td><td>AXM quote for a skill</td></tr>
+        <tr><td class="mono">/health</td><td>Service + readiness checks</td></tr>
+      </tbody>
+    </table>
+    <p>Full protocol notes: <a href="/whitepaper">whitepaper</a> and <a href="/static/docs/SINCOR_whitepaper.md">markdown download</a>.</p>
+
+    <h2 id="support">Support</h2>
+    <p>Sales, incidents, or account questions: <a href="/contact">/contact</a> or <a href="mailto:support@getsincor.com">support@getsincor.com</a>.</p>
+  </main>
+  <footer>© 2026 SINCOR Business Solutions · <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a></footer>
+</body>
+</html>

--- a/tests/pytest/test_mvp_p0_456.py
+++ b/tests/pytest/test_mvp_p0_456.py
@@ -116,6 +116,70 @@ def test_dashboard_paid_no_fabricated_metrics(mvp_client):
     assert "—" in html
 
 
+def test_docs_page_200(mvp_client):
+    r = mvp_client.get("/docs", follow_redirects=False)
+    assert r.status_code == 200
+    html = r.get_data(as_text=True)
+    assert "Docs" in html
+    assert "A2A" in html
+
+
+def test_guides_alias_redirects_docs(mvp_client):
+    r = mvp_client.get("/guides/enterprise-guide-online", follow_redirects=False)
+    assert r.status_code in (301, 302)
+    assert "/docs" in r.headers.get("Location", "")
+
+
+def test_products_operator_redirects_login_when_anon(mvp_client):
+    r = mvp_client.get("/products/operator", follow_redirects=False)
+    assert r.status_code in (301, 302)
+    loc = r.headers.get("Location", "")
+    assert "/login" in loc
+
+
+def test_products_operator_admin_goes_command_center(mvp_client):
+    with mvp_client.session_transaction() as sess:
+        sess["is_admin"] = True
+        sess["admin_username"] = "admin"
+    r = mvp_client.get("/products/operator", follow_redirects=False)
+    assert r.status_code in (301, 302)
+    assert "/command-center" in r.headers.get("Location", "")
+
+
+def test_admin_dashboard_quick_actions_do_not_404(mvp_client):
+    with mvp_client.session_transaction() as sess:
+        sess["is_admin"] = True
+        sess["admin_username"] = "admin"
+        sess["username"] = "admin"
+    r = mvp_client.get("/dashboard", follow_redirects=False)
+    assert r.status_code == 200
+    html = r.get_data(as_text=True)
+    assert "/products/operator" not in html
+    assert "/command-center" in html
+    assert 'href="/admin/training-vault"' in html
+    assert "order_id=admin" not in html
+    assert "42" in html
+    assert "Command Center" in html
+    assert "Training Vault" in html
+    assert "Docs" in html
+
+
+def test_training_vault_admin_session_200(mvp_client):
+    with mvp_client.session_transaction() as sess:
+        sess["is_admin"] = True
+        sess["admin_username"] = "admin"
+    r = mvp_client.get("/admin/training-vault", follow_redirects=False)
+    assert r.status_code == 200
+    html = r.get_data(as_text=True)
+    assert "No Active Subscription" not in html
+    assert "Enterprise" in html or "Training" in html or "vault" in html.lower()
+
+
+def test_training_vault_unauthed_401(mvp_client):
+    r = mvp_client.get("/admin/training-vault", follow_redirects=False)
+    assert r.status_code == 401
+
+
 def test_legacy_mock_dashboards_not_on_mvp_app(mvp_client):
     """gunicorn sincor2.mvp_app:app must not serve app.py mock telemetry dashboards."""
     for path in ("/professional", "/executive", "/admin-dashboard", "/consciousness-transfer"):


### PR DESCRIPTION
Operator sessions on `/dashboard#activity` were 404ing on the rail and top-bar actions.

**Root causes**
- Deploy Agent pointed at `/products/operator` (not a SKU)
- Training Vault required a customer Starter/Pro/Enterprise order, so `order_id=admin` 404ed
- `/docs` rendered a missing `docs.html` (500)
- Operator was not in the catalog, so the console showed 0 agents

**Fix**
- Operator plan = 42 agents; Deploy Agent / Open Swarm goes to `/command-center`
- Admin session can open `/admin/training-vault` without a paid order (Enterprise operator vault)
- Add `docs.html`; leftover `/guides`, `/download`, `/view` links redirect to docs
- Hash nav highlights Activity when you land on `#activity`

Tests added in `tests/pytest/test_mvp_p0_456.py` (19 passed locally).