### PR TITLE
CHROMA — auto detailing vertical pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ flowchart TD
 | Orchestration core | `core/` | Task routing, execution policy, reliability controls |
 | Marketplace services | `marketplace/` | Card registration, discovery, capability matching, reputation |
 | Infrastructure | `infrastructure/` | Deployment config, observability, liquidity, treasury |
-| Vertical packs | `verticals/` | Domain agent packs: healthcare, dental, compliance, trading, lead_gen |
+| Vertical packs | `verticals/` | Domain agent packs: healthcare, dental, compliance, trading, lead_gen, auto_detailing |
 | DAE layer | `dae/` | Governance, incentives, decentralized identity |
 | Enterprise infra | `enterprise_infrastructure/` | Audit logging, container orchestration |
 | Agents | `agents/` | 43 named agent YAML configs with archetypes and persona vectors |
@@ -432,6 +432,19 @@ Full outbound revenue pipeline:
 - **ICP matcher** — Scores inbound leads against Ideal Customer Profile definitions using firmographic and behavioral data.
 - **Outbound agent** — Multi-step enrichment, sequencing, and engagement tracking.
 - **Autonomous outreach engine** — Fetches local business leads from Yelp Fusion and enriches with Google Places, then sends cold outreach via Resend with configurable daily limits and ICP targeting (med spas, gyms, real estate agents, and more).
+
+### Auto Detailing — CHROMA
+
+Autonomous growth OS for detailing, ceramic, PPF, and tint shops. Built for speed-to-lead: comparison shoppers book the first shop that answers.
+
+- **Lead aggregation** — Google, GBP, website, Instagram, Facebook Marketplace, ads, referrals, missed-call text-back. Intent scoring with vehicle-value, photo-quote, and recency weights.
+- **Quote → Calendly** — Package × vehicle-size pricing, coating deposits, weather holds on exterior work, prefilled self-serve booking URLs.
+- **Presence agents** — Metadata, local SEO + AEO FAQ JSON-LD, gallery alt-text, review showcase, GBP categories. Runs 24/7 against the live site.
+- **Landing engagement** — Popup qualifies visitors, prices the job, and hands them the calendar. No human in the loop after hours.
+- **Social + email autopilot** — Scheduled before/after, education, offer, bay-life, and review posts. Comment/DM replies steer to self-booking. Quote follow-ups, 30/60/90-day membership nudges, post-job review asks.
+- **Protocols** — Sub-90s first response, photo-quote intake, T-24h/T-2h reminders, seasonal salt/pollen/UV/PPF campaigns, wash → interior → ceramic → PPF upsell graph.
+
+Skill ids: `detailing-lead-ingest`, `detailing-booking`, `detailing-presence`, `detailing-social`, `detailing-copy`, `detailing-engage`.
 
 ---
 

