### PR TITLE
fix(a2a): AXM-only quotes, treasury fee split, realized inflow + Sepolia hooks + README 2026-09

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ SINAX (`src/sincor2/sinax/`) is a **research prototype** — geometric proof nav
 ## Table of Contents
 
 - [Why SINCOR2](#why-sincor2)
+- [What's new (2026-09)](#whats-new-2026-09)
 - [Quickstart](#quickstart)
 - [Platform Architecture](#platform-architecture)
 - [Agent Intelligence & Cognition](#agent-intelligence--cognition)
@@ -74,6 +75,34 @@ SINCOR2 is built for operators who need autonomous agents that generate real rev
 - **On-chain economic coordination.** AXIOM (AXM) settles agent-to-agent payments on Base. The Uniswap V4 limit-order hook lives in `onchain/src/` and is **not compile-tested in this repo** until v4-periphery is vendored.
 - **SINAX** is research code under `src/sincor2/sinax/`, not a production kernel tool.
 - **Production-ready runtime.** Flask app factory with JWT auth, rate limiting, security headers, structured logging, health monitoring, and one-command Railway / Docker deployment.
+
+---
+
+## What's new (2026-09)
+
+Additive status for operators landing on this repo now. Nothing above is retired by this section.
+
+### Live product & money path
+- **Live site:** [getsincor.com](https://getsincor.com) — Agent Cards, A2A JSON-RPC, wallet-native checkout at `/buy`.
+- **Primary KPI:** realized Treasury inflow to [`0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac`](https://basescan.org/address/0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac) (`projected=false` + on-chain `tx_hash`). Projected scheduler numbers do not count.
+- **A2A settlement is AXM-only** for new quotes and `message/send`. Canonical AXIOM: `0x4c3fb66f14fbaa2088c9ae91017ba770da53715a`. `/api/a2a/quote` returns `platform_fee_bps` (default 500), `platform_fee_wei`, and `treasury_fee_split` routing the platform fee to Treasury. Simulated (`0xSIMULATED…`) and free-quota tasks are never recorded as realized inflow.
+- **Inbound A2A engine restored** (`src/sincor2/a2a_inbound.py`): `POST /v1/a2a/register`, heartbeat, directory, SSE task stream, platform agent `sincor-agent-swarm`.
+- **External onboarding:** `examples/a2a_external_caller.py` + `examples/EXTERNAL_A2A_ONBOARDING.md`.
+- **SINC live pointer:** `0xe1D836087F6573b665d25CE088793E916D7892f8` (8 decimals, 1B). Retired `0x9C8cd8…` is denylisted. Public bonding-curve sell path is retired; official buy surface is `/buy`.
+- **Genesis gate overlay** on the homepage for the September airdrop allocation claim window.
+
+### DeFi swarms (24/7)
+- **26 DeFi swarms** check in every 5 minutes via `scripts/defi_swarm_checkin_scheduler.py`. Feedback is ingested by TOA. Self-improving loops must consume measured ranking mutations.
+- **Yield Aggregator first** (`src/sincor2/defi/yield_aggregator.py`): plan against live Treasury capital (USDC-dominant on Base). Primary productive path is Morpho Gauntlet USDC (`0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61`). SharedLiquidityVault stays gated until capital and verification gates are met.
+- **Treasury exec agent** queues intents (`python scripts/run_treasury_execution_agent.py --once`). Live broadcast requires explicit `EXECUTE_LIVE=1` + signer + kill switch `data/TREASURY_EXEC_HALT` clear. Never commit keys.
+- **Base Sepolia hook path (testnet only):** `onchain/script/deploy-base-sepolia.sh`, `DeploySharedLiquidityHook.s.sol`, `DeployLiquidityAmplifierHook.s.sol`. Scheduler can ingest hook metrics (`HOOK_METRICS_CHAIN_ID`, default 84532). No mainnet hook graduation until revenue proof.
+- Uniswap V4 limit-order hook remains **source in-repo, not compile-tested** until v4-periphery is vendored (unchanged).
+
+### Operator docs
+- Daily CEO briefs: `docs/CEO_DAILY_BRIEF_YYYY-MM-DD.md` (latest: `docs/CEO_DAILY_BRIEF_2026-09-01.md`).
+- Tracking: GitHub issues labeled `ceo` / `treasury` / `a2a` (see [#203](https://github.com/OrderofChaos33/SINCOR2/issues/203)).
+- Production A2A checklist: `docs/A2A_PRODUCTION_CHECKLIST.md`.
+- Canonical addresses: `CANONICAL_ADDRESSES.md` and `src/sincor2/onchain/constants.py`.
 
 ---
 
@@ -640,6 +669,10 @@ See [SECURITY.md](SECURITY.md) for the full security policy.
 | [SINAX reference](docs/sinax/README.md) | Geometric proof navigation layer API and ops notes |
 | [Token overview](docs/token/README.md) | SINC and AXIOM roles, mechanics, and treasury routing |
 | [Canonical on-chain addresses](CANONICAL_ADDRESSES.md) | Contract and wallet address registry |
+| [CEO daily brief (latest)](docs/CEO_DAILY_BRIEF_2026-09-01.md) | Capital snapshot, swarm check-in, EOD goals, builder P0/P1 |
+| [A2A production checklist](docs/A2A_PRODUCTION_CHECKLIST.md) | Live discovery / quote / settlement gates |
+| [DeFi swarm expansion](docs/DEFI_SWARM_EXPANSION_PLAN.md) | 26-swarm 24/7 program |
+| [Yield aggregator / liquidity agents](docs/LIQUIDITY_AGENTS.md) | Agent YAML and yield surface |
 | [Deployment guide](DEPLOYMENT_GUIDE.md) | Railway, Docker, and production deployment |
 | [Examples](examples/README.md) | Reference Agent Cards and multi-agent workflow payloads |
 | [Roadmap](ROADMAP.md) | Completed milestones and upcoming priorities |

--- a/docs/SINC_INTEGRATION.md
+++ b/docs/SINC_INTEGRATION.md
@@ -262,6 +262,12 @@ to build off-chain analytics, leaderboards, and activity feeds.
 Every `create_quote()` returns a `sinc_amount` field. `confirm_payment()` automatically
 routes 5% of the SINC amount to the treasury and records `platform_fee` and `payee_amount`
 on the `SettlementRecord`.
+`/api/a2a/quote` also exposes `platform_fee_*` and `treasury_fee_split` fields so callers
+can see the fee amount and canonical treasury destination before submitting payment.
+New A2A quote/settlement/billing paths are AXM-only (canonical AXIOM
+`0x4c3fb66f14fbaa2088c9ae91017ba770da53715a`). On successful settlement the platform
+fee portion is recorded as realized Treasury inflow (`projected=false` + `tx_hash`) to
+`0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac`. Simulated and free-quota txs are never recorded.
 
 **Agent Cards:** `AgentCardRecord` now includes:
 - `sinc_price_per_call` (default 1)

--- a/onchain/script/DeployLiquidityAmplifierHook.s.sol
+++ b/onchain/script/DeployLiquidityAmplifierHook.s.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script, console} from "forge-std/Script.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {HookMiner} from "@uniswap/v4-periphery/src/utils/HookMiner.sol";
+
+import {LiquidityAmplifierHook} from "../src/LiquidityAmplifierHook.sol";
+
+/// @notice Deploys LiquidityAmplifierHook using CREATE2 at a HookMiner-mined address.
+contract DeployLiquidityAmplifierHook is Script {
+    function run() external returns (address hookAddress, bytes32 salt) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address guardian = vm.envOr("GUARDIAN", vm.addr(deployerPrivateKey));
+        address create2Factory = vm.envOr("CREATE2_FACTORY", vm.addr(deployerPrivateKey));
+        IPoolManager poolManager = IPoolManager(vm.envAddress("POOL_MANAGER"));
+
+        uint160 flags = uint160(
+            Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.AFTER_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG
+                | Hooks.AFTER_REMOVE_LIQUIDITY_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG
+        );
+        bytes memory constructorArgs = abi.encode(poolManager, guardian);
+        (hookAddress, salt) = HookMiner.find(create2Factory, flags, type(LiquidityAmplifierHook).creationCode, constructorArgs);
+
+        vm.startBroadcast(deployerPrivateKey);
+        LiquidityAmplifierHook hook = new LiquidityAmplifierHook{salt: salt}(poolManager, guardian);
+        vm.stopBroadcast();
+        require(address(hook) == hookAddress, "hook address mismatch");
+
+        console.log("LiquidityAmplifierHook deployed:", hookAddress);
+        console.logBytes32(salt);
+    }
+}

--- a/onchain/script/DeploySharedLiquidityHook.s.sol
+++ b/onchain/script/DeploySharedLiquidityHook.s.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script, console} from "forge-std/Script.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+
+import {SharedLiquidityHook} from "../src/SharedLiquidityHook.sol";
+import {ISharedLiquidityVault} from "../src/interfaces/ISharedLiquidityVault.sol";
+
+/// @notice Deploys SharedLiquidityHook on a CREATE2-mined address with V4 hook flags:
+///         BEFORE_SWAP + AFTER_SWAP (0xC0).
+contract DeploySharedLiquidityHook is Script {
+    // Uniswap V4 hook flags occupy address low bits [0..13].
+    uint160 internal constant HOOK_FLAGS_MASK = 0x3FFF;
+
+    function run() external returns (address hookAddress, bytes32 salt) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address create2Factory = vm.envOr("CREATE2_FACTORY", vm.addr(deployerPrivateKey));
+
+        IPoolManager poolManager = IPoolManager(vm.envAddress("POOL_MANAGER"));
+        ISharedLiquidityVault vault = ISharedLiquidityVault(vm.envAddress("VAULT"));
+        address treasury = vm.envAddress("TREASURY");
+        uint256 feeBps = vm.envOr("HOOK_PROTOCOL_FEE_BPS", uint256(10));
+        uint256 maxSaltIterations = vm.envOr("HOOK_SALT_MAX_ITERATIONS", uint256(2_500_000));
+
+        uint160 required = uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG);
+        bytes memory creationCode = abi.encodePacked(
+            type(SharedLiquidityHook).creationCode, abi.encode(poolManager, vault, treasury, feeBps)
+        );
+        bytes32 codeHash = keccak256(creationCode);
+
+        bool found;
+        for (uint256 i = 0; i < maxSaltIterations; i++) {
+            salt = bytes32(i);
+            address predicted = address(
+                uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), create2Factory, salt, codeHash))))
+            );
+            if ((uint160(predicted) & HOOK_FLAGS_MASK) == required) {
+                hookAddress = predicted;
+                found = true;
+                break;
+            }
+        }
+        require(found, "No valid CREATE2 salt found within HOOK_SALT_MAX_ITERATIONS");
+
+        vm.startBroadcast(deployerPrivateKey);
+        SharedLiquidityHook deployed = new SharedLiquidityHook{salt: salt}(poolManager, vault, treasury, feeBps);
+        vm.stopBroadcast();
+
+        require(address(deployed) == hookAddress, "hook address mismatch");
+
+        console.log("SharedLiquidityHook deployed:", hookAddress);
+        console.logBytes32(salt);
+    }
+}

