### PR TITLE
feat: Agent Underwriting — treasury mandate runtime

### DIFF
--- a/docs/underwriting/PARTNER_ONE_PAGER.md
+++ b/docs/underwriting/PARTNER_ONE_PAGER.md
@@ -1,0 +1,13 @@
+# Agent Underwriting
+
+Spend envelopes for machine treasuries.
+
+**Problem.** Static caps treat agent spend like a card swipe. Agents fail over trajectories — loops, new counterparties, rising error rates. Issuers and operators cannot underwrite unattended float.
+
+**Object.** An operator signs an Intent Mandate (max notional, skills, payees, TTL, kill switch). A Temporal Optimization pass scores futures and issues a Spend Envelope. A facilitator outside the model is the only component allowed to move value. Settlement is x402. The same envelope can open a simulated ledger, USDC on Base, or a licensed mint tap later.
+
+**Controls.** CIP attaches to the human/operator. Agents are authorized users. Append-only audit. Freeze and clawback. Fail closed if the path set is empty.
+
+**Not this.** Not a public ticker. Not permissionless issuance. Not yield to holders.
+
+**Ask.** Design-partner slot and, when ready, sandbox keys for closed-loop mint behind the same envelope.

--- a/scripts/underwrite_demo.sh
+++ b/scripts/underwrite_demo.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PYTHONPATH="$ROOT/src:${PYTHONPATH:-}"
+export UNDERWRITE_DATA_DIR="${UNDERWRITE_DATA_DIR:-$ROOT/data/underwriting}"
+export UNDERWRITE_TAP="${UNDERWRITE_TAP:-ledger_sim}"
+rm -rf "$UNDERWRITE_DATA_DIR"
+mkdir -p "$UNDERWRITE_DATA_DIR"
+
+python3 - <<'PY'
+from sincor2.underwriting.runtime import boot
+from sincor2.underwriting.types import AuthorizeRequest
+from sincor2.underwriting.x402_seller import handle_echo
+
+rt = boot()
+m = rt.mandates.issue(
+    operator_id="court",
+    controller_wallet="0x1111111111111111111111111111111111111111",
+    agent_id="E-altair-04",
+    max_notional_usd="25.00",
+    max_single_tx_usd="5.00",
+    allowed_skills=["underwrite.echo"],
+    allowed_payees=["sincor:skill:underwrite.echo"],
+)
+print(f"mandate   {m.mandate_id}  max=25.00 single=5.00 agent={m.agent_id}")
+env = rt.envelopes.request(
+    m,
+    requested_usd="5.00",
+    skill_id="underwrite.echo",
+    payee="sincor:skill:underwrite.echo",
+)
+print(f"envelope  {env.envelope_id}  amount={env.amount_usd} ttl={env.ttl_seconds} reason={env.reason_codes[0]} toa={env.toa_run_id}")
+for i in (1, 2):
+    code, body = handle_echo(rt.facilitator, envelope_id=env.envelope_id, payment_sig=env.envelope_id)
+    print(f"pay#{i}     0.05    remaining={body.get('remaining_usd')}  {code}")
+r = rt.facilitator.authorize(AuthorizeRequest(env.envelope_id, "0xevil", "0.05", "underwrite.echo"))
+print(f"pay#bad   0.05    payee=0xevil    {403 if not r.allowed else 200} {r.reason}")
+rt.mandates.revoke(m.mandate_id, "operator")
+print("kill      ok")
+r = rt.facilitator.authorize(AuthorizeRequest(env.envelope_id, "sincor:skill:underwrite.echo", "0.05", "underwrite.echo"))
+print(f"pay#3     0.05                    {403 if not r.allowed else 200} {r.reason}")
+lines = list(rt.store.iter_audit())
+print(f"audit     {rt.store.root}  lines={len(lines)}")
+print("viewer    python -m sincor2.underwriting.api   → http://127.0.0.1:8787/underwrite/demo")
+PY

--- a/src/sincor2/underwriting/README.md
+++ b/src/sincor2/underwriting/README.md
@@ -1,0 +1,13 @@
+# Agent Underwriting (v1)
+
+Treasury Mandate Runtime. Not a stablecoin.
+
+Default tap is `ledger_sim`. `bridge_mint` is a stub that cannot move funds.
+
+See `docs/underwriting/BUILD_GUIDE.md`.
+
+```
+python -m pytest tests/underwriting -q
+bash scripts/underwrite_demo.sh
+python -m sincor2.underwriting.api
+```

