### PR TITLE
fix(checkout): USDC fallback — Starter $297 is price_unavailable on production

### DIFF
--- a/agents/results/icp_2026-09-01_tick2.json
+++ b/agents/results/icp_2026-09-01_tick2.json
@@ -1,0 +1,97 @@
+{
+  "tick": "2026-09-01T12:30:00Z",
+  "checkout": "https://getsincor.com/products/starter",
+  "buy": "https://getsincor.com/buy",
+  "rule": "public sources only. no invented emails. no send this tick.",
+  "checkout_blocker_this_tick": "POST /api/platform/checkout plan=starter returned price_unavailable (AXM DexScreener pairs=null, CoinGecko empty). Report plan still quotes 500 AXM fixed. USDC fallback PR opened this tick.",
+  "icps": [
+    {
+      "name": "Cedar Rapids Smile Center, PLC",
+      "city": "Cedar Rapids, IA",
+      "site": "https://www.cedarrapidssmilecenter.com/",
+      "observable": "family/restorative/cosmetic dental practice, public site 200, contact path present",
+      "play": "dental-missed-calls",
+      "cta": "https://getsincor.com/products/starter"
+    },
+    {
+      "name": "Dental Health Partners",
+      "city": "Cedar Rapids, IA",
+      "site": "https://www.dentalhealthpartners.com/",
+      "observable": "family dentist, phone 319-365-4997, contact/appointment path",
+      "play": "dental-missed-calls",
+      "cta": "https://getsincor.com/products/starter"
+    },
+    {
+      "name": "The Dental Center",
+      "city": "Cedar Rapids / Hiawatha, IA",
+      "site": "https://thedentalcenter.dental/",
+      "observable": "general dentistry + prosthodontics, phone 319.362.0043",
+      "play": "dental-missed-calls",
+      "cta": "https://getsincor.com/products/starter"
+    },
+    {
+      "name": "Quad Cities Periodontics",
+      "city": "Davenport, IA",
+      "site": "https://www.qcperio.com/",
+      "observable": "periodontics specialty, phone (563) 344-4867, appointment path",
+      "play": "dental-missed-calls",
+      "cta": "https://getsincor.com/products/starter"
+    },
+    {
+      "name": "Comfort Dental of Clinton",
+      "city": "Clinton, IA",
+      "site": "https://www.smileclinton.com/",
+      "observable": "public insurance/financial page; new vs prior Clinton cluster",
+      "play": "dental-missed-calls",
+      "cta": "https://getsincor.com/products/starter"
+    },
+    {
+      "name": "Great River OMS — Clinton office",
+      "city": "Clinton, IA",
+      "site": "https://greatriveroms.com/clinton-office-map/",
+      "observable": "oral surgery, 511 South 4th Street, phone (563) 259-4349",
+      "play": "dental-missed-calls",
+      "cta": "https://getsincor.com/products/starter"
+    },
+    {
+      "name": "Total Maintenance Inc.",
+      "city": "Davenport, IA",
+      "site": "https://www.tmiservices.net/",
+      "observable": "HVAC + plumbing since 1973, Quad Cities, phone (563) 316-6695, contact form",
+      "play": "trades-missed-calls",
+      "cta": "https://getsincor.com/products/starter"
+    },
+    {
+      "name": "Northwest Plumbing, Heating & AC",
+      "city": "Davenport, IA",
+      "site": "https://callnw.com/",
+      "observable": "5885 Tremont Ave, residential plumbing/HVAC, phone (563) 391-1344",
+      "play": "trades-missed-calls",
+      "cta": "https://getsincor.com/products/starter"
+    },
+    {
+      "name": "Triton Services",
+      "city": "Davenport, IA",
+      "site": "https://tritonservice.net/",
+      "observable": "plumbing/heating/AC, 2324 Hickory Grove Rd, phone 563.322.9500",
+      "play": "trades-missed-calls",
+      "cta": "https://getsincor.com/products/starter"
+    },
+    {
+      "name": "Hometown Mechanical",
+      "city": "Davenport, IA",
+      "site": "https://hometownmechanical.com/",
+      "observable": "commercial/industrial/residential mechanical contractor, Quad Cities",
+      "play": "trades-missed-calls",
+      "cta": "https://getsincor.com/products/starter"
+    },
+    {
+      "name": "Midwest Orthopedic Specialty Hospital",
+      "city": "Milwaukee, WI",
+      "site": "https://www.mymosh.com/",
+      "observable": "specialty hospital, phone 414-817-5800 — credentialing/RCM buyer, not a cold patient practice",
+      "play": "healthcare-rcm",
+      "cta": "https://getsincor.com/products/starter"
+    }
+  ]
+}