--- a/docs/guides/vertical-integration.md
+++ b/docs/guides/vertical-integration.md
@@ -71,4 +71,11 @@ Plain-text input is also accepted; the dispatcher wraps it as `{ "task_type": "<
 | `trading-signals` | TradingAgent |
 | `compliance-sbom` | ComplianceAgent |
 
+| `detailing-lead-ingest` | AutoDetailingAgent |
+| `detailing-booking` | AutoDetailingAgent |
+| `detailing-presence` | AutoDetailingAgent |
+| `detailing-social` | AutoDetailingAgent |
+| `detailing-copy` | AutoDetailingAgent |
+| `detailing-engage` | AutoDetailingAgent |
+
 See each pack's `agent_card.json` for the full skill catalogue.

--- a/src/sincor2/vertical_dispatch.py
+++ b/src/sincor2/vertical_dispatch.py
@@ -58,8 +58,12 @@ _SKILL_TASK_TYPE_MAP: Dict[str, str] = {
     "competitor-intel": "market_analysis",
     "content-blog": "content_generation",
     "toa-decision": "toa_decision",
-    "healthcare-credential-check": "credentialing_workflow",
-    "dental-billing-scrub": "dental_billing_scrub",
+    "detailing-lead-ingest": "lead_ingest",
+    "detailing-booking": "calendly_handoff",
+    "detailing-presence": "seo_optimize",
+    "detailing-social": "social_schedule",
+    "detailing-copy": "ad_copy",
+    "detailing-engage": "landing_engage",
 }
 
 
@@ -175,6 +179,14 @@ def _normalize_demo_payload(
         normalized.setdefault("target", "SINCOR")
         normalized.setdefault("market", "AI SaaS")
         normalized.setdefault("horizon", "90d")
+
+    elif skill_id in {"detailing-lead-ingest", "detailing-booking", "detailing-presence", "detailing-social", "detailing-copy", "detailing-engage"}:
+        normalized.setdefault("source", "website")
+        normalized.setdefault("package_id", "full_detail")
+        normalized.setdefault("city", "Dubuque")
+        normalized.setdefault("visitor_message", normalized.get("input", "I need a full detail"))
+        normalized.setdefault("channel", "google_rsa")
+        normalized.setdefault("vehicle", {"year": 2022, "make": "BMW", "model": "X5", "body_style": "suv"})
 
     return normalized
 

--- a/tests/pytest/test_auto_detailing.py
+++ b/tests/pytest/test_auto_detailing.py
@@ -1,0 +1,188 @@
+"""Unit + dispatch tests for the CHROMA auto detailing vertical."""
+
+from __future__ import annotations
+
+import json
+
+from verticals.auto_detailing.agent import AutoDetailingAgent
+from verticals.auto_detailing.lead_agent import DetailingLeadAgent
+from verticals.auto_detailing.protocols import PACKAGES, deposit_for
+from verticals.loader import instantiate_vertical_agents, load_agent_cards, resolve_vertical_agent
+
+
+def test_pack_card_loads():
+    cards = load_agent_cards()
+    names = [c.get("name", "") for c in cards]
+    assert any("Detailing" in n or "CHROMA" in n for n in names)
+    detailing = next(c for c in cards if "Detailing" in c.get("name", "") or "CHROMA" in c.get("name", ""))
+    skill_ids = {s["id"] for s in detailing["skills"]}
+    assert {
+        "detailing-lead-ingest",
+        "detailing-booking",
+        "detailing-presence",
+        "detailing-social",
+        "detailing-copy",
+        "detailing-engage",
+    } <= skill_ids
+
+
+def test_agent_registered():
+    agents = instantiate_vertical_agents()
+    assert "auto_detailing_agent" in agents
+    resolved = resolve_vertical_agent("detailing-booking", agents)
+    assert resolved is not None
+    assert resolved.name == "auto_detailing_agent"
+
+
+def test_luxury_ceramic_scores_hot():
+    agent = DetailingLeadAgent()
+    result = agent.ingest(
+        {
+            "source": "google",
+            "name": "Ava Chen",
+            "email": "ava@example.com",
+            "message": "Need ceramic coating and paint correction on my Porsche",
+            "vehicle": {"year": 2023, "make": "Porsche", "model": "911", "condition": "daily"},
+            "photo_urls": ["https://cdn.example/hood.jpg"],
+        }
+    )
+    assert result["ranking"]["score"] >= 78
+    assert result["ranking"]["band"] == "hot"
+    assert result["ranking"]["next_action"] == "book_now"
+
+
+def test_ceramic_requires_deposit():
+    assert deposit_for("ceramic") == 0.5
+    assert deposit_for("express_wash") == 0.0
+    agent = AutoDetailingAgent()
+    out = agent.run(
+        {
+            "task_type": "quote_estimate",
+            "payload": {
+                "package_id": "ceramic",
+                "vehicle": {"make": "BMW", "body_style": "suv"},
+            },
+            "correlation_id": "q-1",
+        }
+    )
+    assert out["status"] == "success"
+    assert out["result"]["deposit"] > 0
+    assert out["result"]["vehicle_size"] == "suv"
+    assert out["result"]["total"] > PACKAGES["ceramic"]["price"]
+
+
+def test_calendly_url_prefills():
+    agent = AutoDetailingAgent()
+    out = agent.run(
+        {
+            "task_type": "calendly_handoff",
+            "payload": {
+                "package_id": "interior",
+                "name": "Marcus Hale",
+                "email": "marcus@example.com",
+                "vehicle": {"year": 2019, "make": "Toyota", "model": "Tundra", "body_style": "truck"},
+                "calendly_handle": "northline-detail",
+            },
+        }
+    )
+    assert out["status"] == "success"
+    url = out["result"]["calendly_url"]
+    assert url.startswith("https://calendly.com/northline-detail/interior-revival")
+    assert "Marcus" in url or "name=Marcus" in url
+    assert out["result"]["quote"]["vehicle_size"] == "truck"
+
+
+def test_weather_hold_on_exterior():
+    agent = AutoDetailingAgent()
+    out = agent.run(
+        {
+            "task_type": "calendly_handoff",
+            "payload": {
+                "package_id": "maintenance_wash",
+                "weather_precip_pct": 80,
+                "vehicle": {"body_style": "sedan"},
+            },
+        }
+    )
+    assert out["result"]["weather_hold"] is True
+    interior = agent.run(
+        {
+            "task_type": "calendly_handoff",
+            "payload": {
+                "package_id": "interior",
+                "weather_precip_pct": 80,
+                "vehicle": {"body_style": "sedan"},
+            },
+        }
+    )
+    assert interior["result"]["weather_hold"] is False
+
+
+def test_seo_metadata_bounds():
+    agent = AutoDetailingAgent()
+    out = agent.run(
+        {
+            "task_type": "seo_optimize",
+            "payload": {
+                "shop_name": "Northline Detail",
+                "city": "Dubuque",
+                "region": "IA",
+                "reviews": [{"author": "Ken", "rating": 5, "text": "Ceramic looks wet"}],
+                "gallery": [{"src": "/gallery/hero-amg.jpg", "vehicle": "AMG", "kind": "after"}],
+            },
+        }
+    )
+    result = out["result"]
+    assert 50 <= len(result["title"]) <= 70
+    assert 120 <= len(result["meta_description"]) <= 160
+    assert result["json_ld"]["@type"]
+    assert result["seo_score"] >= 70
+
+
+def test_engagement_returns_booking_link():
+    agent = AutoDetailingAgent()
+    out = agent.run(
+        {
+            "task_type": "landing_engage",
+            "payload": {"visitor_message": "I want ceramic on my SUV"},
+        }
+    )
+    assert out["status"] == "success"
+    assert "calendly_url" in out["result"]
+    assert out["result"]["package_id"] == "ceramic"
+
+
+def test_social_calendar_and_copy():
+    agent = AutoDetailingAgent()
+    social = agent.run({"task_type": "social_schedule", "payload": {"cadence_per_week": 5}})
+    assert social["result"]["posts"]
+    assert len(social["result"]["posts"]) == 5
+    copy = agent.run(
+        {
+            "task_type": "ad_copy",
+            "payload": {"channel": "google_rsa", "city": "Dubuque", "package_id": "ceramic"},
+        }
+    )
+    assert len(copy["result"]["headlines"]) >= 8
+
+
+def test_dispatch_skill_id():
+    from sincor2.vertical_dispatch import dispatch_vertical_task
+
+    agents = instantiate_vertical_agents()
+    output, error = dispatch_vertical_task(
+        "detailing-lead-ingest",
+        json.dumps(
+            {
+                "task_type": "lead_ingest",
+                "payload": {
+                    "source": "website",
+                    "message": "full detail for a daily driver",
+                    "name": "Sam",
+                },
+            }
+        ),
+        {"vertical_agents": agents},
+    )
+    assert error is None
+    assert "success" in output

--- a/tests/pytest/test_platform_integration.py
+++ b/tests/pytest/test_platform_integration.py
@@ -28,8 +28,9 @@ def test_vertical_agent_cards_load():
 
 def test_vertical_agents_instantiate():
     agents = instantiate_vertical_agents()
-    assert len(agents) >= 5
+    assert len(agents) >= 6
     assert "healthcare_rcm_agent" in agents
+    assert "auto_detailing_agent" in agents
 
 
 def test_skill_resolution():

--- a/verticals/README.md
+++ b/verticals/README.md
@@ -8,4 +8,6 @@ All verticals follow the same high-standard structure:
 - Detailed capability definitions
 - Clear A2A Agent Card output
 
+Current packs: `healthcare`, `dental`, `compliance`, `trading`, `lead_gen`, `auto_detailing` (CHROMA).
+
 Current status: Wired to the live runtime via `platform_bootstrap.py`. Vertical agents dispatch through A2A for registered skill ids. External API integrations remain the next implementation step per vertical.

--- a/verticals/__init__.py
+++ b/verticals/__init__.py
@@ -1,9 +1,10 @@
 """Revenue-focused vertical agent packs for SINCOR2."""
 
 __all__ = [
-    'healthcare',
-    'dental',
-    'compliance',
-    'trading',
-    'lead_gen',
+    "healthcare",
+    "dental",
+    "compliance",
+    "trading",
+    "lead_gen",
+    "auto_detailing",
 ]

--- a/verticals/auto_detailing/README.md
+++ b/verticals/auto_detailing/README.md
@@ -1,0 +1,45 @@
+# Auto Detailing Vertical Pack — CHROMA
+
+**Domain:** Autonomous growth OS for auto detailing, ceramic coating, PPF, and tint shops.
+
+**Why this pack exists**
+
+Detailers lose jobs to speed, not skill. A customer Googles three shops and books the first one that answers. CHROMA is the swarm that answers, qualifies, quotes, and books — then keeps the site, reviews, and socials compounding while the bays are full.
+
+**Core capabilities**
+
+* Lead aggregation across Google, GBP, website, Instagram, Facebook Marketplace, ads, referrals, and missed calls
+* Intent scoring with vehicle-value, photo-quote, and recency weights
+* Instant quote by package × vehicle size, with deposit rules for ceramic / PPF
+* Calendly (or native slot) handoff with prefilled service + vehicle
+* Website presence agents: metadata, local SEO / AEO JSON-LD, gallery, review showcase
+* Landing engagement popup that qualifies visitors 24/7 and steers to self-booking
+* Social autopilot: scheduled posts, Marketplace replies, GBP posts, comment engagement
+* Email / SMS outreach: quote follow-up, 30-day maintenance nudges, membership upsells, review asks
+* Weather holds for exterior work, no-show recovery, photo-quote intake
+
+**Protocols included (research-backed)**
+
+| Protocol | Effect |
+|---|---|
+| Sub-5-minute first response | Captures comparison shoppers |
+| Photo-quote intake | Cuts back-and-forth on ceramic / interior jobs |
+| Deposit-on-booking for coatings | Collapses no-shows |
+| T-24h / T-2h reminders | No-show rate toward <2% |
+| Post-job review request (T+2h) | GBP ranking compounding |
+| 30 / 60 / 90-day wash membership nudges | Smooths seasonal demand |
+| Seasonal campaign engine | Salt, pollen, summer ceramic, fall PPF |
+| AEO FAQ + LocalBusiness JSON-LD | Surfaces in AI search and Maps |
+| Missed-call text-back | Recovers after-hours demand |
+| Upsell graph wash → interior → ceramic → PPF | Raises ticket without extra ads |
+
+**Integration points**
+
+* Marketplace capability discovery (`agent_card.json`)
+* Core task router with circuit-breaker protection
+* A2A-compliant skill ids (`detailing-lead-ingest`, `detailing-booking`, `detailing-presence`, `detailing-social`, `detailing-copy`, `detailing-engage`)
+* Calendly deep links via shop config (`calendly_handle`, event slugs)
+
+**Resilience**
+
+Circuit breaker protection enabled on all agent executions.

--- a/verticals/auto_detailing/__init__.py
+++ b/verticals/auto_detailing/__init__.py
@@ -1,0 +1,4 @@
+from ..agent import VerticalAgent
+from .agent import AutoDetailingAgent
+
+__all__ = ["VerticalAgent", "AutoDetailingAgent"]

--- a/verticals/auto_detailing/agent.py
+++ b/verticals/auto_detailing/agent.py
@@ -1,0 +1,113 @@
+"""CHROMA — auto detailing vertical agent (production A2A entry)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..agent import VerticalAgent
+from .booking_agent import DetailingBookingAgent
+from .copy_agent import DetailingCopyAgent
+from .engagement_agent import DetailingEngagementAgent
+from .lead_agent import DetailingLeadAgent
+from .outreach_agent import DetailingOutreachAgent
+from .presence_agent import DetailingPresenceAgent
+from .schemas import TaskInput, TaskOutput
+from .social_agent import DetailingSocialAgent
+
+
+class AutoDetailingAgent(VerticalAgent):
+    name = "auto_detailing_agent"
+    version = "1.0.0"
+    description = (
+        "Autonomous growth OS for auto detailing shops: lead aggregation, "
+        "intent scoring, instant quotes, Calendly self-booking, website SEO / "
+        "metadata / gallery / reviews, landing engagement, social autopilot, "
+        "and email/SMS outreach that steers to a booked bay."
+    )
+    capabilities = [
+        "lead_ingest",
+        "lead_score",
+        "quote_estimate",
+        "calendly_handoff",
+        "ad_copy",
+        "seo_optimize",
+        "metadata_optimize",
+        "gallery_curate",
+        "review_showcase",
+        "review_reply",
+        "landing_engage",
+        "social_schedule",
+        "social_engage",
+        "email_outreach",
+        "membership_nudge",
+        "missed_call_textback",
+        "photo_quote",
+        "seasonal_campaign",
+    ]
+    tags = ["auto_detailing", "detailing", "ceramic", "ppf", "booking", "local_seo", "chroma"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.leads = DetailingLeadAgent()
+        self.booking = DetailingBookingAgent()
+        self.copy = DetailingCopyAgent()
+        self.presence = DetailingPresenceAgent()
+        self.social = DetailingSocialAgent()
+        self.engage_agent = DetailingEngagementAgent()
+        self.outreach = DetailingOutreachAgent()
+
+    def execute(self, task: dict) -> dict:  # type: ignore[override]
+        task_input = TaskInput.model_validate(task)
+        task_type = task_input.task_type
+        payload: Dict[str, Any] = dict(task_input.payload or {})
+        cid = task_input.correlation_id
+
+        # Skill-id aliases from A2A dispatch.
+        aliases = {
+            "detailing-lead-ingest": "lead_ingest",
+            "detailing-booking": "calendly_handoff",
+            "detailing-presence": "seo_optimize",
+            "detailing-social": "social_schedule",
+            "detailing-copy": "ad_copy",
+            "detailing-engage": "landing_engage",
+        }
+        task_type = aliases.get(task_type, task_type)
+
+        try:
+            result = self._route(task_type, payload)
+            return TaskOutput(status="success", result=result, correlation_id=cid).model_dump()
+        except ValueError as exc:
+            return TaskOutput(
+                status="error", result={}, error=str(exc), correlation_id=cid
+            ).model_dump()
+
+    def _route(self, task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if task_type in {"lead_ingest", "photo_quote"}:
+            return self.leads.ingest(payload)
+        if task_type in {"lead_score", "lead_qualify"}:
+            return self.leads.score_batch(payload)
+        if task_type == "quote_estimate":
+            return self.booking.quote(payload)
+        if task_type in {"calendly_handoff", "booking"}:
+            return self.booking.calendly_handoff(payload)
+        if task_type in {"ad_copy", "copy"}:
+            return self.copy.generate(payload)
+        if task_type in {"seo_optimize", "metadata_optimize", "gallery_curate", "review_showcase"}:
+            return self.presence.optimize(payload)
+        if task_type == "review_reply":
+            return self.presence.review_reply(payload)
+        if task_type in {"landing_engage", "engage"}:
+            return self.engage_agent.engage(payload)
+        if task_type == "missed_call_textback":
+            return self.engage_agent.missed_call(payload)
+        if task_type == "social_schedule":
+            return self.social.schedule(payload)
+        if task_type == "social_engage":
+            return self.social.engage(payload)
+        if task_type == "seasonal_campaign":
+            return self.social.seasonal(payload)
+        if task_type in {"email_outreach", "membership_nudge"}:
+            if task_type == "membership_nudge":
+                payload = {**payload, "kind": "membership_nudge"}
+            return self.outreach.sequence(payload)
+        raise ValueError(f"Unsupported detailing task: {task_type}")

--- a/verticals/auto_detailing/agent_card.json
+++ b/verticals/auto_detailing/agent_card.json
@@ -1,0 +1,106 @@
+{
+  "name": "SINCOR2 Auto Detailing Pack — CHROMA",
+  "description": "Autonomous growth OS for auto detailing, ceramic coating, PPF, and tint shops. Aggregates leads, scores intent, quotes by vehicle size, hands off to Calendly, keeps the website/reviews/gallery compounding, and runs social + email outreach that steers to self-booking.",
+  "version": "1.0.0",
+  "supportedInterfaces": [
+    {
+      "url": "https://getsincor.com/api/a2a",
+      "protocolBinding": "JSONRPC",
+      "protocolVersion": "1.0.1"
+    }
+  ],
+  "provider": {
+    "organization": "SINCOR2",
+    "url": "https://getsincor.com"
+  },
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": true,
+    "stateTransitionHistory": true
+  },
+  "defaultInputModes": ["application/json"],
+  "defaultOutputModes": ["application/json"],
+  "skills": [
+    {
+      "id": "detailing-lead-ingest",
+      "name": "Detailing Lead Ingest & Score",
+      "description": "Ingests Google, GBP, website, Instagram, Marketplace, ads, referral, and missed-call leads. Scores intent, vehicle value, and photo-quote completeness.",
+      "tags": ["detailing", "leads", "scoring", "marketplace"],
+      "examples": [
+        "Ingest a Facebook Marketplace ceramic lead with photos.",
+        "Score a batch of weekend wash inquiries."
+      ],
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "detailing-booking",
+      "name": "Quote & Calendly Handoff",
+      "description": "Prices packages by vehicle size, applies coating deposits, weather-holds exterior work, and returns a prefilled Calendly URL.",
+      "tags": ["detailing", "booking", "calendly", "quote"],
+      "examples": [
+        "Quote a ceramic coating for a 2022 BMW X5.",
+        "Hand a qualified interior lead to Calendly."
+      ],
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "detailing-presence",
+      "name": "Website, SEO, Gallery & Reviews",
+      "description": "Writes metadata, LocalBusiness + AEO FAQ JSON-LD, gallery alt text, and review showcase widgets. Replies to Google reviews.",
+      "tags": ["seo", "aeo", "reviews", "gallery", "gbp"],
+      "examples": [
+        "Optimize title and JSON-LD for a Dubuque detailing shop.",
+        "Draft a reply to a 5-star ceramic review."
+      ],
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "detailing-social",
+      "name": "Social Autopilot",
+      "description": "Builds a weekly content calendar (before/after, education, offer, bay life, reviews) and replies to comments/DMs by steering to self-booking.",
+      "tags": ["social", "instagram", "gbp", "marketplace"],
+      "examples": [
+        "Schedule five posts for this week.",
+        "Reply to a comment asking how much ceramic costs."
+      ],
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "detailing-copy",
+      "name": "Detailing Ad Copy",
+      "description": "Generates Google RSA, Meta, GBP, SMS, email, and landing copy for detailing offers.",
+      "tags": ["copy", "ads", "google", "meta"],
+      "examples": [
+        "Write Google RSAs for ceramic coating in Dubuque.",
+        "Draft an SMS for a quote follow-up."
+      ],
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "detailing-engage",
+      "name": "Landing Engagement Agent",
+      "description": "24/7 site popup that qualifies visitors, prices the job, and hands them a booking link. Also runs missed-call text-back.",
+      "tags": ["chat", "popup", "booking", "after-hours"],
+      "examples": [
+        "Greet a visitor on the ceramic page.",
+        "Text back a missed call asking about PPF."
+      ],
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
+    }
+  ],
+  "securitySchemes": {
+    "apiKey": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "X-API-Key"
+    }
+  },
+  "security": [{ "apiKey": [] }],
+  "documentationUrl": "https://getsincor.com/docs/api"
+}

--- a/verticals/auto_detailing/booking_agent.py
+++ b/verticals/auto_detailing/booking_agent.py
@@ -1,0 +1,131 @@
+"""Quote math, Calendly handoff, weather holds, and deposit rules."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict
+from urllib.parse import urlencode
+from uuid import uuid4
+
+from .protocols import (
+    PACKAGES,
+    PHOTO_QUOTE_FAMILIES,
+    WEATHER_HOLD_PRECIP_PCT,
+    deposit_for,
+    vehicle_size_from_body,
+)
+from .schemas import BookingHandoffRequest, QuoteRequest, Vehicle
+
+
+def _quote(req: QuoteRequest) -> Dict[str, Any]:
+    pkg = PACKAGES.get(req.package_id)
+    if not pkg:
+        raise ValueError(f"Unknown package: {req.package_id}")
+    size = req.vehicle.size or vehicle_size_from_body(req.vehicle.body_style, req.vehicle.make)
+    multiplier = {
+        "compact": 0.90,
+        "sedan": 1.00,
+        "coupe": 1.00,
+        "suv": 1.20,
+        "crossover": 1.12,
+        "truck": 1.25,
+        "van": 1.28,
+        "exotic": 1.45,
+        "oversized": 1.35,
+    }.get(size, 1.0)
+    mobile_fee = 45 if req.mobile else 0
+    addon_fees = {"engine_bay": 65, "pet_hair": 85, "headlight": 90, "ozone": 70}
+    addons_total = sum(addon_fees.get(a, 40) for a in req.addons)
+    base = float(pkg["price"]) * multiplier
+    total = round(base + addons_total + mobile_fee, 2)
+    deposit_rate = deposit_for(req.package_id)
+    deposit = round(total * deposit_rate, 2)
+    family = str(pkg["family"])
+    return {
+        "package_id": req.package_id,
+        "label": pkg["label"],
+        "vehicle_size": size,
+        "duration_min": pkg["duration_min"],
+        "base_price": float(pkg["price"]),
+        "size_multiplier": multiplier,
+        "addons_total": addons_total,
+        "mobile_fee": mobile_fee,
+        "total": total,
+        "deposit": deposit,
+        "deposit_rate": deposit_rate,
+        "balance_due_at_bay": round(total - deposit, 2),
+        "photo_quote_recommended": family in PHOTO_QUOTE_FAMILIES,
+        "exterior": bool(pkg["exterior"]),
+    }
+
+
+class DetailingBookingAgent:
+    def quote(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        vehicle = Vehicle.model_validate(payload.get("vehicle") or {})
+        req = QuoteRequest(
+            package_id=payload.get("package_id") or payload.get("input") or "full_detail",
+            vehicle=vehicle,
+            addons=list(payload.get("addons") or []),
+            mobile=bool(payload.get("mobile", False)),
+        )
+        if req.package_id not in PACKAGES:
+            req = req.model_copy(update={"package_id": "full_detail"})
+        return _quote(req)
+
+    def calendly_handoff(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        vehicle = Vehicle.model_validate(payload.get("vehicle") or {})
+        req = BookingHandoffRequest(
+            lead_id=payload.get("lead_id"),
+            package_id=payload.get("package_id", "full_detail"),
+            vehicle=vehicle,
+            name=payload.get("name"),
+            email=payload.get("email"),
+            phone=payload.get("phone"),
+            calendly_handle=payload.get("calendly_handle", "northline-detail"),
+            preferred_slot=payload.get("preferred_slot"),
+            weather_precip_pct=payload.get("weather_precip_pct"),
+        )
+        if req.package_id not in PACKAGES:
+            req = req.model_copy(update={"package_id": "full_detail"})
+        quote = _quote(
+            QuoteRequest(package_id=req.package_id, vehicle=req.vehicle, mobile=bool(payload.get("mobile")))
+        )
+        pkg = PACKAGES[req.package_id]
+        event = str(pkg["calendly_event"])
+        params = {
+            "name": req.name or "",
+            "email": req.email or "",
+            "a1": " ".join(
+                str(p)
+                for p in (req.vehicle.year, req.vehicle.make, req.vehicle.model)
+                if p
+            ),
+            "a2": str(pkg["label"]),
+            "utm_source": "chroma",
+            "utm_medium": "agent",
+            "utm_campaign": req.package_id,
+        }
+        url = f"https://calendly.com/{req.calendly_handle}/{event}?{urlencode(params)}"
+        precip = req.weather_precip_pct if req.weather_precip_pct is not None else 0
+        weather_hold = bool(pkg["exterior"]) and precip >= WEATHER_HOLD_PRECIP_PCT
+        booking_id = f"BK-{uuid4().hex[:8].upper()}"
+        reminders = [
+            (datetime.now(timezone.utc) + timedelta(hours=-24)).isoformat(),
+            (datetime.now(timezone.utc) + timedelta(hours=-2)).isoformat(),
+        ]
+        return {
+            "booking_id": booking_id,
+            "lead_id": req.lead_id,
+            "calendly_url": url,
+            "event": event,
+            "quote": quote,
+            "weather_hold": weather_hold,
+            "weather_reason": (
+                f"Exterior work paused — precipitation forecast {precip}%"
+                if weather_hold
+                else None
+            ),
+            "reminders": ["T-24h", "T-2h"],
+            "deposit_required": quote["deposit"] > 0,
+            "self_serve": True,
+        }

--- a/verticals/auto_detailing/copy_agent.py
+++ b/verticals/auto_detailing/copy_agent.py
@@ -1,0 +1,120 @@
+"""Ad copy, RSA, Meta, SMS, and landing headlines for detailing shops."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .protocols import PACKAGES, SEASONAL_CAMPAIGNS
+from .schemas import CopyRequest
+
+
+def _package_label(package_id: str | None) -> str:
+    if package_id and package_id in PACKAGES:
+        return str(PACKAGES[package_id]["label"])
+    return "auto detailing"
+
+
+class DetailingCopyAgent:
+    def generate(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        req = CopyRequest(
+            channel=payload.get("channel") or payload.get("input") or "google_rsa",
+            package_id=payload.get("package_id"),
+            city=payload.get("city", "Dubuque"),
+            offer=payload.get("offer"),
+            tone=payload.get("tone", "direct"),
+        )
+        service = _package_label(req.package_id)
+        city = req.city
+        offer = req.offer or "Same-week bays. Deposit locks ceramic dates."
+        season = next((c for c in SEASONAL_CAMPAIGNS if c["package"] == (req.package_id or "")), None)
+
+        if req.channel in {"google_rsa", "google"}:
+            headlines: List[str] = [
+                f"{service.title()} in {city}",
+                f"Book {service} This Week",
+                f"{city} Ceramic & Detail",
+                "Self-Book in 60 Seconds",
+                "Paint Correction Specialists",
+                f"{city} Auto Detailing",
+                "Deposits Save Your Bay",
+                "Mobile & Shop Bays Open",
+                "Before/After, Not Filters",
+                "Google-Rated Local Shop",
+                offer[:30],
+                "Skip the Text Tag — Book",
+                "Interior Revival From $249",
+                "PPF Consult by Photo Quote",
+                "Membership Washes, 30-Day",
+            ]
+            descriptions = [
+                f"Northline Detail — {city}. {offer} Choose a package, add your vehicle, book the next open bay.",
+                "Ceramic, PPF, paint correction, interiors. Instant quote. Review-backed. Open late for drop-offs.",
+            ]
+            return {
+                "channel": "google_rsa",
+                "headlines": headlines[:15],
+                "descriptions": descriptions,
+                "path1": "detailing",
+                "path2": city.lower().replace(" ", "-"),
+                "keywords": [
+                    f"auto detailing {city}",
+                    f"ceramic coating {city}",
+                    f"mobile detailing {city}",
+                    "paint correction near me",
+                ],
+            }
+
+        if req.channel in {"meta", "facebook", "instagram"}:
+            primary = (
+                f"Your {city} neighbors are comparing three detailers and booking the first one that answers. "
+                f"We answer in under 90 seconds — and you pick the bay yourself."
+            )
+            return {
+                "channel": "meta",
+                "primary_text": primary,
+                "headline": f"{service} — {city}",
+                "description": offer,
+                "cta": "Book Now",
+                "placements": ["feed", "stories", "reels"],
+            }
+
+        if req.channel == "gbp":
+            body = season["offer"] if season else (
+                f"{city} {service}. Photo-quote ceramic and PPF. Self-book washes and interiors today."
+            )
+            return {
+                "channel": "gbp",
+                "summary": f"{service} in {city}",
+                "body": body,
+                "cta": season["cta"] if season else "Book online",
+            }
+
+        if req.channel == "sms":
+            return {
+                "channel": "sms",
+                "body": (
+                    f"Northline: your {service} quote is ready. "
+                    f"{offer} Book here — it takes about a minute."
+                )[:160],
+            }
+
+        if req.channel == "email":
+            return {
+                "channel": "email",
+                "subject": f"{city} {service} — your bay is open",
+                "preview": offer,
+                "body": (
+                    f"Hi — you asked about {service}. "
+                    f"We priced it for your vehicle and held the logic (not the bay) until you book.\n\n"
+                    f"{offer}\n\n"
+                    "Self-book the next slot. Coatings take a deposit so no-shows don't steal the day."
+                ),
+            }
+
+        return {
+            "channel": "landing",
+            "headline": f"The {city} shop that books itself.",
+            "subhead": f"{service}. Instant quote. Live bays. {offer}",
+            "primary_cta": "See open bays",
+            "secondary_cta": "Get a photo quote",
+        }

--- a/verticals/auto_detailing/engagement_agent.py
+++ b/verticals/auto_detailing/engagement_agent.py
@@ -1,0 +1,115 @@
+"""Landing popup + after-hours engagement that qualifies and books."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .booking_agent import DetailingBookingAgent
+from .protocols import FIRST_RESPONSE_SECONDS, PACKAGES
+
+
+_STEPS = ("greet", "service", "vehicle", "quote", "book")
+
+
+class DetailingEngagementAgent:
+    """Site visitor agent — popup, missed-call text-back, photo-quote chat."""
+
+    def __init__(self) -> None:
+        self._booking = DetailingBookingAgent()
+
+    def engage(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        message = (payload.get("visitor_message") or payload.get("input") or "").strip()
+        page = payload.get("page", "/")
+        step = payload.get("step") or "greet"
+        history: List[Dict[str, str]] = list(payload.get("history") or [])
+
+        if not message:
+            return {
+                "step": "greet",
+                "prompt": (
+                    "Need the car camera-ready or just honest-clean? "
+                    "Tell me the year, make, and what you want done — I'll price it and hand you the calendar."
+                ),
+                "quick_replies": ["Wash", "Interior", "Ceramic", "PPF"],
+                "popup_delay_ms": 4000,
+                "exit_intent": True,
+                "sla_seconds": FIRST_RESPONSE_SECONDS,
+                "page": page,
+            }
+
+        lower = message.lower()
+        package_id = payload.get("package_id")
+        for key, pkg in PACKAGES.items():
+            label = str(pkg["label"]).lower()
+            if key.replace("_", " ") in lower or label.split()[0].lower() in lower:
+                package_id = key
+                break
+        if "ceramic" in lower:
+            package_id = "ceramic"
+        elif "ppf" in lower or "film" in lower:
+            package_id = "ppf"
+        elif "interior" in lower:
+            package_id = "interior"
+        elif "correct" in lower:
+            package_id = "paint_correction"
+        elif "wash" in lower:
+            package_id = "maintenance_wash"
+
+        if package_id:
+            quote = self._booking.quote(
+                {
+                    "package_id": package_id,
+                    "vehicle": payload.get("vehicle") or {},
+                    "mobile": "mobile" in lower,
+                }
+            )
+            handoff = self._booking.calendly_handoff(
+                {
+                    "package_id": package_id,
+                    "vehicle": payload.get("vehicle") or {},
+                    "name": payload.get("known_name"),
+                    "email": payload.get("email"),
+                    "phone": payload.get("phone"),
+                    "calendly_handle": payload.get("calendly_handle", "northline-detail"),
+                }
+            )
+            return {
+                "step": "book",
+                "package_id": package_id,
+                "reply": (
+                    f"{quote['label']} for a {quote['vehicle_size']} lands at ${quote['total']:.0f}. "
+                    + (
+                        f"${quote['deposit']:.0f} deposit holds the bay. "
+                        if quote["deposit"]
+                        else "No deposit on this package. "
+                    )
+                    + "Grab the next open slot — no one has to text you back."
+                ),
+                "quote": quote,
+                "calendly_url": handoff["calendly_url"],
+                "cta": "Self-book this bay",
+                "history": history,
+            }
+
+        return {
+            "step": step if step != "greet" else "service",
+            "reply": (
+                "Got it. Wash, interior, ceramic, or film? "
+                "Add year/make if you have it — size changes the number."
+            ),
+            "quick_replies": ["Maintenance wash", "Interior revival", "Ceramic coating", "PPF consult"],
+            "history": history + [{"role": "visitor", "text": message}],
+        }
+
+    def missed_call(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        phone = payload.get("phone") or "unknown"
+        return {
+            "channel": "sms",
+            "to": phone,
+            "body": (
+                "Northline Detail — we missed you. Reply WASH, INTERIOR, CERAMIC, or PPF "
+                "and we'll send a quote plus a booking link. Usually faster than a callback."
+            ),
+            "sent": True,
+            "sla_seconds": 30,
+        }

--- a/verticals/auto_detailing/lead_agent.py
+++ b/verticals/auto_detailing/lead_agent.py
@@ -1,0 +1,108 @@
+"""Lead aggregation, scoring, and qualification for detailing shops."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from uuid import uuid4
+
+from .protocols import INTENT_KEYWORDS, LUXURY_MAKES, SOURCE_WEIGHT
+from .schemas import LeadIngestRequest, Vehicle
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def score_lead(req: LeadIngestRequest) -> Dict[str, Any]:
+    text = (req.message or "").lower()
+    source = SOURCE_WEIGHT.get(req.source, 0.55)
+    intent = 0.08
+    matched: List[str] = []
+    for kw, lift in INTENT_KEYWORDS.items():
+        if kw in text:
+            intent += lift
+            matched.append(kw)
+    intent = min(intent, 1.0)
+
+    vehicle_lift = 0.0
+    make = (req.vehicle.make if req.vehicle else None) or ""
+    if make.lower() in LUXURY_MAKES:
+        vehicle_lift += 0.18
+    condition = (req.vehicle.condition if req.vehicle else None) or ""
+    if condition in {"dirty", "neglected"}:
+        vehicle_lift += 0.10
+    if req.vehicle and req.vehicle.year:
+        vehicle_lift += 0.04
+
+    photo_lift = 0.12 if req.photo_urls else 0.0
+    identity_lift = 0.06 if (req.email or req.phone) else 0.0
+
+    raw = (source * 0.42) + (intent * 0.32) + vehicle_lift + photo_lift + identity_lift
+    score = round(min(max(raw, 0.05), 0.99) * 100, 1)
+
+    if score >= 78:
+        band = "hot"
+        action = "book_now"
+    elif score >= 58:
+        band = "warm"
+        action = "qualify"
+    else:
+        band = "nurture"
+        action = "sequence"
+
+    return {
+        "score": score,
+        "band": band,
+        "next_action": action,
+        "matched_intents": matched,
+        "source_weight": source,
+        "photo_quote": bool(req.photo_urls),
+        "sla_seconds": 90,
+    }
+
+
+class DetailingLeadAgent:
+    """Ingests multi-channel leads and ranks them for booking."""
+
+    def ingest(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        vehicle_raw = payload.get("vehicle") or {}
+        vehicle = Vehicle.model_validate(vehicle_raw) if vehicle_raw else None
+        req = LeadIngestRequest(
+            source=payload.get("source", "website"),
+            name=payload.get("name"),
+            email=payload.get("email"),
+            phone=payload.get("phone"),
+            message=payload.get("message") or payload.get("input") or "",
+            vehicle=vehicle,
+            photo_urls=list(payload.get("photo_urls") or []),
+            zip_code=payload.get("zip_code"),
+            landing_page=payload.get("landing_page"),
+            utm=dict(payload.get("utm") or {}),
+        )
+        ranking = score_lead(req)
+        lead_id = f"LD-{uuid4().hex[:8].upper()}"
+        return {
+            "lead_id": lead_id,
+            "ingested_at": _now(),
+            "source": req.source,
+            "name": req.name,
+            "contact": {"email": req.email, "phone": req.phone},
+            "vehicle": req.vehicle.model_dump() if req.vehicle else None,
+            "message": req.message,
+            "ranking": ranking,
+            "pipeline_stage": "new" if ranking["band"] != "hot" else "ready_to_book",
+        }
+
+    def score_batch(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        leads = payload.get("leads") or []
+        ranked = []
+        for item in leads:
+            ranked.append(self.ingest(item))
+        ranked.sort(key=lambda row: row["ranking"]["score"], reverse=True)
+        hot = sum(1 for row in ranked if row["ranking"]["band"] == "hot")
+        return {
+            "count": len(ranked),
+            "hot": hot,
+            "leads": ranked,
+        }

--- a/verticals/auto_detailing/outreach_agent.py
+++ b/verticals/auto_detailing/outreach_agent.py
@@ -1,0 +1,104 @@
+"""Email / SMS sequences: follow-up, membership nudges, review asks, winbacks."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .protocols import MEMBERSHIP_NUDGE_DAYS, MEMBERSHIPS, PACKAGES, UPSELL_GRAPH
+from .schemas import OutreachRequest
+
+
+class DetailingOutreachAgent:
+    def sequence(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        req = OutreachRequest(
+            kind=payload.get("kind") or payload.get("input") or "quote_followup",
+            name=payload.get("name") or "there",
+            package_id=payload.get("package_id"),
+            last_service_days=payload.get("last_service_days"),
+            channel=payload.get("channel", "email"),
+        )
+        pkg_label = (
+            str(PACKAGES[req.package_id]["label"])
+            if req.package_id in PACKAGES
+            else "detailing"
+        )
+        next_up = UPSELL_GRAPH.get(req.package_id or "", "ceramic")
+        next_label = str(PACKAGES.get(next_up, {}).get("label", "ceramic coating"))
+
+        if req.kind == "quote_followup":
+            steps: List[Dict[str, Any]] = [
+                {
+                    "day": 0,
+                    "channel": req.channel,
+                    "subject": f"{req.name}, your {pkg_label} quote is still live",
+                    "body": (
+                        f"Still holding the math for your {pkg_label}. "
+                        "Bays move — grab the slot if you want this week."
+                    ),
+                },
+                {
+                    "day": 2,
+                    "channel": "sms",
+                    "body": f"Northline: 2-day follow-up on {pkg_label}. Booking link in the last email.",
+                },
+                {
+                    "day": 5,
+                    "channel": "email",
+                    "subject": "We'll release the hold",
+                    "body": "If timing was the issue, the membership wash is the easier on-ramp.",
+                },
+            ]
+        elif req.kind == "membership_nudge":
+            days = req.last_service_days or MEMBERSHIP_NUDGE_DAYS[0]
+            plan = MEMBERSHIPS["monthly_gloss"]
+            steps = [
+                {
+                    "day": 0,
+                    "channel": req.channel,
+                    "subject": f"{days} days since the last wash",
+                    "body": (
+                        f"{req.name}, clear coat doesn't wait. "
+                        f"{plan['label']} is ${plan['price']}/mo — same bay, no re-booking tax."
+                    ),
+                }
+            ]
+        elif req.kind == "review_ask":
+            steps = [
+                {
+                    "day": 0,
+                    "channel": "sms",
+                    "body": (
+                        f"Thanks {req.name}. If the {pkg_label} looks like the photos, "
+                        "a Google review takes 20 seconds and actually moves our rank."
+                    ),
+                }
+            ]
+        elif req.kind == "winback":
+            steps = [
+                {
+                    "day": 0,
+                    "channel": "email",
+                    "subject": "Your ceramic isn't immortal",
+                    "body": (
+                        f"It's been a while. The honest next step is a {next_label} "
+                        "inspection wash — we'll tell you if the coating still beads."
+                    ),
+                }
+            ]
+        else:
+            steps = [
+                {
+                    "day": 0,
+                    "channel": req.channel,
+                    "subject": f"Next up: {next_label}",
+                    "body": f"Most {pkg_label} clients add {next_label} within 90 days. Photo quote is open.",
+                }
+            ]
+        return {
+            "kind": req.kind,
+            "contact": req.name,
+            "channel": req.channel,
+            "steps": steps,
+            "stop_on_book": True,
+            "compliance": {"opt_out": True, "quiet_hours": True},
+        }

--- a/verticals/auto_detailing/presence_agent.py
+++ b/verticals/auto_detailing/presence_agent.py
@@ -1,0 +1,141 @@
+"""Website metadata, local SEO / AEO, gallery, and review showcase."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .protocols import AEO_FAQS, GBP_CATEGORIES, LOCAL_SEO_KEYWORDS, PACKAGES
+from .schemas import PresenceRequest
+
+
+def _json_ld(req: PresenceRequest) -> Dict[str, Any]:
+    return {
+        "@context": "https://schema.org",
+        "@type": ["AutoRepair", "LocalBusiness"],
+        "name": req.shop_name,
+        "url": req.url,
+        "telephone": req.phone,
+        "address": {
+            "@type": "PostalAddress",
+            "addressLocality": req.city,
+            "addressRegion": req.region,
+            "addressCountry": "US",
+        },
+        "image": [g.get("src") for g in req.gallery if g.get("src")],
+        "priceRange": "$$-$$$",
+        "knowsAbout": list(LOCAL_SEO_KEYWORDS),
+        "hasOfferCatalog": {
+            "@type": "OfferCatalog",
+            "name": "Detailing services",
+            "itemListElement": [
+                {
+                    "@type": "Offer",
+                    "itemOffered": {"@type": "Service", "name": str(p["label"])},
+                    "price": p["price"],
+                    "priceCurrency": "USD",
+                }
+                for p in PACKAGES.values()
+            ],
+        },
+        "aggregateRating": _aggregate(req.reviews),
+        "mainEntity": [
+            {"@type": "Question", "name": q, "acceptedAnswer": {"@type": "Answer", "text": a}}
+            for q, a in AEO_FAQS
+        ],
+    }
+
+
+def _aggregate(reviews: List[Dict[str, Any]]) -> Dict[str, Any] | None:
+    if not reviews:
+        return None
+    ratings = [float(r.get("rating", 5)) for r in reviews]
+    return {
+        "@type": "AggregateRating",
+        "ratingValue": round(sum(ratings) / len(ratings), 2),
+        "reviewCount": len(ratings),
+        "bestRating": 5,
+    }
+
+
+class DetailingPresenceAgent:
+    def optimize(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        req = PresenceRequest(
+            shop_name=payload.get("shop_name", "Northline Detail"),
+            city=payload.get("city", "Dubuque"),
+            region=payload.get("region", "IA"),
+            phone=payload.get("phone", "(563) 555-0148"),
+            url=payload.get("url", "https://northlinedetail.com"),
+            services=list(payload.get("services") or list(PACKAGES.keys())),
+            reviews=list(payload.get("reviews") or []),
+            gallery=list(payload.get("gallery") or []),
+        )
+        title = f"{req.shop_name} | Ceramic, PPF & Auto Detailing in {req.city}, {req.region}"
+        description = (
+            f"{req.shop_name} is the {req.city} detailing shop you can actually book. "
+            "Ceramic coatings, paint correction, interiors, and membership washes — "
+            "instant quotes, photo intake, self-serve calendar."
+        )
+        title = title[:60]
+        description = description[:155]
+        gallery = []
+        for item in req.gallery:
+            alt = item.get("alt") or (
+                f"{item.get('vehicle', 'Vehicle')} {item.get('kind', 'after')} — {req.shop_name} {req.city}"
+            )
+            gallery.append({**item, "alt": alt[:120]})
+        showcase = sorted(
+            [r for r in req.reviews if float(r.get("rating", 0)) >= 4],
+            key=lambda r: float(r.get("rating", 0)),
+            reverse=True,
+        )[:6]
+        score = 62
+        score += 8 if 50 <= len(title) <= 60 else 0
+        score += 8 if 140 <= len(description) <= 155 else 0
+        score += 6 if gallery else 0
+        score += 6 if showcase else 0
+        score += 5  # JSON-LD always present
+        score = min(score, 98)
+        return {
+            "title": title,
+            "meta_description": description,
+            "canonical": req.url,
+            "og": {
+                "title": title,
+                "description": description,
+                "type": "website",
+            },
+            "json_ld": _json_ld(req),
+            "gbp_categories": list(GBP_CATEGORIES),
+            "keywords": [f"{kw} {req.city}" for kw in LOCAL_SEO_KEYWORDS[:6]],
+            "gallery": gallery,
+            "review_showcase": showcase,
+            "aeo_faqs": [{"q": q, "a": a} for q, a in AEO_FAQS],
+            "seo_score": score,
+            "fixes": [
+                "Keep title 50–60 characters with city + primary service.",
+                "Pin 6 five-star reviews with vehicle + service mentioned.",
+                "Every gallery image needs vehicle + treatment in alt text.",
+                "Publish weekly GBP photos from the bay, not stock.",
+            ],
+        }
+
+    def review_reply(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        author = payload.get("author") or "there"
+        rating = float(payload.get("rating", 5))
+        service = payload.get("service") or "detail"
+        if rating >= 5:
+            text = (
+                f"Thanks {author} — glad the {service} landed the way it should. "
+                "Book the 30-day maintenance wash from the same link so the finish stays honest."
+            )
+        elif rating >= 4:
+            text = (
+                f"Appreciate you {author}. If anything on the {service} was a hair off, "
+                "text the shop — we'll make the next visit cleaner."
+            )
+        else:
+            text = (
+                f"{author}, sorry the {service} missed. A manager will reach out today "
+                "to make it right before we ask for another look."
+            )
+        return {"author": author, "rating": rating, "reply": text, "public": True}

--- a/verticals/auto_detailing/protocols.py
+++ b/verticals/auto_detailing/protocols.py
@@ -1,0 +1,270 @@
+"""Shared protocols for the auto detailing vertical.
+
+These constants encode how high-performing detail shops actually autopilot:
+speed-to-lead, photo quotes, deposits on coatings, review compounding,
+membership cadence, seasonal offers, and self-serve booking.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, FrozenSet, List, Tuple
+
+# First-response SLA that wins comparison shoppers.
+FIRST_RESPONSE_SECONDS = 90
+QUALIFIED_HANDOFF_SECONDS = 180
+
+# Source intent weights (0–1). Search and missed-call beat social.
+SOURCE_WEIGHT: Dict[str, float] = {
+    "missed_call": 0.96,
+    "google": 0.95,
+    "gbp": 0.92,
+    "referral": 0.90,
+    "website": 0.88,
+    "google_ads": 0.85,
+    "facebook_marketplace": 0.78,
+    "yelp": 0.74,
+    "instagram": 0.62,
+    "tiktok": 0.55,
+    "walk_in": 0.70,
+}
+
+# Message keywords that lift intent.
+INTENT_KEYWORDS: Dict[str, float] = {
+    "ceramic": 0.28,
+    "coating": 0.26,
+    "ppf": 0.30,
+    "paint protection": 0.30,
+    "paint correction": 0.24,
+    "swirl": 0.16,
+    "oxidation": 0.18,
+    "interior": 0.12,
+    "pet hair": 0.14,
+    "detail": 0.10,
+    "wash": 0.06,
+    "salt": 0.14,
+    "pollen": 0.10,
+    "wedding": 0.18,
+    "show car": 0.22,
+    "exotic": 0.20,
+}
+
+LUXURY_MAKES: FrozenSet[str] = frozenset(
+    {
+        "mercedes",
+        "mercedes-benz",
+        "bmw",
+        "audi",
+        "porsche",
+        "tesla",
+        "lexus",
+        "range rover",
+        "land rover",
+        "cadillac",
+        "genesis",
+        "jaguar",
+        "maserati",
+        "ferrari",
+        "lamborghini",
+        "mclaren",
+        "bentley",
+        "rolls-royce",
+        "aston martin",
+        "rivian",
+        "lucid",
+    }
+)
+
+VEHICLE_SIZE_MULTIPLIER: Dict[str, float] = {
+    "compact": 0.90,
+    "sedan": 1.00,
+    "coupe": 1.00,
+    "suv": 1.20,
+    "crossover": 1.12,
+    "truck": 1.25,
+    "van": 1.28,
+    "exotic": 1.45,
+    "oversized": 1.35,
+}
+
+# Deposit fractions by package family.
+DEPOSIT_RATE: Dict[str, float] = {
+    "express_wash": 0.00,
+    "maintenance_wash": 0.00,
+    "interior": 0.20,
+    "full_detail": 0.25,
+    "paint_correction": 0.40,
+    "ceramic": 0.50,
+    "ppf": 0.50,
+    "membership": 0.00,
+}
+
+PACKAGES: Dict[str, Dict[str, object]] = {
+    "express_wash": {
+        "label": "Express Wash",
+        "duration_min": 45,
+        "price": 79,
+        "family": "express_wash",
+        "exterior": True,
+        "calendly_event": "express-wash",
+    },
+    "maintenance_wash": {
+        "label": "Maintenance Wash",
+        "duration_min": 75,
+        "price": 129,
+        "family": "maintenance_wash",
+        "exterior": True,
+        "calendly_event": "maintenance-wash",
+    },
+    "interior": {
+        "label": "Interior Revival",
+        "duration_min": 180,
+        "price": 249,
+        "family": "interior",
+        "exterior": False,
+        "calendly_event": "interior-revival",
+    },
+    "full_detail": {
+        "label": "Signature Detail",
+        "duration_min": 300,
+        "price": 449,
+        "family": "full_detail",
+        "exterior": True,
+        "calendly_event": "signature-detail",
+    },
+    "paint_correction": {
+        "label": "Paint Correction",
+        "duration_min": 480,
+        "price": 899,
+        "family": "paint_correction",
+        "exterior": True,
+        "calendly_event": "paint-correction",
+    },
+    "ceramic": {
+        "label": "Ceramic Coating",
+        "duration_min": 720,
+        "price": 1499,
+        "family": "ceramic",
+        "exterior": True,
+        "calendly_event": "ceramic-coating",
+    },
+    "ppf": {
+        "label": "Paint Protection Film",
+        "duration_min": 960,
+        "price": 2899,
+        "family": "ppf",
+        "exterior": True,
+        "calendly_event": "ppf-consult",
+    },
+}
+
+MEMBERSHIPS: Dict[str, Dict[str, object]] = {
+    "monthly_gloss": {"label": "Monthly Gloss", "price": 149, "interval_days": 30},
+    "fleet_care": {"label": "Fleet Care", "price": 99, "interval_days": 21, "min_vehicles": 4},
+    "ceramic_warranty": {"label": "Ceramic Warranty Wash", "price": 89, "interval_days": 60},
+}
+
+SEASONAL_CAMPAIGNS: List[Dict[str, str]] = [
+    {
+        "id": "winter_salt",
+        "months": "12,1,2,3",
+        "headline": "Salt is etching your clear coat",
+        "offer": "Undercarriage + decontamination wash — book before the next thaw.",
+        "cta": "Book salt removal",
+        "package": "maintenance_wash",
+    },
+    {
+        "id": "spring_pollen",
+        "months": "4,5",
+        "headline": "Pollen is sandpaper",
+        "offer": "Safe decon wash + ceramic booster before the yellow dust sets in.",
+        "cta": "Clear the pollen",
+        "package": "full_detail",
+    },
+    {
+        "id": "summer_ceramic",
+        "months": "6,7,8",
+        "headline": "UV is bleaching unprotected paint",
+        "offer": "Ceramic coating with 50% deposit locks the date. Warranty included.",
+        "cta": "Reserve a coating bay",
+        "package": "ceramic",
+    },
+    {
+        "id": "fall_ppf",
+        "months": "9,10,11",
+        "headline": "Rock chips happen on the first gravel road",
+        "offer": "Front-end PPF consult — photo quote in the chat, no shop visit required.",
+        "cta": "Get a film quote",
+        "package": "ppf",
+    },
+]
+
+# Wash → interior → ceramic → PPF upsell graph.
+UPSELL_GRAPH: Dict[str, str] = {
+    "express_wash": "maintenance_wash",
+    "maintenance_wash": "interior",
+    "interior": "full_detail",
+    "full_detail": "ceramic",
+    "paint_correction": "ceramic",
+    "ceramic": "ppf",
+}
+
+REMINDER_OFFSETS_HOURS: Tuple[int, ...] = (24, 2)
+REVIEW_REQUEST_HOURS_AFTER_JOB = 2
+MEMBERSHIP_NUDGE_DAYS = (30, 60, 90)
+WEATHER_HOLD_PRECIP_PCT = 40
+NO_SHOW_RECOVERY_HOURS = 1
+PHOTO_QUOTE_FAMILIES: FrozenSet[str] = frozenset({"ceramic", "ppf", "paint_correction", "interior"})
+
+LOCAL_SEO_KEYWORDS: Tuple[str, ...] = (
+    "auto detailing near me",
+    "ceramic coating",
+    "paint correction",
+    "mobile detailing",
+    "interior car detailing",
+    "PPF paint protection film",
+    "car wash membership",
+    "salt removal car wash",
+)
+
+GBP_CATEGORIES: Tuple[str, ...] = (
+    "Auto detailing service",
+    "Car wash",
+    "Vehicle wrapping service",
+)
+
+AEO_FAQS: List[Tuple[str, str]] = [
+    (
+        "How long does a ceramic coating take?",
+        "A single-stage coating is a full-day bay. Multi-coat systems run 1–2 days including paint correction.",
+    ),
+    (
+        "Do I need to drop the car off?",
+        "Yes for coatings and PPF. Washes and interiors can be mobile within the service radius if weather allows.",
+    ),
+    (
+        "How do I book?",
+        "Pick a package, confirm vehicle size, and self-book the next open bay. Coatings require a deposit.",
+    ),
+]
+
+
+def vehicle_size_from_body(body_style: str | None, make: str | None) -> str:
+    body = (body_style or "").lower()
+    make_l = (make or "").lower()
+    if make_l in {"ferrari", "lamborghini", "mclaren", "porsche"} or "exotic" in body:
+        return "exotic"
+    if any(k in body for k in ("truck", "pickup", "f-150", "silverado")):
+        return "truck"
+    if "van" in body:
+        return "van"
+    if any(k in body for k in ("suv", "crossover", "4runner", "tahoe", "x5")):
+        return "suv"
+    if "compact" in body or "hatch" in body:
+        return "compact"
+    return "sedan"
+
+
+def deposit_for(package_id: str) -> float:
+    pkg = PACKAGES.get(package_id, {})
+    family = str(pkg.get("family", package_id))
+    return float(DEPOSIT_RATE.get(family, 0.25))

--- a/verticals/auto_detailing/schemas.py
+++ b/verticals/auto_detailing/schemas.py
@@ -1,0 +1,111 @@
+"""Production Pydantic schemas for the auto detailing (CHROMA) vertical."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class TaskInput(BaseModel):
+    task_type: str
+    payload: Dict[str, Any]
+    metadata: Optional[Dict[str, Any]] = Field(default_factory=dict)
+    correlation_id: Optional[str] = None
+
+
+class TaskOutput(BaseModel):
+    status: str = Field(..., pattern="^(success|error|partial)$")
+    result: Dict[str, Any]
+    error: Optional[str] = None
+    correlation_id: Optional[str] = None
+
+
+class Vehicle(BaseModel):
+    year: Optional[int] = Field(None, ge=1950, le=2035)
+    make: Optional[str] = None
+    model: Optional[str] = None
+    body_style: Optional[str] = None
+    color: Optional[str] = None
+    condition: Optional[str] = Field(
+        None, description="showroom | clean | daily | dirty | neglected"
+    )
+    size: Optional[str] = None
+
+
+class LeadIngestRequest(BaseModel):
+    source: str
+    name: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    message: str = ""
+    vehicle: Optional[Vehicle] = None
+    photo_urls: List[str] = Field(default_factory=list)
+    zip_code: Optional[str] = None
+    landing_page: Optional[str] = None
+    utm: Dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("source")
+    @classmethod
+    def source_known(cls, v: str) -> str:
+        return v.strip().lower().replace(" ", "_")
+
+
+class QuoteRequest(BaseModel):
+    package_id: str
+    vehicle: Vehicle = Field(default_factory=Vehicle)
+    addons: List[str] = Field(default_factory=list)
+    mobile: bool = False
+
+
+class BookingHandoffRequest(BaseModel):
+    lead_id: Optional[str] = None
+    package_id: str
+    vehicle: Vehicle = Field(default_factory=Vehicle)
+    name: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    calendly_handle: str = "northline-detail"
+    preferred_slot: Optional[str] = None
+    weather_precip_pct: Optional[int] = None
+
+
+class CopyRequest(BaseModel):
+    channel: str = Field(..., description="google_rsa | meta | gbp | sms | email | landing")
+    package_id: Optional[str] = None
+    city: str = "Dubuque"
+    offer: Optional[str] = None
+    tone: str = "direct"
+
+
+class PresenceRequest(BaseModel):
+    shop_name: str = "Northline Detail"
+    city: str = "Dubuque"
+    region: str = "IA"
+    phone: str = "(563) 555-0148"
+    url: str = "https://northlinedetail.com"
+    services: List[str] = Field(default_factory=list)
+    reviews: List[Dict[str, Any]] = Field(default_factory=list)
+    gallery: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class SocialScheduleRequest(BaseModel):
+    platforms: List[str] = Field(default_factory=lambda: ["instagram", "facebook", "gbp"])
+    cadence_per_week: int = Field(5, ge=1, le=21)
+    city: str = "Dubuque"
+    season: Optional[str] = None
+
+
+class OutreachRequest(BaseModel):
+    kind: str = Field(..., description="quote_followup | membership_nudge | review_ask | winback")
+    name: str
+    package_id: Optional[str] = None
+    last_service_days: Optional[int] = None
+    channel: str = "email"
+
+
+class EngageRequest(BaseModel):
+    visitor_message: str
+    page: str = "/"
+    vehicle: Optional[Vehicle] = None
+    known_name: Optional[str] = None

--- a/verticals/auto_detailing/social_agent.py
+++ b/verticals/auto_detailing/social_agent.py
@@ -1,0 +1,106 @@
+"""Scheduled posting and proactive social engagement that steers to booking."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+
+from .protocols import PACKAGES, SEASONAL_CAMPAIGNS
+
+
+_PILLARS = ("before_after", "education", "offer", "bay_life", "review")
+
+
+class DetailingSocialAgent:
+    def schedule(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        platforms = list(payload.get("platforms") or ["instagram", "facebook", "gbp"])
+        cadence = int(payload.get("cadence_per_week") or 5)
+        city = payload.get("city", "Dubuque")
+        start = datetime.now(timezone.utc).replace(hour=15, minute=0, second=0, microsecond=0)
+        posts: List[Dict[str, Any]] = []
+        for i in range(cadence):
+            pillar = _PILLARS[i % len(_PILLARS)]
+            pkg_id = list(PACKAGES.keys())[i % len(PACKAGES)]
+            pkg = PACKAGES[pkg_id]
+            caption = {
+                "before_after": (
+                    f"Same {city} car. Same sun. Different clear coat. "
+                    f"{pkg['label']} — book the bay from the link in bio."
+                ),
+                "education": (
+                    "If a wash mitt squeaks, you're grinding grit into the clear. "
+                    "Two-bucket or don't bother. We built the membership around that rule."
+                ),
+                "offer": (
+                    f"{city}: {pkg['label']} this week. Self-book, no text tag. "
+                    "Coatings take a deposit so the date actually holds."
+                ),
+                "bay_life": (
+                    "Bay two, lights down, wet floor. This is the part Instagram usually skips — "
+                    "the hour after the polish when the panel either tells the truth or it doesn't."
+                ),
+                "review": (
+                    f"Five stars don't detail the car. Showing up for the 30-day wash does. "
+                    f"{city} members get the bay that keeps ceramic honest."
+                ),
+            }[pillar]
+            when = start + timedelta(days=i)
+            posts.append(
+                {
+                    "id": f"POST-{i+1:02d}",
+                    "at": when.isoformat(),
+                    "platforms": platforms if pillar != "review" else ["gbp", "facebook"],
+                    "pillar": pillar,
+                    "caption": caption,
+                    "cta": "Book from the link — no DM required.",
+                    "package_id": pkg_id,
+                }
+            )
+        return {
+            "cadence_per_week": cadence,
+            "platforms": platforms,
+            "posts": posts,
+            "engagement_policy": {
+                "reply_to_every_comment": True,
+                "steer_to_booking": True,
+                "marketplace_autodm": True,
+                "quiet_hours": "21:00-07:00 local",
+            },
+        }
+
+    def engage(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        inbound = (payload.get("comment") or payload.get("input") or payload.get("message") or "").lower()
+        platform = payload.get("platform", "instagram")
+        if any(k in inbound for k in ("price", "how much", "cost", "$")):
+            reply = (
+                "Pricing is by vehicle size and package — 60-second quote in the booking link. "
+                "Coatings need a photo for a real number."
+            )
+            intent = "quote"
+        elif any(k in inbound for k in ("book", "available", "this week", "saturday")):
+            reply = "Open bays are on the calendar. Pick the package, drop the vehicle, done."
+            intent = "book"
+        elif any(k in inbound for k in ("mobile", "come to me", "house")):
+            reply = (
+                "We mobile washes and interiors inside the radius when weather holds. "
+                "Coatings and PPF stay in the shop bays."
+            )
+            intent = "qualify"
+        else:
+            reply = (
+                "Appreciate you. If you want this finish on yours, the booking link is the fastest path — "
+                "we don't make people DM for a time."
+            )
+            intent = "nurture"
+        return {
+            "platform": platform,
+            "intent": intent,
+            "reply": reply,
+            "cta_url_hint": "/book",
+            "escalate_to_human": intent == "book" and "fleet" in inbound,
+        }
+
+    def seasonal(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        month = int(payload.get("month") or datetime.now(timezone.utc).month)
+        active = [c for c in SEASONAL_CAMPAIGNS if str(month) in c["months"].split(",")]
+        return {"month": month, "campaigns": active}

--- a/verticals/loader.py
+++ b/verticals/loader.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Type
 
 from verticals.agent import VerticalAgent
+from verticals.auto_detailing.agent import AutoDetailingAgent
 from verticals.compliance.agent import ComplianceAgent
 from verticals.dental.agent import DentalAgent
 from verticals.healthcare.agent import HealthcareAgent
@@ -26,6 +27,7 @@ VERTICAL_AGENT_CLASSES: Tuple[Type[VerticalAgent], ...] = (
     TradingAgent,
     LeadGenAgent,
     YieldOptimizerAgent,
+    AutoDetailingAgent,
 )
 
 # Maps A2A skill ids (from Agent Cards or SINCOR catalogue) to vertical agents.
@@ -50,6 +52,12 @@ SKILL_VERTICAL_MAP: Dict[str, str] = {
     "icp-matching": "lead_generation_agent",
     "lead-enrichment": "lead_generation_agent",
     "lead-outreach": "lead_generation_agent",
+    "detailing-lead-ingest": "auto_detailing_agent",
+    "detailing-booking": "auto_detailing_agent",
+    "detailing-presence": "auto_detailing_agent",
+    "detailing-social": "auto_detailing_agent",
+    "detailing-copy": "auto_detailing_agent",
+    "detailing-engage": "auto_detailing_agent",
 }
 
 


### PR DESCRIPTION
## CHROMA — Auto Detailing Vertical

Production vertical pack for detailing / ceramic / PPF / tint shops. Comparison shoppers book the first shop that answers; this swarm answers, qualifies, quotes, and hands them Calendly.

### Agents
- **Lead ingest & score** — Google, GBP, website, Instagram, Marketplace, ads, referrals, missed-call. Intent × vehicle-value × photo-quote weights.
- **Quote → Calendly** — package × vehicle-size pricing, coating deposits, weather holds, prefilled booking URLs.
- **Presence** — metadata, local SEO + AEO FAQ JSON-LD, gallery alt-text, review showcase + replies.
- **Landing engagement** — 24/7 popup that qualifies and self-books. Missed-call text-back.
- **Social autopilot** — weekly calendar (before/after, education, offer, bay life, reviews) + comment replies that steer to booking.
- **Outreach** — quote follow-up, 30/60/90-day membership nudges, review asks, ceramic winbacks.

### Wiring
- `verticals/auto_detailing/` pack + A2A `agent_card.json`
- `VERTICAL_AGENT_CLASSES` / `SKILL_VERTICAL_MAP` in `verticals/loader.py`
- Skill aliases in `src/sincor2/vertical_dispatch.py`
- Tests in `tests/pytest/test_auto_detailing.py`

Skill ids: `detailing-lead-ingest`, `detailing-booking`, `detailing-presence`, `detailing-social`, `detailing-copy`, `detailing-engage`.

Operator OS (CHROMA) is live in the app preview for go-live demo: command center, leads, bays, copy studio, presence, social, outreach, shop with engagement popup.