--- a/src/sincor2/underwriting/__init__.py
+++ b/src/sincor2/underwriting/__init__.py
@@ -1,0 +1,33 @@
+"""SINCOR Agent Underwriting — Treasury Mandate Runtime.
+
+Public surface is small on purpose. Agents request envelopes.
+Only Facilitator may call a Tap.
+"""
+
+from .types import (
+    REASON,
+    IntentMandate,
+    SpendEnvelope,
+    AuditEvent,
+    AuthorizeRequest,
+    AuthorizeResult,
+)
+from .store import UnderwriteStore
+from .mandates import MandateService
+from .policy import Policy
+from .envelopes import EnvelopeService
+from .facilitator import Facilitator
+
+__all__ = [
+    "REASON",
+    "IntentMandate",
+    "SpendEnvelope",
+    "AuditEvent",
+    "AuthorizeRequest",
+    "AuthorizeResult",
+    "UnderwriteStore",
+    "MandateService",
+    "Policy",
+    "EnvelopeService",
+    "Facilitator",
+]

--- a/src/sincor2/underwriting/mandates.py
+++ b/src/sincor2/underwriting/mandates.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from .store import UnderwriteStore
+from .types import IntentMandate, iso, new_id, utcnow
+
+
+class MandateService:
+    def __init__(self, store: UnderwriteStore) -> None:
+        self.store = store
+
+    def issue(
+        self,
+        *,
+        operator_id: str,
+        controller_wallet: str,
+        agent_id: str,
+        max_notional_usd: str,
+        max_single_tx_usd: str,
+        hours: float = 2.0,
+        allowed_skills: list[str] | None = None,
+        allowed_payees: list[str] | None = None,
+        asset: str = "USDC",
+        chain_id: int = 8453,
+        legal_customer_id: str | None = None,
+    ) -> IntentMandate:
+        now = utcnow()
+        m = IntentMandate(
+            mandate_id=new_id(),
+            issued_at=iso(now),
+            expires_at=iso(now + timedelta(hours=hours)),
+            operator_id=operator_id,
+            controller_wallet=controller_wallet,
+            agent_id=agent_id,
+            asset=asset,
+            chain_id=chain_id,
+            max_notional_usd=max_notional_usd,
+            max_single_tx_usd=max_single_tx_usd,
+            allowed_skills=allowed_skills or [],
+            allowed_payees=allowed_payees or [],
+            legal_customer_id=legal_customer_id,
+        )
+        self.store.write_mandate(m)
+        self.store.audit(
+            "mandate.issued",
+            agent_id,
+            {"max_notional_usd": max_notional_usd, "max_single_tx_usd": max_single_tx_usd},
+            mandate_id=m.mandate_id,
+        )
+        return m
+
+    def revoke(self, mandate_id: str, by: str) -> IntentMandate:
+        m = self.store.get_mandate(mandate_id)
+        if m is None:
+            raise KeyError(mandate_id)
+        m.killed = True
+        self.store.write_mandate(m)
+        self.store.audit("mandate.revoked", m.agent_id, {"by": by}, mandate_id=m.mandate_id)
+        self.store.audit("kill.triggered", m.agent_id, {"by": by, "scope": "mandate"}, mandate_id=m.mandate_id)
+        return m
+
+    def active_for(self, agent_id: str) -> IntentMandate | None:
+        return self.store.active_mandate_for(agent_id)