--- a/docs/CEO_CONVERSION_TICK_2026-09-01_T2.md
+++ b/docs/CEO_CONVERSION_TICK_2026-09-01_T2.md
@@ -1,0 +1,22 @@
+# Conversion 4h tick — 2026-09-01 ~12:30 UTC
+
+KPI: sent=0 · checkout_clicks=unknown · realized_tx_hash=none
+
+## Finding that matters
+`POST /api/platform/checkout` with `plan_id=starter` is **price_unavailable** on production.
+AXM (`0x4c3f…715a`) has no CoinGecko price and DexScreener `pairs: null`.
+Only the $49 **report** plan quotes (500 AXM fixed). Sequences sell $297 Starter into a dead quote.
+
+## Code this tick
+USDC fallback for USD-priced human checkout when AXM spot is missing.
+A2A quotes stay AXM-only (4.0000 AXM healthcare-credential-check, 500 bps to treasury).
+Agent Card copy: AXM-only (was SINC or AXM).
+
+## Not done (by design)
+- No Morpho
+- No founder $800
+- No cold email (no RESEND_API_KEY on runner)
+- agentpeering POST /api/agents = 401 (needs GitHub login / PAT)
+- itinai submit still 404
+
+Treasury live: ~$207.62 USDC + ~0.00063 ETH. 1e9 AXM in-wallet is unlisted inventory, not runway.