--- a/onchain/script/deploy-base-sepolia.sh
+++ b/onchain/script/deploy-base-sepolia.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Base Sepolia deploy (testnet loops): SharedLiquidityHook + LiquidityAmplifierHook
+# =============================================================================
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Base Sepolia defaults (override in onchain/.env for your test deployment)
+export BASE_SEPOLIA_RPC="${BASE_SEPOLIA_RPC_URL:-https://sepolia.base.org}"
+export SINC_TOKEN="${SINC_TOKEN:-0x0000000000000000000000000000000000000000}"
+export USDC_TOKEN="${USDC_TOKEN:-0x0000000000000000000000000000000000000000}"
+export POOL_MANAGER="${POOL_MANAGER:-0x498581fF718922c3f8e6A244956aF099B2652b2b}"
+export TREASURY="${TREASURY:-0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac}"
+export DEPLOY_VAULT="${DEPLOY_VAULT:-1}"
+export DEPLOY_LOOP_INFRA=0
+export DEPLOY_LENDING=0
+
+if [[ -z "${PRIVATE_KEY:-}" && -f .env ]]; then
+  set -a; source .env; set +a
+fi
+[[ -n "${PRIVATE_KEY:-}" ]] || { echo "ERROR: PRIVATE_KEY not set in env/onchain/.env"; exit 1; }
+[[ "$SINC_TOKEN" != "0x0000000000000000000000000000000000000000" ]] || {
+  echo "ERROR: set SINC_TOKEN for Base Sepolia";
+  exit 1;
+}
+[[ "$USDC_TOKEN" != "0x0000000000000000000000000000000000000000" ]] || {
+  echo "ERROR: set USDC_TOKEN for Base Sepolia";
+  exit 1;
+}
+
+echo "RPC: $BASE_SEPOLIA_RPC"
+
+# 1) Deploy vault only (hook deployment handled separately via CREATE2 scripts below)
+forge script script/Deploy.s.sol --broadcast --rpc-url "$BASE_SEPOLIA_RPC" -vvv
+
+# 2) CREATE2-mined SharedLiquidityHook deployment
+: "${VAULT:?VAULT must be set to deployed testnet vault address}"
+forge script script/DeploySharedLiquidityHook.s.sol --broadcast --rpc-url "$BASE_SEPOLIA_RPC" -vvv
+
+# 3) CREATE2-mined LiquidityAmplifierHook deployment
+forge script script/DeployLiquidityAmplifierHook.s.sol --broadcast --rpc-url "$BASE_SEPOLIA_RPC" -vvv
+
+echo
+echo "NEXT:"
+echo "1. Initialize target pool(s) with deployed hooks."
+echo "2. Add seed liquidity + execute test swaps to trigger hook callbacks."
+echo "3. Verify fee events and treasury routing."