--- a/src/sincor2/underwriting/policy.py
+++ b/src/sincor2/underwriting/policy.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from .types import REASON, IntentMandate, SpendEnvelope, money, parse_iso, utcnow
+
+
+class Policy:
+    """Pure checks. Return a reason code or None if allowed."""
+
+    @staticmethod
+    def mandate_live(mandate: IntentMandate | None, now: datetime | None = None) -> str | None:
+        if mandate is None:
+            return REASON.DENY_NO_MANDATE
+        now = now or utcnow()
+        if parse_iso(mandate.expires_at) <= now:
+            return REASON.DENY_MANDATE_EXPIRED
+        return None
+
+    @staticmethod
+    def kill(mandate: IntentMandate) -> str | None:
+        if mandate.killed:
+            return REASON.DENY_KILL_SWITCH
+        return None
+
+    @staticmethod
+    def ttl(envelope: SpendEnvelope, now: datetime | None = None) -> str | None:
+        now = now or utcnow()
+        if envelope.status != "active":
+            return REASON.DENY_CAP_EXCEEDED if envelope.status in {"exhausted"} else REASON.DENY_MANDATE_EXPIRED
+        if parse_iso(envelope.expires_at) <= now:
+            return REASON.DENY_MANDATE_EXPIRED
+        return None
+
+    @staticmethod
+    def amount(mandate: IntentMandate, envelope: SpendEnvelope, amount: str) -> str | None:
+        amt = money(amount)
+        if amt <= 0:
+            return REASON.DENY_CAP_EXCEEDED
+        if amt > money(envelope.remaining_usd):
+            return REASON.DENY_CAP_EXCEEDED
+        if amt > money(envelope.max_tx_usd or mandate.max_single_tx_usd):
+            return REASON.DENY_CAP_EXCEEDED
+        if amt > money(mandate.max_single_tx_usd):
+            return REASON.DENY_CAP_EXCEEDED
+        return None
+
+    @staticmethod
+    def payee(mandate: IntentMandate, envelope: SpendEnvelope, payee: str) -> str | None:
+        denied = set(mandate.denied_payees)
+        if payee in denied:
+            return REASON.DENY_UNKNOWN_PAYEE
+        allow = envelope.allowlist_payees or mandate.allowed_payees
+        if allow and payee not in allow:
+            return REASON.DENY_UNKNOWN_PAYEE
+        return None
+
+    @staticmethod
+    def skill(mandate: IntentMandate, envelope: SpendEnvelope, skill_id: str) -> str | None:
+        allow = envelope.allowlist_skills or mandate.allowed_skills
+        if allow and skill_id not in allow:
+            return REASON.DENY_UNKNOWN_PAYEE
+        return None

--- a/src/sincor2/underwriting/runtime.py
+++ b/src/sincor2/underwriting/runtime.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from .envelopes import EnvelopeService
+from .facilitator import Facilitator
+from .mandates import MandateService
+from .store import UnderwriteStore
+from .taps.bridge_mint import BridgeMintTap
+from .taps.ledger_sim import LedgerSimTap
+from .toa_adapter import FormulaToa, SpendUnderwriter
+
+
+def build_tap(name: str | None = None):
+    name = (name or os.getenv("UNDERWRITE_TAP") or "ledger_sim").strip()
+    if name == "bridge_mint":
+        return BridgeMintTap()
+    return LedgerSimTap(vault_usd=os.getenv("UNDERWRITE_VAULT_USD", "100.00"))
+
+
+@dataclass
+class UnderwriteRuntime:
+    store: UnderwriteStore
+    mandates: MandateService
+    envelopes: EnvelopeService
+    facilitator: Facilitator
+    tap_name: str
+
+
+def boot(data_dir: str | None = None) -> UnderwriteRuntime:
+    store = UnderwriteStore(data_dir or os.getenv("UNDERWRITE_DATA_DIR", "data/underwriting"))
+    tap = build_tap()
+    mandates = MandateService(store)
+    underwriter = SpendUnderwriter(port=FormulaToa(), tap_name=getattr(tap, "name", "ledger_sim"))
+    envelopes = EnvelopeService(store, underwriter)
+    fac = Facilitator(store, mandates, envelopes, tap)
+    return UnderwriteRuntime(store, mandates, envelopes, fac, getattr(tap, "name", "ledger_sim"))