--- a/src/sincor2/a2a_integration.py
+++ b/src/sincor2/a2a_integration.py
@@ -1039,8 +1039,8 @@ def build_agent_card() -> AgentCard:
         description=(
             "SINCOR is a production-grade autonomous AI workforce platform running "
             "43 specialised agents across 7 archetypes (Scout, Builder, Synthesizer, "
-            "Negotiator, Director, Auditor, Caretaker). External agents pay in SINC "
-            "or AXIOM (AXM) — the SINCOR ecosystem tokens on Base — and receive "
+            "Negotiator, Director, Auditor, Caretaker). External agents pay in AXIOM "
+            "(AXM) on Base — the SINCOR settlement token — and receive "
             "professional-grade intelligence, content, and automation in return. "
             "Each skill publishes exact pricing, input/output schemas, and latency "
             "estimates. The top 5 skills offer a free quota for new external callers. "

--- a/src/sincor2/platform_payments.py
+++ b/src/sincor2/platform_payments.py
@@ -3,6 +3,8 @@
 CEO 2026-08-18/19: AXM primary address corrected to 0x4c3fb66f14fbaa2088c9ae91017ba770da53715a.
 CEO 2026-08-19: SINC updated to new 8-decimal live contract 0xe1D836087F6573b665d25CE088793E916D7892f8.
 New flows prefer AXM. SINC is legacy for residual subscription renewals only.
+CEO 2026-09-01: USD-priced human checkout falls back to Base USDC when AXM has
+no DEX/CoinGecko spot. A2A skills stay AXM-only (fixed wei).
 """
 
 from __future__ import annotations
@@ -27,17 +29,21 @@ from sincor2.onchain.constants import (
     SINC_DECIMALS as _SINC_DECIMALS,
     SINC_TOKEN,
     TREASURY,
+    USDC_DECIMALS as _USDC_DECIMALS,
+    USDC_TOKEN,
     resolve_address,
 )
 
 # Canonical Base mainnet (see sincor2.onchain.constants)
 SINC = SINC_TOKEN
 AXM = AXIOM_TOKEN
+USDC = USDC_TOKEN
 TREASURY = resolve_address("PLATFORM_TREASURY_ADDRESS", TREASURY)
 CHAIN_ID = BASE_CHAIN_ID
 
 SINC_DECIMALS = _SINC_DECIMALS
 AXM_DECIMALS = _AXM_DECIMALS
+USDC_DECIMALS = _USDC_DECIMALS
 
 TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 AMOUNT_TOLERANCE_BPS = 150  # 1.5% underpayment slack for spot drift
@@ -160,11 +166,18 @@ def token_address(symbol: str) -> str:
         return SINC
     if s in ("AXM", "AXIOM"):
         return AXM
+    if s == "USDC":
+        return USDC
     raise ValueError(f"unknown token: {symbol}")
 
 
 def token_decimals(symbol: str) -> int:
-    return SINC_DECIMALS if symbol.upper() == "SINC" else AXM_DECIMALS
+    s = symbol.upper()
+    if s == "SINC":
+        return SINC_DECIMALS
+    if s == "USDC":
+        return USDC_DECIMALS
+    return AXM_DECIMALS
 
 
 def _http_json(url: str, timeout: int = 12) -> dict | list | None:
@@ -258,13 +271,16 @@ def fetch_axm_spot_usd() -> float | None:
 
 def usd_to_token_amount(usd: float, token: str) -> tuple[float, float | None]:
     """Return (display_amount, spot_usd)."""
-    if token.upper() == "SINC":
+    t = token.upper()
+    if t == "USDC":
+        return round(usd, 2), 1.0
+    if t == "SINC":
         spot = fetch_sinc_spot_usd()
     else:
         spot = fetch_axm_spot_usd() or float(os.environ.get("AXM_USD_FALLBACK", "0") or 0) or None
     if not spot or spot <= 0:
         return 0.0, None
-    return round(usd / spot, 8 if token.upper() == "SINC" else 4), spot
+    return round(usd / spot, 8 if t == "SINC" else 4), spot
 
 
 def display_to_atomic(amount: float, token: str) -> int:
@@ -303,16 +319,40 @@ def _plan_token_quote(
     return round(plan["usd_reference"] / spot, dec), spot, "spot"
 
 
+def settle_plan_quote(
+    plan: dict[str, Any],
+    *,
+    sinc_spot: float | None = None,
+    axm_spot: float | None = None,
+) -> tuple[str, float, float | None, str]:
+    """Return (token, display_amount, spot_usd, pricing_mode).
+
+    Reports / A2A-style fixed AXM amounts stay AXM. USD-priced human checkout
+    (Starter $297, Professional, Enterprise, intel) falls back to Base USDC
+    1:1 when AXM has no live DEX/CoinGecko spot. SINC is never a buy path.
+    """
+    preferred = plan["token"]
+    display, spot, mode = _plan_token_quote(
+        plan, sinc_spot=sinc_spot, axm_spot=axm_spot
+    )
+    if display > 0:
+        return preferred, display, spot, mode
+    usd = float(plan.get("usd_reference") or 0)
+    if usd > 0 and preferred.upper() != "SINC":
+        return "USDC", round(usd, 2), 1.0, "usdc_fallback"
+    return preferred, 0.0, None, mode
+
+
 def list_plans() -> list[dict[str, Any]]:
     sinc_spot = fetch_sinc_spot_usd()
     axm_spot = fetch_axm_spot_usd()
     out = []
     for plan_id, plan in PLATFORM_PLANS.items():
-        token = plan["token"]
-        display, spot, mode = _plan_token_quote(
+        preferred = plan["token"]
+        token, display, spot, mode = settle_plan_quote(
             plan,
-            sinc_spot=sinc_spot if token.upper() == "SINC" else None,
-            axm_spot=axm_spot if token.upper() != "SINC" else None,
+            sinc_spot=sinc_spot if preferred.upper() == "SINC" else None,
+            axm_spot=axm_spot if preferred.upper() != "SINC" else None,
         )
         out.append(
             {
@@ -322,7 +362,8 @@ def list_plans() -> list[dict[str, Any]]:
                 "usd_reference": plan["usd_reference"],
                 "billing": plan["billing"],
                 "token": token,
-                "token_address": token_address(token),
+                "preferred_token": preferred,
+                "token_address": token_address(token) if display > 0 else token_address(preferred),
                 "amount_display": display,
                 "amount_atomic": str(display_to_atomic(display, token)) if display > 0 else None,
                 "spot_usd": spot,
@@ -350,8 +391,7 @@ def create_checkout(
     if not plan:
         return {"ok": False, "error": "unknown_plan"}
 
-    token = plan["token"]
-    display, spot, mode = _plan_token_quote(plan)
+    token, display, spot, mode = settle_plan_quote(plan)
     if display <= 0:
         return {"ok": False, "error": "price_unavailable", "token": token}
 
@@ -380,7 +420,12 @@ def create_checkout(
                 customer_email,
                 now.isoformat(),
                 expires_at,
-                json.dumps({"billing": plan["billing"], "order_type": plan["order_type"]}),
+                json.dumps({
+                    "billing": plan["billing"],
+                    "order_type": plan["order_type"],
+                    "pricing_mode": mode,
+                    "preferred_token": plan["token"],
+                }),
             ),
         )
         conn.commit()

--- a/templates/buy_tokens.html
+++ b/templates/buy_tokens.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Pay with SINC or AXM — SINCOR</title>
+  <title>Pay on Base — SINCOR</title>
   <link rel="icon" type="image/png" href="/static/sincor_favicon.png">
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
@@ -38,9 +38,9 @@
 <div class="wrap">
   <nav><a href="/">← Back to SINCOR</a> · <a href="/pricing">Pricing</a> · <a href="/sinc">Buy SINC</a> · <a href="/axiom">AXIOM</a></nav>
 
-  <span class="pill">SINC + AXM checkout</span>
-  <h1>Pay with platform tokens</h1>
-  <p class="sub">SINCOR billing runs on <strong>SINC</strong> (platform access) and <strong>AXM</strong> (one-off intel &amp; agent tasks). No Stripe. No PayPal. Base mainnet only.</p>
+  <span class="pill">Base USDC / AXM checkout</span>
+  <h1>Pay on Base</h1>
+  <p class="sub">Starter is <strong>$297 USDC</strong> on Base while AXM has no DEX spot. One-time reports quote in <strong>AXM</strong>. No Stripe. No PayPal. Treasury <span class="mono">0x09E289…12Ac</span>.</p>
 
   <div class="card">
     <div class="row">
@@ -74,8 +74,8 @@
   <div class="card">
     <h2 style="font-size:1rem;margin:0 0 8px">How it works</h2>
     <ol class="muted" style="padding-left:18px;margin:0">
-      <li>Pick a plan — subscriptions bill in <span class="token-badge">SINC</span>, one-time reports in <span class="token-badge">AXM</span>.</li>
-      <li>We quote live spot from the bonding curve (SINC) or DEX (AXM).</li>
+      <li>Pick a plan — Starter / Professional / Enterprise settle in <span class="token-badge">USDC</span> at list price when AXM has no live pair. One-time reports stay <span class="token-badge">AXM</span>.</li>
+      <li>We quote USDC 1:1 for USD plans, or live DEX spot when AXM is priced.</li>
       <li>Connect MetaMask/Rabby on <strong>Base</strong> and send the exact token amount to treasury.</li>
       <li>Verify your tx — fulfillment starts immediately.</li>
     </ol>
@@ -101,9 +101,9 @@ async function loadPlans() {
   (data.plans || []).forEach((p) => {
     const o = document.createElement('option');
     o.value = p.id;
-    const suffix = p.spot_available ? '' : ' — price loading…';
-    o.textContent = `${p.label} — $${p.usd_reference} ref · ${p.token}${suffix}`;
-    if (!p.spot_available && p.token === 'SINC') o.disabled = true;
+    const suffix = p.spot_available ? ` · ${p.token}` : ' — price loading…';
+    o.textContent = `${p.label} — $${p.usd_reference} ref${suffix}`;
+    if (!p.spot_available) o.disabled = true;
     sel.appendChild(o);
   });
   let wanted = params.get('plan') || 'starter';
@@ -139,7 +139,9 @@ async function refreshQuote() {
   $('usd-ref').textContent = `$${data.usd_reference} reference · ${data.billing === 'month' ? 'monthly' : 'one-time'}`;
   $('spot').textContent = data.pricing_mode === 'fixed'
     ? `Fixed list price (${data.token})`
-    : (data.spot_usd ? `Spot ≈ $${Number(data.spot_usd).toPrecision(4)} / ${data.token}` : '');
+    : (data.pricing_mode === 'usdc_fallback'
+      ? 'USDC at list price — AXM DEX spot unavailable'
+      : (data.spot_usd ? `Spot ≈ $${Number(data.spot_usd).toPrecision(4)} / ${data.token}` : ''));
   $('treasury').textContent = data.treasury;
   if (account) {
     $('btn-pay').disabled = false;

--- a/tests/test_platform_payments_usdc_fallback.py
+++ b/tests/test_platform_payments_usdc_fallback.py
@@ -1,0 +1,91 @@
+"""Human checkout: USD plans settle in Base USDC when AXM has no spot."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(ROOT / "src"))
+
+from sincor2.onchain.constants import TREASURY, USDC_TOKEN  # noqa: E402
+from sincor2 import platform_payments as pp  # noqa: E402
+
+
+def test_usdc_token_metadata():
+    assert pp.token_address("USDC") == USDC_TOKEN
+    assert pp.token_decimals("USDC") == 6
+    assert pp.display_to_atomic(297, "USDC") == 297_000_000
+
+
+def test_starter_falls_back_to_usdc_when_axm_spot_missing():
+    pp._spot_cache.clear()
+    with patch.object(pp, "fetch_axm_spot_usd", return_value=None):
+        token, display, spot, mode = pp.settle_plan_quote(pp.PLATFORM_PLANS["starter"])
+    assert token == "USDC"
+    assert display == 297.0
+    assert spot == 1.0
+    assert mode == "usdc_fallback"
+
+
+def test_report_stays_axm_fixed_without_spot():
+    with patch.object(pp, "fetch_axm_spot_usd", return_value=None):
+        token, display, spot, mode = pp.settle_plan_quote(pp.PLATFORM_PLANS["report"])
+    assert token == "AXM"
+    assert display == 500.0
+    assert mode == "fixed"
+
+
+def test_starter_axm_when_spot_exists():
+    with patch.object(pp, "fetch_axm_spot_usd", return_value=0.10):
+        token, display, spot, mode = pp.settle_plan_quote(pp.PLATFORM_PLANS["starter"])
+    assert token == "AXM"
+    assert display == 2970.0
+    assert mode == "spot"
+
+
+def test_list_plans_starter_spot_available_via_usdc():
+    with patch.object(pp, "fetch_axm_spot_usd", return_value=None):
+        plans = {p["id"]: p for p in pp.list_plans()}
+    starter = plans["starter"]
+    assert starter["token"] == "USDC"
+    assert starter["preferred_token"] == "AXM"
+    assert starter["spot_available"] is True
+    assert starter["amount_display"] == 297.0
+    assert starter["amount_atomic"] == "297000000"
+    assert starter["treasury"] == TREASURY
+    assert starter["token_address"].lower() == USDC_TOKEN.lower()
+
+
+def test_create_checkout_starter_usdc(tmp_path, monkeypatch):
+    monkeypatch.setenv("ORDERS_DB_PATH", str(tmp_path / "orders.db"))
+    pp._spot_cache.clear()
+    with patch.object(pp, "fetch_axm_spot_usd", return_value=None):
+        result = pp.create_checkout("starter", customer_email="ops@example.com")
+    assert result["ok"] is True
+    assert result["token"] == "USDC"
+    assert result["amount_display"] == 297.0
+    assert result["amount_atomic"] == "297000000"
+    assert result["pricing_mode"] == "usdc_fallback"
+    assert result["treasury"].lower() == TREASURY.lower()
+    assert result["token_address"].lower() == USDC_TOKEN.lower()
+
+
+def test_sinc_is_not_revived_as_fallback():
+    fake = {
+        "label": "Legacy",
+        "product_name": "Legacy",
+        "order_type": "subscription",
+        "usd_reference": 297,
+        "token": "SINC",
+        "billing": "month",
+    }
+    with patch.object(pp, "fetch_sinc_spot_usd", return_value=None):
+        token, display, _spot, mode = pp.settle_plan_quote(fake)
+    assert token == "SINC"
+    assert display == 0.0
+    assert mode == "spot"


### PR DESCRIPTION
## Why
KPI is realized inflow to `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac`.

Production right now:
- `POST /api/platform/checkout` `plan_id=starter` → `{"ok":false,"error":"price_unavailable","token":"AXM"}`
- CoinGecko AXM price = `{}`
- DexScreener `pairs: null`
- Sequences sell Starter $297 into a quote that cannot be created.

Only the one-time **report** plan quotes (500 AXM fixed). That is not $297 and AXM has no market.

## What
USD-priced human checkout (Starter / Professional / Enterprise / intel) falls back to **Base USDC 1:1** when AXM has no live spot. Report stays 500 AXM fixed. A2A `/api/a2a/quote` stays AXM-only (500 bps treasury split already live).

Agent Card description: AXM-only (was "SINC or AXM"). Sequences still `/buy` + `/products/starter`.

## Tests
`tests/test_platform_payments_usdc_fallback.py` — 7 passed locally with `test_a2a_fee_split_axm.py` (11 total).

## Not in this PR
- Morpho (killed)
- Founder $800 (hold)
- Cold email (no RESEND on runner)
- SINC as a buy path (never revived)

Closes conversion leak on `/buy` once deployed. Does not by itself produce a `tx_hash`.