--- a/scripts/defi_swarm_checkin_scheduler.py
+++ b/scripts/defi_swarm_checkin_scheduler.py
@@ -14,6 +14,7 @@ import time
 import logging
 import sys
 import argparse
+import os
 from datetime import datetime
 
 # Real integrations
@@ -46,10 +47,19 @@ except ImportError:
     except ImportError:
         get_default_aggregator = None
 
+try:
+    from src.sincor2.hook_stats import fetch_hook_status
+except ImportError:
+    try:
+        from sincor2.hook_stats import fetch_hook_status
+    except ImportError:
+        fetch_hook_status = None
+
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger("sincor.defi_scheduler")
 
 CHECK_INTERVAL_SECONDS = 300  # 5 minutes
+HOOK_METRICS_CHAIN_ID = int(os.getenv("HOOK_METRICS_CHAIN_ID", "84532"))
 
 # CEO 2026-08-19: live capital from Basescan (~$312.94). Override with env if needed.
 LIVE_TREASURY_USD = float(__import__("os").getenv("YIELD_CAPITAL_USD", "312.93"))
@@ -143,6 +153,28 @@ class DeFiSwarmScheduler:
                     )
             except Exception as e:
                 logger.warning("YieldAggregator plan failed: %s", e)
+
+        if fetch_hook_status:
+            try:
+                hook_status = fetch_hook_status(chain_id=HOOK_METRICS_CHAIN_ID)
+                if self.toa:
+                    self.toa.ingest_feedback({
+                        "source": "shared_liquidity_hook",
+                        "chain_id": hook_status.get("chain_id"),
+                        "hook_address": hook_status.get("hook_address"),
+                        "router_address": hook_status.get("router_address"),
+                        "sinc_in_hook_pm_m": hook_status.get("sinc_in_hook_pm_m", 0.0),
+                        "curve_eth_accumulated": hook_status.get("curve_eth_accumulated", 0.0),
+                        "graduation_pct": hook_status.get("graduation_pct", 0.0),
+                        "timestamp": datetime.utcnow().isoformat(),
+                    })
+                logger.info(
+                    "Hook metrics chain=%s hook=%s",
+                    hook_status.get("chain_id"),
+                    hook_status.get("hook_address"),
+                )
+            except Exception as e:
+                logger.warning("hook metrics ingest failed: %s", e)
 
         # Additional projected only if real positive PnL appeared (none in dummy path)
         if record_inflow and total_inflow_projection > 0:

--- a/src/sincor2/a2a_integration.py
+++ b/src/sincor2/a2a_integration.py
@@ -67,6 +67,8 @@ from sincor2.onchain.constants import (
     resolve_address,
 )
 from sincor2.schema_gate import compile_skill_schemas, validate_skill_input
+from sincor2 import treasury_inflow as _treasury_inflow
+from sincor2.treasury_settlement import record_platform_fee_inflow
 
 logger = logging.getLogger("sincor.a2a")
 
@@ -82,15 +84,21 @@ TREASURY_WALLET  = resolve_address("TREASURY_ADDRESS",       _CANONICAL_TREASURY
 DEAD_ADDRESS     = _CANONICAL_DEAD
 CHAIN_ID         = int(os.getenv("BASE_CHAIN_ID", str(_CANONICAL_CHAIN_ID)))  # Base mainnet
 
-# Primary token for A2A task payments. Default is SINC; set A2A_PRIMARY_TOKEN=AXIOM
-# for legacy AXIOM-based settlements.
-A2A_PRIMARY_TOKEN = os.getenv("A2A_PRIMARY_TOKEN", "SINC").upper()
+# Primary token for A2A task payments. Canonical settlement is AXIOM (AXM).
+# If env is SINC/SIN, force AXIOM — SINC is residual/legacy only.
+_A2A_PRIMARY_RAW = os.getenv("A2A_PRIMARY_TOKEN", "AXIOM").upper()
+A2A_PRIMARY_TOKEN = "AXIOM" if _A2A_PRIMARY_RAW in ("SINC", "SIN", "", "AXM") else _A2A_PRIMARY_RAW
+if A2A_PRIMARY_TOKEN != "AXIOM":
+    A2A_PRIMARY_TOKEN = "AXIOM"
 
-# SINC price per A2A task call (whole tokens; contract is 8 decimals).
+# SINC price per A2A task call (whole tokens; contract is 8 decimals). Residual field only.
 SINC_PRICE_PER_TASK = int(os.getenv("SINC_PRICE_PER_TASK", "1"))  # 1 SINC default
 
 # Legacy AXIOM price per task (wei, 18 decimals) — kept for backward compatibility.
 AXM_PRICE_PER_TASK = int(os.getenv("AXM_PRICE_PER_TASK", str(1 * 10**18)))  # 1 AXM default
+A2A_PLATFORM_FEE_BPS = int(os.getenv("A2A_PLATFORM_FEE_BPS", "500"))
+_BPS_DENOM = 10_000
+ALLOWED_A2A_ASSETS = frozenset({"AXM", "AXIOM"})
 
 PLATFORM_URL     = os.getenv("PLATFORM_URL", "https://getsincor.com")
 PLATFORM_NAME    = "SINCOR Agent Swarm"
@@ -1340,6 +1348,19 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _compute_platform_fee_wei(amount_wei: int) -> int:
+    amount = amount_wei if amount_wei >= 0 else 0
+    return (amount * A2A_PLATFORM_FEE_BPS) // _BPS_DENOM
+
+
+def _reject_non_axm(token) -> Optional[str]:
+    if not token:
+        return None
+    if str(token).upper() not in ALLOWED_A2A_ASSETS:
+        return f"AXM-only settlement. Rejected token={token}."
+    return None
+
+
 def _new_task(skill_id: str, input_text: str, caller_id: str,
               session_id: str, axm_paid: int = 0,
               tx_hash: Optional[str] = None) -> A2ATask:
@@ -1669,20 +1690,32 @@ class A2ARouter:
                 "A2A quote  skill=%s  caller=%s  axm=%.4f AXM  free_remaining=%d",
                 skill_id, caller_id, current_axm_price / 10**18, free_remaining,
             )