--- a/src/sincor2/underwriting/store.py
+++ b/src/sincor2/underwriting/store.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from .types import AuditEvent, IntentMandate, SpendEnvelope, iso, new_id, utcnow
+
+
+class UnderwriteStore:
+    def __init__(self, root: str | Path = "data/underwriting") -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._mandates = self.root / "mandates.jsonl"
+        self._envelopes = self.root / "envelopes.jsonl"
+
+    def _audit_path(self, ts: datetime | None = None) -> Path:
+        day = (ts or utcnow()).strftime("%Y-%m-%d")
+        return self.root / f"audit-{day}.jsonl"
+
+    def _append(self, path: Path, obj: dict[str, Any]) -> None:
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(obj, separators=(",", ":")) + "\n")
+
+    def _read_jsonl(self, path: Path) -> list[dict[str, Any]]:
+        if not path.exists():
+            return []
+        out: list[dict[str, Any]] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                out.append(json.loads(line))
+        return out
+
+    def write_mandate(self, m: IntentMandate) -> None:
+        self._append(self._mandates, m.to_dict())
+
+    def write_envelope(self, e: SpendEnvelope) -> None:
+        self._append(self._envelopes, e.to_dict())
+
+    def audit(self, kind: str, agent_id: str, payload: dict[str, Any],
+              mandate_id: str | None = None, envelope_id: str | None = None) -> AuditEvent:
+        ev = AuditEvent(
+            event_id=new_id(),
+            ts=iso(utcnow()),
+            kind=kind,
+            agent_id=agent_id,
+            payload=payload,
+            mandate_id=mandate_id,
+            envelope_id=envelope_id,
+        )
+        self._append(self._audit_path(), ev.to_dict())
+        return ev
+
+    def latest_mandates(self) -> dict[str, IntentMandate]:
+        latest: dict[str, IntentMandate] = {}
+        for row in self._read_jsonl(self._mandates):
+            m = IntentMandate.from_dict(row)
+            latest[m.mandate_id] = m
+        return latest
+
+    def latest_envelopes(self) -> dict[str, SpendEnvelope]:
+        latest: dict[str, SpendEnvelope] = {}
+        for row in self._read_jsonl(self._envelopes):
+            e = SpendEnvelope.from_dict(row)
+            latest[e.envelope_id] = e
+        return latest
+
+    def get_mandate(self, mandate_id: str) -> IntentMandate | None:
+        return self.latest_mandates().get(mandate_id)
+
+    def get_envelope(self, envelope_id: str) -> SpendEnvelope | None:
+        return self.latest_envelopes().get(envelope_id)
+
+    def active_mandate_for(self, agent_id: str) -> IntentMandate | None:
+        now = utcnow()
+        found: IntentMandate | None = None
+        for m in self.latest_mandates().values():
+            if m.agent_id != agent_id or m.killed:
+                continue
+            exp = datetime.fromisoformat(m.expires_at.replace("Z", "+00:00"))
+            if exp <= now:
+                continue
+            found = m
+        return found
+
+    def iter_audit(self) -> Iterable[dict[str, Any]]:
+        for path in sorted(self.root.glob("audit-*.jsonl")):
+            yield from self._read_jsonl(path)

--- a/src/sincor2/underwriting/taps/__init__.py
+++ b/src/sincor2/underwriting/taps/__init__.py
@@ -1,0 +1,5 @@
+from .base import Tap, TapReceipt
+from .ledger_sim import LedgerSimTap
+from .bridge_mint import BridgeMintTap
+
+__all__ = ["Tap", "TapReceipt", "LedgerSimTap", "BridgeMintTap"]

--- a/src/sincor2/underwriting/taps/base.py
+++ b/src/sincor2/underwriting/taps/base.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass
+class TapReceipt:
+    ok: bool
+    receipt_id: str
+    tap: str
+    amount_usd: str
+    detail: str = ""
+
+
+class Tap(Protocol):
+    name: str
+
+    def transfer(self, *, from_agent: str, to_payee: str, amount_usd: str, asset: str, meta: dict) -> TapReceipt: ...
+
+    def clawback(self, *, envelope_id: str, amount_usd: str, asset: str) -> TapReceipt: ...

--- a/src/sincor2/underwriting/taps/bridge_mint.py
+++ b/src/sincor2/underwriting/taps/bridge_mint.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from ..types import new_id
+from .base import TapReceipt
+
+
+class BridgeMintTap:
+    """Stub. Must not perform HTTP. Partnership keys unlock a real adapter later."""
+
+    name = "bridge_mint"
+
+    def describe(self) -> dict:
+        return {
+            "status": "stub",
+            "would_call": "POST https://api.bridge.xyz/v0/transfers",
+            "note": "closed-loop mint on_behalf_of CIP customer — not implemented",
+        }
+
+    def transfer(self, *, from_agent: str, to_payee: str, amount_usd: str, asset: str, meta: dict) -> TapReceipt:
+        return TapReceipt(False, new_id(), self.name, amount_usd, "stub_refuses_transfer")
+
+    def clawback(self, *, envelope_id: str, amount_usd: str, asset: str) -> TapReceipt:
+        return TapReceipt(False, new_id(), self.name, amount_usd, "stub_refuses_clawback")

--- a/src/sincor2/underwriting/taps/ledger_sim.py
+++ b/src/sincor2/underwriting/taps/ledger_sim.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from ..types import money, money_str, new_id
+from .base import TapReceipt
+
+
+class LedgerSimTap:
+    name = "ledger_sim"
+
+    def __init__(self, vault_usd: str = "100.00") -> None:
+        self.vault = money(vault_usd)
+        self.balances: dict[str, Decimal] = {"vault": self.vault}
+
+    def _credit(self, acct: str, amt: Decimal) -> None:
+        self.balances[acct] = money(self.balances.get(acct, Decimal("0")) + amt)
+
+    def transfer(self, *, from_agent: str, to_payee: str, amount_usd: str, asset: str, meta: dict) -> TapReceipt:
+        amt = money(amount_usd)
+        if self.balances.get("vault", Decimal("0")) < amt:
+            return TapReceipt(False, new_id(), self.name, amount_usd, "vault_empty")
+        self.balances["vault"] -= amt
+        self._credit(to_payee, amt)
+        return TapReceipt(True, new_id(), self.name, money_str(amt), f"{from_agent}->{to_payee}")
+
+    def clawback(self, *, envelope_id: str, amount_usd: str, asset: str) -> TapReceipt:
+        amt = money(amount_usd)
+        self._credit("vault", amt)
+        return TapReceipt(True, new_id(), self.name, money_str(amt), f"clawback:{envelope_id}")

--- a/src/sincor2/underwriting/taps/usdc_base.py
+++ b/src/sincor2/underwriting/taps/usdc_base.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from ..types import new_id
+from .base import TapReceipt
+
+USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+
+class UsdcBaseTap:
+    """Phase 2 placeholder. No RPC in v1."""
+
+    name = "usdc_base"
+
+    def transfer(self, *, from_agent: str, to_payee: str, amount_usd: str, asset: str, meta: dict) -> TapReceipt:
+        return TapReceipt(False, new_id(), self.name, amount_usd, "phase2_not_wired")
+
+    def clawback(self, *, envelope_id: str, amount_usd: str, asset: str) -> TapReceipt:
+        return TapReceipt(False, new_id(), self.name, amount_usd, "phase2_not_wired")