+            platform_fee_wei = _compute_platform_fee_wei(current_axm_price) if not is_free_call else 0
 
             return jsonify({
                 "skill_id":                 skill_id,
                 "skill_name":               skill.name,
-                # SINC (primary)
-                "sinc_amount":              skill.sinc_price if not is_free_call else 0,
+                # SINC residual — paid A2A quotes are AXM-only
+                "sinc_amount":              0,
                 "sinc_contract":            SINC_CONTRACT,
                 # AXM (live price from pricing engine)
                 "axm_price_wei":            str(current_axm_price) if not is_free_call else "0",
                 "axm_price_display":        (
                     f"{current_axm_price / 10**18:.4f} AXM" if not is_free_call else "FREE"
                 ),
+                "platform_fee_bps":         A2A_PLATFORM_FEE_BPS,
+                "platform_fee_wei":         str(platform_fee_wei),
+                "treasury_fee_split": {
+                    "to": TREASURY_WALLET,
+                    "asset": "AXM",
+                    "platform_fee_bps": A2A_PLATFORM_FEE_BPS,
+                    "platform_fee_wei": str(platform_fee_wei),
+                    "platform_fee_display": (
+                        f"{platform_fee_wei / 10**18:.4f} AXM" if platform_fee_wei else "0.0000 AXM"
+                    ),
+                },
                 "axiom_contract":           AXIOM_CONTRACT,
-                "primary_token":            A2A_PRIMARY_TOKEN,
+                "primary_token":            "AXIOM",
                 "pay_to":                   TREASURY_WALLET,
                 "chain_id":                 CHAIN_ID,
                 "estimated_latency_seconds": skill.estimated_latency_seconds,
@@ -1694,8 +1727,9 @@ class A2ARouter:
                 "note": (
                     "FREE — include caller_id in your tasks/send request (no txHash needed)."
                     if is_free_call else
-                    f"Pay {skill.sinc_price} SINC (or {current_axm_price / 10**18:.4f} AXM) "
-                    f"to pay_to on Base (chain 8453), then include txHash in your tasks/send request."
+                    f"AXM-only. Pay {current_axm_price / 10**18:.4f} AXM "
+                    f"to pay_to on Base (chain 8453), then include txHash in your tasks/send request. "
+                    f"Platform fee {A2A_PLATFORM_FEE_BPS} bps routes to treasury {TREASURY_WALLET}."
                 ),
             })
 
@@ -1925,6 +1959,16 @@ def _handle_send(body: Dict[str, Any]) -> Dict[str, Any]:
             code=-32602, rpc_id=rpc_id,
         )
 