--- a/src/sincor2/underwriting/types.py
+++ b/src/sincor2/underwriting/types.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+from uuid import uuid4
+
+SCHEMA_MANDATE = "sincor.intent_mandate.v1"
+SCHEMA_ENVELOPE = "sincor.spend_envelope.v1"
+SCHEMA_AUDIT = "sincor.underwrite_audit.v1"
+
+CHAIN_ID_BASE = 8453
+
+
+class REASON:
+    OK_BASELINE = "OK_BASELINE"
+    OK_REDUCED_DRIFT = "OK_REDUCED_DRIFT"
+    OK_REDUCED_COUNTERPARTY = "OK_REDUCED_COUNTERPARTY"
+    DENY_NO_MANDATE = "DENY_NO_MANDATE"
+    DENY_MANDATE_EXPIRED = "DENY_MANDATE_EXPIRED"
+    DENY_KILL_SWITCH = "DENY_KILL_SWITCH"
+    DENY_CRITIC_FAIL_RATE = "DENY_CRITIC_FAIL_RATE"
+    DENY_PATH_UNSAFE = "DENY_PATH_UNSAFE"
+    DENY_SANCTIONS = "DENY_SANCTIONS"
+    DENY_CAP_EXCEEDED = "DENY_CAP_EXCEEDED"
+    DENY_UNKNOWN_PAYEE = "DENY_UNKNOWN_PAYEE"
+    DENY_TOA_NO_VIABLE_PATH = "DENY_TOA_NO_VIABLE_PATH"
+    HOLD_HUMAN_REQUIRED = "HOLD_HUMAN_REQUIRED"
+
+
+OK_CODES = {
+    REASON.OK_BASELINE,
+    REASON.OK_REDUCED_DRIFT,
+    REASON.OK_REDUCED_COUNTERPARTY,
+}
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_iso(s: str) -> datetime:
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def money(x: Any) -> Decimal:
+    return Decimal(str(x)).quantize(Decimal("0.000001"))
+
+
+def money_str(x: Decimal) -> str:
+    return format(money(x), "f")
+
+
+def new_id() -> str:
+    return str(uuid4())
+
+
+@dataclass
+class IntentMandate:
+    mandate_id: str
+    issued_at: str
+    expires_at: str
+    operator_id: str
+    controller_wallet: str
+    agent_id: str
+    asset: str
+    chain_id: int
+    max_notional_usd: str
+    max_single_tx_usd: str
+    allowed_skills: list[str] = field(default_factory=list)
+    allowed_payees: list[str] = field(default_factory=list)
+    denied_payees: list[str] = field(default_factory=list)
+    human_approval_above_usd: str = "25.00"
+    legal_customer_id: str | None = None
+    kill_enabled: bool = True
+    killed: bool = False
+    schema: str = SCHEMA_MANDATE
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "IntentMandate":
+        known = {f.name for f in cls.__dataclass_fields__.values()}  # type: ignore[attr-defined]
+        return cls(**{k: v for k, v in d.items() if k in known})
+
+
+@dataclass
+class SpendEnvelope:
+    envelope_id: str
+    mandate_id: str
+    agent_id: str
+    issued_at: str
+    expires_at: str
+    status: str
+    asset: str
+    chain_id: int
+    amount_usd: str
+    remaining_usd: str
+    ttl_seconds: int
+    reason_codes: list[str]
+    tap: str
+    allowlist_payees: list[str] = field(default_factory=list)
+    allowlist_skills: list[str] = field(default_factory=list)
+    max_tx_usd: str = "0"
+    toa_run_id: str | None = None
+    toa_paths_considered: int = 0
+    toa_paths_viable: int = 0
+    toa_scenario_id: str | None = None
+    toa_composite: float | None = None
+    toa_risk: float | None = None
+    toa_rationale: str = ""
+    denied: bool = False
+    schema: str = SCHEMA_ENVELOPE
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "SpendEnvelope":
+        known = {f.name for f in cls.__dataclass_fields__.values()}  # type: ignore[attr-defined]
+        return cls(**{k: v for k, v in d.items() if k in known})
+
+
+@dataclass
+class AuditEvent:
+    event_id: str
+    ts: str
+    kind: str
+    agent_id: str
+    payload: dict[str, Any]
+    mandate_id: str | None = None
+    envelope_id: str | None = None
+    schema: str = SCHEMA_AUDIT
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class AuthorizeRequest:
+    envelope_id: str
+    payee: str
+    amount_usd: str
+    skill_id: str
+
+
+@dataclass
+class AuthorizeResult:
+    allowed: bool
+    reason: str
+    remaining_usd: str
+    receipt_id: str | None = None
+    envelope_status: str = ""

--- a/tests/underwriting/test_mandates.py
+++ b/tests/underwriting/test_mandates.py
@@ -1,0 +1,21 @@
+from sincor2.underwriting.mandates import MandateService
+from sincor2.underwriting.store import UnderwriteStore
+
+
+def test_mandate_issue_unsigned(tmp_path):
+    store = UnderwriteStore(tmp_path)
+    svc = MandateService(store)
+    m = svc.issue(
+        operator_id="court",
+        controller_wallet="0x" + "ab" * 20,
+        agent_id="E-altair-04",
+        max_notional_usd="25.00",
+        max_single_tx_usd="5.00",
+        allowed_skills=["underwrite.echo"],
+        allowed_payees=["sincor:skill:underwrite.echo"],
+    )
+    got = store.get_mandate(m.mandate_id)
+    assert got is not None
+    assert got.agent_id == "E-altair-04"
+    assert got.max_notional_usd == "25.00"
+    assert svc.active_for("E-altair-04").mandate_id == m.mandate_id


### PR DESCRIPTION
Adds the Agent Underwriting module (spend envelopes for machine treasuries).

On this branch so far:
- `src/sincor2/underwriting/` core package (types, store, mandates, policy, runtime, taps)
- `scripts/underwrite_demo.sh`
- `docs/underwriting/PARTNER_ONE_PAGER.md`
- `tests/underwriting/test_mandates.py`

Still to land on this branch from the local v1 package (copy from the build session artifacts if missing after pull):
- envelopes.py, facilitator.py, toa_adapter.py, x402_seller.py, api.py, viewer.py
- remaining tests + BUILD_GUIDE.md + schemas

Not a branded stablecoin. Bridge mint tap is a stub that refuses transfers.

Do not merge to main until the remaining modules are on the branch and `pytest tests/underwriting` is green.