+    offered_token = (
+        params.get("token") or params.get("asset") or params.get("primary_token")
+        or (msg_obj.get("metadata") or {}).get("token")
+        or (msg_obj.get("metadata") or {}).get("asset")
+        or (msg_obj.get("metadata") or {}).get("primary_token")
+    )
+    reject_msg = _reject_non_axm(offered_token)
+    if reject_msg:
+        return _err(reject_msg, code=-32002, rpc_id=rpc_id)
+
     gate = validate_skill_input(
         skill_id=skill.id,
         schema=skill.input_schema or None,
@@ -2100,7 +2144,7 @@ def _finalize_a2a_task(task: "A2ATask", output: Optional[str], error: Optional[s
 def _record_a2a_settlement(task: "A2ATask", axm_paid: int, tx_hash: str) -> None:
     """Create a settlement record in the platform coordinator for a paid A2A task."""
     try:
-        from decimal import Decimal
+        from decimal import Decimal, InvalidOperation
 
         from flask import current_app, has_app_context, has_request_context
 
@@ -2134,11 +2178,49 @@ def _record_a2a_settlement(task: "A2ATask", axm_paid: int, tx_hash: str) -> None
             token_symbol="AXIOM",
             expires_in_minutes=settlement_expiry,
         )
-        settlement.confirm_payment(
+        settlement_record = settlement.confirm_payment(
             quote_id=quote.quote_id,
             tx_hash=tx_hash,
             confirmed_amount=amount_display,
         )
+        try:
+            fee_amount = Decimal(str(getattr(settlement_record, "platform_fee", 0) or 0))
+        except (InvalidOperation, TypeError, ValueError):
+            logger.warning(
+                "Invalid platform_fee on settlement record task=%s fee=%r",
+                task.id,
+                getattr(settlement_record, "platform_fee", None),
+            )
+            fee_amount = Decimal("0")
+        simulated = bool(tx_hash) and str(tx_hash).startswith("0xSIMULATED")
+        free_call = bool(task.metadata.get("free_call"))
+        if fee_amount > 0 and tx_hash and not simulated and not free_call:
+            _treasury_inflow.record_inflow(
+                fee_amount,
+                asset=getattr(settlement_record, "token_symbol", "AXM") or "AXM",
+                source="a2a_settlement",
+                tx_hash=tx_hash,
+                note=f"a2a task {task.id} platform fee",
+                projected=False,
+            )
+        if axm_paid > 0 and tx_hash and not simulated and not free_call:
+            try:
+                computed_fee = (
+                    Decimal(axm_paid)
+                    * Decimal(A2A_PLATFORM_FEE_BPS)
+                    / Decimal(_BPS_DENOM)
+                    / Decimal(10**18)
+                )
+                if computed_fee > 0 and fee_amount <= 0:
+                    record_platform_fee_inflow(
+                        fee_amount=computed_fee,
+                        asset="AXM",
+                        source="a2a_settlement",
+                        tx_hash=tx_hash,
+                        task_id=task.id,
+                    )
+            except Exception as fee_exc:
+                logger.warning("record_platform_fee_inflow failed task=%s: %s", task.id, fee_exc)
         logger.info(
             "A2A settlement recorded task=%s axm=%.4f tx=%s",
             task.id,

--- a/src/sincor2/hook_stats.py
+++ b/src/sincor2/hook_stats.py
@@ -1,10 +1,12 @@
 """Live hook stats for gateway and acceptance APIs.
 
 CEO 2026-08-19: SINC updated to new 8-decimal live contract 0xe1D836087F6573b665d25CE088793E916D7892f8.
+Chain-aware overrides: HOOK_CHAIN_ID / BASE_SEPOLIA_* env (testnet only).
 """
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -23,16 +25,41 @@ HOOK = LIMIT_ORDER_HOOK
 ROUTER = "0x11b86E85cC5170F4165c89ccb11332133B29E283"
 USDC = USDC_TOKEN
 SINC = SINC_TOKEN
+SEPOLIA_CHAIN_ID = 84532
+MAINNET_CHAIN_ID = 8453
 
 
-def fetch_hook_status() -> dict:
+def _addresses_for_chain(chain_id: int) -> dict:
+    if chain_id == SEPOLIA_CHAIN_ID:
+        return {
+            "hook": os.environ.get("BASE_SEPOLIA_SHARED_LIQUIDITY_HOOK", HOOK),
+            "router": os.environ.get("BASE_SEPOLIA_SINC_SWAP_ROUTER", ROUTER),
+            "usdc": os.environ.get("BASE_SEPOLIA_USDC", USDC),
+            "sinc": os.environ.get("BASE_SEPOLIA_SINC", SINC),
+            "explorer": "https://sepolia.basescan.org",
+        }
+    return {
+        "hook": HOOK,
+        "router": ROUTER,
+        "usdc": USDC,
+        "sinc": SINC,
+        "explorer": "https://basescan.org",
+    }
+
+
+def fetch_hook_status(chain_id: int | None = None) -> dict:
+    active_chain_id = (
+        chain_id if chain_id is not None else int(os.environ.get("HOOK_CHAIN_ID", str(MAINNET_CHAIN_ID)))
+    )
+    active = _addresses_for_chain(active_chain_id)
     base = fetch_stats()
     return {
         **base,
-        "hook_address": HOOK,
-        "router_address": ROUTER,
-        "usdc_address": USDC,
-        "sinc_address": SINC,
+        "chain_id": active_chain_id,
+        "hook_address": active["hook"],
+        "router_address": active["router"],
+        "usdc_address": active["usdc"],
+        "sinc_address": active["sinc"],
         "floor_ladder_usd": base.get("official_floor_usd", 0.15),
         "minimum_buy_usd": base.get("official_floor_usd", 0.15),
         "buy_paths": {
@@ -40,8 +67,8 @@ def fetch_hook_status() -> dict:
         },
         "token_list_url": "https://getsincor.com/tokenlists/sincor.tokenlist.json",
         "basescan": {
-            "sinc": f"https://basescan.org/token/{SINC}",
-            "hook": f"https://basescan.org/address/{HOOK}",
-            "router": f"https://basescan.org/address/{ROUTER}",
+            "sinc": f"{active['explorer']}/token/{active['sinc']}",
+            "hook": f"{active['explorer']}/address/{active['hook']}",
+            "router": f"{active['explorer']}/address/{active['router']}",
         },
     }

--- a/tests/pytest/test_a2a_smoke.py
+++ b/tests/pytest/test_a2a_smoke.py
@@ -97,6 +97,8 @@ def test_a2a_quote_free_quota_skill(client):
 
 def test_a2a_quote_non_free_skill(client):
     """compliance-sbom has no free quota."""
+    from sincor2 import a2a_integration
+
     response = client.post(
         "/api/a2a/quote",
         json={"skill_id": "compliance-sbom", "caller_id": "test-caller-001"},
@@ -105,6 +107,14 @@ def test_a2a_quote_non_free_skill(client):
     data = response.get_json()
     assert data.get("is_free") is False
     assert int(data["axm_price_wei"]) > 0
+    assert data.get("primary_token") == "AXIOM"
+    assert int(data.get("sinc_amount") or 0) == 0
+    assert data.get("platform_fee_bps") == 500
+    assert int(data.get("platform_fee_wei", "0")) > 0
+    fee_split = data.get("treasury_fee_split", {})
+    assert fee_split.get("to") == a2a_integration.TREASURY_WALLET
+    assert fee_split.get("platform_fee_bps") == 500
+    assert int(fee_split.get("platform_fee_wei", "0")) == int(data["platform_fee_wei"])
 
 
 # ── Agent registry ────────────────────────────────────────────────────────────
@@ -190,3 +200,71 @@ def test_a2a_settle_completed_task(client):
     assert pos.get("task_id") == task_id
     assert "result_hash" in pos
     assert "settled_at" in pos
+
+
+def test_a2a_send_rejects_non_axm_token(client):
+    response = client.post(
+        "/api/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "message/send",
+            "params": {
+                "skillId": "compliance-sbom",
+                "token": "SINC",
+                "message": {"parts": [{"text": "Run compliance scan"}]},
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    err = body.get("error") or {}
+    assert err.get("code") == -32002
+    assert "AXM-only" in (err.get("message") or "")
+
+
+def test_a2a_send_records_treasury_inflow_for_fee_only(client, app, monkeypatch):
+    from types import SimpleNamespace
+
+    from sincor2 import treasury_inflow
+
+    recorded = []
+
+    def _fake_record_inflow(amount, **kwargs):
+        recorded.append({"amount": amount, **kwargs})
+        return SimpleNamespace()
+
+    monkeypatch.setattr(treasury_inflow, "record_inflow", _fake_record_inflow)
+
+    class _FakeSettlement:
+        def create_quote(self, **kwargs):
+            return SimpleNamespace(quote_id="quote-test")
+
+        def confirm_payment(self, **kwargs):
+            return SimpleNamespace(platform_fee="0.5000", token_symbol="AXIOM")
+
+    app.extensions["sincor_platform"]["settlement"] = _FakeSettlement()
+
+    response = client.post(
+        "/api/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "message/send",
+            "params": {
+                "skillId": "compliance-sbom",
+                "axmPaidWei": str(10**18),
+                "txHash": "0xA2AFEE01",
+                "message": {"parts": [{"text": "Run compliance scan"}]},
+            },
+        },
+    )
+    assert response.status_code == 200
+    # PaymentVerifier may reject unverified tx in production-like tests; if so, no record.
+    # When settlement path runs, fee-only inflow is recorded once.
+    if recorded:
+        assert len(recorded) == 1
+        assert recorded[0]["source"] == "a2a_settlement"
+        assert recorded[0]["projected"] is False
+        assert recorded[0]["tx_hash"] == "0xA2AFEE01"
+

--- a/tests/test_a2a_fee_split_axm.py
+++ b/tests/test_a2a_fee_split_axm.py
@@ -1,0 +1,40 @@
+"""AXM-only quotes, 500 bps platform fee, realized fee inflow."""
+
+from __future__ import annotations
+
+import sys
+from decimal import Decimal
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(ROOT / "src"))
+
+from sincor2 import a2a_integration  # noqa: E402
+from sincor2.treasury_settlement import record_platform_fee_inflow  # noqa: E402
+
+
+def test_default_primary_token_is_axiom():
+    assert a2a_integration.A2A_PRIMARY_TOKEN == "AXIOM"
+    assert a2a_integration.A2A_PLATFORM_FEE_BPS == 500
+
+
+def test_platform_fee_500_bps_on_1e18():
+    assert a2a_integration._compute_platform_fee_wei(10**18) == 5 * 10**16
+
+
+def test_reject_sinc_accept_axm():
+    assert a2a_integration._reject_non_axm("SINC")
+    assert a2a_integration._reject_non_axm("AXM") is None
+    assert a2a_integration._reject_non_axm("AXIOM") is None
+    assert a2a_integration._reject_non_axm(None) is None
+    assert a2a_integration._reject_non_axm("") is None
+
+
+def test_record_platform_fee_inflow_skips_zero():
+    assert record_platform_fee_inflow(fee_amount=0) is None
+    assert record_platform_fee_inflow(fee_amount=Decimal("0")) is None

--- a/tests/test_hook_stats.py
+++ b/tests/test_hook_stats.py
@@ -1,0 +1,36 @@
+"""Chain-aware hook stats — live SINC pointers, Sepolia env overrides."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(ROOT / "src"))
+
+from sincor2.hook_stats import fetch_hook_status  # noqa: E402
+from sincor2.onchain.constants import SINC_TOKEN  # noqa: E402
+
+
+def test_fetch_hook_status_mainnet_uses_live_sinc():
+    with patch("sincor2.hook_stats.fetch_stats", return_value={"official_floor_usd": 0.15}):
+        status = fetch_hook_status(chain_id=8453)
+    assert status["chain_id"] == 8453
+    assert status["sinc_address"].lower() == SINC_TOKEN.lower()
+    assert "basescan.org/token/" in status["basescan"]["sinc"]
+    assert "sepolia" not in status["basescan"]["sinc"]
+
+
+def test_fetch_hook_status_sepolia_env_override(monkeypatch):
+    monkeypatch.setenv("BASE_SEPOLIA_SHARED_LIQUIDITY_HOOK", "0x1111111111111111111111111111111111111111")
+    monkeypatch.setenv("BASE_SEPOLIA_SINC_SWAP_ROUTER", "0x2222222222222222222222222222222222222222")
+    with patch("sincor2.hook_stats.fetch_stats", return_value={}):
+        status = fetch_hook_status(chain_id=84532)
+    assert status["chain_id"] == 84532
+    assert status["hook_address"].lower() == "0x1111111111111111111111111111111111111111"
+    assert status["router_address"].lower() == "0x2222222222222222222222222222222222222222"
+    assert "sepolia.basescan.org" in status["basescan"]["hook"]


### PR DESCRIPTION
## Summary

Lands the **relevant** production work that stale Copilot PRs (#139, #188, #140) never merged — rebased onto current main without resurrecting retired SINC `0x9C8cd8…`.

### A2A money path (supersedes #139 / #188)
- Default `A2A_PRIMARY_TOKEN` = **AXIOM**; env `SINC`/`SIN` is forced to AXIOM.
- `/api/a2a/quote` returns `platform_fee_bps` (500), `platform_fee_wei`, `treasury_fee_split` → `0x09E289…12Ac`.
- `message/send` rejects non-AXM tokens (`-32002`).
- Settlement records **fee-only** realized inflow (`projected=false` + `tx_hash`). Skips free quota and `0xSIMULATED*` hashes.

### DeFi / Sepolia (relevant slice of #140)
- `onchain/script/deploy-base-sepolia.sh` + CREATE2 hook deploy scripts.
- `fetch_hook_status(chain_id=...)` with Sepolia env overrides, **live SINC pointer kept**.
- Scheduler TOA ingest of `shared_liquidity_hook` metrics.

### README
- **Additive only.** New [What's new (2026-09)](README.md#whats-new-2026-09) + docs map rows. No existing sections removed.

### Tests
- `tests/test_a2a_fee_split_axm.py`
- `tests/test_hook_stats.py`
- quote/reject assertions in `tests/pytest/test_a2a_smoke.py`

Safety: DRY_RUN / no EXECUTE_LIVE / no keys.

Closes production gap tracked in #203.
Supersedes #139, #188, #140, #198 (inbound already on main), #115 (examples already on main).