### PR TITLE
feat(kya): Know Your Agent v0 on inbound fabric

### DIFF
--- a/docs/KYA_SPEC.md
+++ b/docs/KYA_SPEC.md
@@ -1,0 +1,30 @@
+# SINCOR KYA v0
+
+Drop-in trust layer on inbound fabric. Does not replace `/v1/a2a/register`.
+
+- Chain: Base 8453
+- AXM bond/fee: `0x4c3fb66f14fbaa2088c9ae91017ba770da53715a`
+- Do not use dead AXM `0xfF7aF6ffca25A9DC0FC990d998AcF24Cc60b7822`
+- Min stake: 10 AXM. Verify fee: 2 AXM.
+- States: listed -> bound -> staked -> verified | revoked | expired
+- Phase 1: lookup only. Do not gate message/send until 50 verified records.
+
+## Hooks
+
+`register_agent_record` calls `kya_registry.hook_listed`.
+`heartbeat_agent` calls `kya_registry.hook_heartbeat`.
+`mount()` registers `/v1/kya`.
+
+## API
+
+- POST /v1/kya/list
+- POST /v1/kya/bind
+- POST /v1/kya/verify
+- POST /v1/kya/heartbeat
+- POST /v1/kya/sla
+- POST /v1/kya/revoke
+- GET /v1/kya/{kya_id}
+- GET /v1/kya/agent/{agent_id}
+- GET /v1/kya/lookup?wallet=
+
+On-chain `contracts/kya/KYARegistry.sol` is bond/revoke truth. Do not deploy until list+bind is live on Railway.

--- a/src/sincor2/a2a_inbound_ext.py
+++ b/src/sincor2/a2a_inbound_ext.py
@@ -29,6 +29,27 @@ logger = logging.getLogger("sincor.a2a.inbound")
 _HEARTBEAT_THREAD = None
 
 
+def _kya_listed(agent: Dict[str, Any]) -> None:
+    try:
+        from sincor2.kya_registry import hook_listed
+
+        rec = hook_listed(agent)
+        if rec:
+            agent["kya_id"] = rec.get("kya_id")
+            agent["kya_status"] = rec.get("status")
+    except Exception as err:
+        logger.warning("[KYA] list hook skipped: %s", err)
+
+
+def _kya_heartbeat(agent_id: str) -> None:
+    try:
+        from sincor2.kya_registry import hook_heartbeat
+
+        hook_heartbeat(agent_id, ok=True)
+    except Exception as err:
+        logger.debug("[KYA] heartbeat hook skipped: %s", err)
+
+
 def register_agent_record(body: Dict[str, Any]) -> Dict[str, Any]:
     parsed = _normalize_registration(body)
     agent_id = parsed["agent_id"]
@@ -67,6 +88,14 @@ def register_agent_record(body: Dict[str, Any]) -> Dict[str, Any]:
         snapshot = dict(agent)
     _save_agents(fabric)
     fabric.publish("agent.registered", snapshot["capability_tags"], {"agent_id": agent_id, "tags": snapshot["capability_tags"], "wallet": snapshot["wallet"]})
+    _kya_listed(snapshot)
+    if snapshot.get("kya_id"):
+        with fabric.lock:
+            live = fabric.agents.get(agent_id)
+            if live is not None:
+                live["kya_id"] = snapshot["kya_id"]
+                live["kya_status"] = snapshot.get("kya_status")
+        _save_agents(fabric)
     return snapshot
 
 
@@ -80,6 +109,7 @@ def heartbeat_agent(agent_id: str, signature: str = "") -> Dict[str, Any]:
         agent["last_heartbeat"] = ts
         tags = list(agent.get("capability_tags") or [])
     fabric.publish("agent.heartbeat", tags, {"agent_id": agent_id, "ttl_s": HEARTBEAT_TTL_S})
+    _kya_heartbeat(agent_id)
     return {"ok": True, "agent_id": agent_id, "expires_at": ts + HEARTBEAT_TTL_S * 1000}
 
 
@@ -164,6 +194,8 @@ def mount(app: Flask) -> None:
             "probation": bool(agent.get("probation")),
             "heartbeat_ttl_s": HEARTBEAT_TTL_S,
             "stream_url": "/v1/a2a/stream",
+            "kya_id": agent.get("kya_id"),
+            "kya_status": agent.get("kya_status"),
         }), 201
 
     @bp.post("/v1/a2a/heartbeat")
@@ -185,7 +217,14 @@ def mount(app: Flask) -> None:
 
     @bp.get("/v1/a2a/directory")
     def v1_directory():
-        return jsonify({"agents": list_agents(), "kpis": health_snapshot()})
+        kpis = health_snapshot()
+        try:
+            from sincor2.kya_registry import snapshot as kya_snapshot
+
+            kpis["kya"] = kya_snapshot()
+        except Exception:
+            pass
+        return jsonify({"agents": list_agents(), "kpis": kpis})
 
     @bp.get("/v1/a2a/chain")
     def v1_chain():
@@ -193,6 +232,14 @@ def mount(app: Flask) -> None:
 
     attach_market_routes(bp)
     app.register_blueprint(bp)
+    try:
+        from sincor2.kya_blueprint import kya_bp
+
+        if "kya" not in (getattr(app, "blueprints", {}) or {}):
+            app.register_blueprint(kya_bp)
+            logger.info("[KYA] /v1/kya mounted")
+    except Exception as err:
+        logger.warning("[KYA] blueprint skipped: %s", err)
     try:
         ensure_platform_agent()
     except Exception as err:

--- a/src/sincor2/kya_blueprint.py
+++ b/src/sincor2/kya_blueprint.py
@@ -1,0 +1,125 @@
+"""Flask blueprint — mount next to inbound A2A.
+
+    from sincor2.kya_blueprint import kya_bp
+    app.register_blueprint(kya_bp)
+"""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from sincor2 import kya_registry as kya
+
+kya_bp = Blueprint("kya", __name__, url_prefix="/v1/kya")
+
+
+def _err(msg: str, status: int = 400):
+    return jsonify({"error": msg, "status": status}), status
+
+
+@kya_bp.get("/health")
+def health():
+    return jsonify({"ok": True, **kya.snapshot()})
+
+
+@kya_bp.post("/list")
+def list_agent():
+    body = request.get_json(silent=True) or {}
+    try:
+        rec = kya.list_from_inbound(body, card=body.get("agent_card") if isinstance(body.get("agent_card"), dict) else None)
+    except ValueError as exc:
+        return _err(str(exc))
+    return jsonify(rec), 201
+
+
+@kya_bp.post("/bind")
+def bind():
+    body = request.get_json(silent=True) or {}
+    try:
+        rec = kya.bind(
+            agent_id=str(body.get("agent_id") or ""),
+            principal=str(body.get("principal") or ""),
+            signature=str(body.get("signature") or ""),
+            message=str(body.get("message") or ""),
+            recovered=body.get("recovered"),
+        )
+    except KeyError:
+        return _err("unknown agent", 404)
+    except ValueError as exc:
+        return _err(str(exc))
+    return jsonify(rec)
+
+
+@kya_bp.post("/verify")
+def verify():
+    body = request.get_json(silent=True) or {}
+    kya_id = str(body.get("kya_id") or "")
+    if body.get("stake_tx") and body.get("stake_wei"):
+        try:
+            kya.apply_stake(kya_id, str(body["stake_wei"]), str(body["stake_tx"]))
+        except (KeyError, ValueError) as exc:
+            return _err(str(exc), 404 if isinstance(exc, KeyError) else 400)
+    try:
+        rec = kya.verify(kya_id)
+    except KeyError:
+        return _err("unknown kya", 404)
+    except ValueError as exc:
+        return _err(str(exc))
+    return jsonify(rec)
+
+
+@kya_bp.post("/heartbeat")
+def heartbeat():
+    body = request.get_json(silent=True) or {}
+    rec = kya.heartbeat(str(body.get("agent_id") or ""), ok=bool(body.get("ok", True)), latency_ms=body.get("latency_ms"))
+    if rec is None:
+        return _err("unknown agent", 404)
+    return jsonify(rec)
+
+
+@kya_bp.post("/sla")
+def sla():
+    body = request.get_json(silent=True) or {}
+    try:
+        rec = kya.post_sla(
+            kya_id=str(body.get("kya_id") or ""),
+            ok=bool(body.get("ok", True)),
+            latency_ms=int(body.get("latency_ms") or 0),
+            proof_tx=body.get("proof_tx"),
+        )
+    except KeyError:
+        return _err("unknown kya", 404)
+    return jsonify(rec)
+
+
+@kya_bp.post("/revoke")
+def revoke():
+    body = request.get_json(silent=True) or {}
+    try:
+        rec = kya.revoke(str(body.get("kya_id") or ""), reason=str(body.get("reason") or ""))
+    except KeyError:
+        return _err("unknown kya", 404)
+    return jsonify(rec)
+
+
+@kya_bp.get("/agent/<agent_id>")
+def by_agent(agent_id: str):
+    rec = kya.get_by_agent(agent_id)
+    if rec is None:
+        return _err("unknown agent", 404)
+    return jsonify(kya.refresh_status(rec))
+
+
+@kya_bp.get("/lookup")
+def lookup():
+    wallet = str(request.args.get("wallet") or "")
+    if not kya.WALLET_RE.match(wallet):
+        return _err("bad wallet")
+    return jsonify({"records": kya.lookup_wallet(wallet)})
+
+
+@kya_bp.get("/<kya_id>")
+def get_one(kya_id: str):
+    rec = kya.get(kya_id)
+    if rec is None:
+        return _err("unknown kya", 404)
+    return jsonify(kya.refresh_status(rec))

--- a/src/sincor2/kya_registry.py
+++ b/src/sincor2/kya_registry.py
@@ -1,0 +1,1 @@
+placeholder

--- a/src/sincor2/kya_registry.py
+++ b/src/sincor2/kya_registry.py
@@ -1,1 +1,371 @@
-placeholder
+"""SINCOR KYA v0 — in-process registry.
+
+Hooks the existing inbound fabric without replacing it.
+Persist path: data_dir()/kya_records.json
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+WALLET_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+AGENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+AXM = "0x4c3fb66f14fbaa2088c9ae91017ba770da53715a"
+CHAIN_ID = 8453
+MIN_STAKE_WEI = 10 * 10**18
+VERIFY_FEE_WEI = 2 * 10**18
+HEARTBEAT_TTL_MS = 60_000
+LIVE_GRACE = 3
+
+_LOCK = threading.Lock()
+_STORE: Dict[str, Dict[str, Any]] = {}
+_BY_AGENT: Dict[str, str] = {}
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def reset() -> None:
+    """Test-only: wipe in-memory index. Does not delete disk until next save."""
+    with _LOCK:
+        _STORE.clear()
+        _BY_AGENT.clear()
+
+
+def _persist_path() -> Optional[Path]:
+    import os
+
+    override = os.environ.get("KYA_STORE_PATH")
+    if override:
+        return Path(override)
+    try:
+        from sincor2.data_paths import data_dir
+
+        return data_dir() / "kya_records.json"
+    except Exception:
+        return Path("/tmp/kya_records.json")
+
+
+def load() -> None:
+    path = _persist_path()
+    if path is None or not path.is_file():
+        return
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        records = raw.get("records") if isinstance(raw, dict) else raw
+        if isinstance(records, list):
+            with _LOCK:
+                for rec in records:
+                    if isinstance(rec, dict) and rec.get("kya_id"):
+                        _STORE[rec["kya_id"]] = rec
+                        _BY_AGENT[rec["agent_id"]] = rec["kya_id"]
+    except Exception:
+        pass
+
+
+def save() -> None:
+    path = _persist_path()
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _LOCK:
+        payload = {"records": list(_STORE.values()), "saved_at": _now_ms()}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _canonical(obj: Any) -> str:
+    return json.dumps(obj, separators=(",", ":"), sort_keys=True, ensure_ascii=True)
+
+
+def card_hash(card: Dict[str, Any]) -> str:
+    digest = hashlib.sha256(_canonical(card).encode()).hexdigest()
+    return "0x" + digest
+
+
+def make_kya_id(agent_id: str, principal: str, c_hash: str) -> str:
+    raw = f"{agent_id}:{principal.lower()}:{c_hash}".encode()
+    return "kya_" + hashlib.sha256(raw).hexdigest()[:16]
+
+
+def _safe_url(value: Any) -> str:
+    url = str(value or "").strip()
+    parsed = urlparse(url)
+    return url if url and parsed.scheme in ("http", "https") and parsed.netloc else ""
+
+
+def score(rec: Dict[str, Any]) -> int:
+    sla = rec.get("sla") or {}
+    jobs = rec.get("jobs") or {}
+    live = 1 if rec.get("status") in ("verified", "staked", "bound") and _is_live(rec) else 0
+    bound = 1 if rec.get("status") in ("bound", "staked", "verified") else 0
+    staked = 1 if int(rec.get("stake_axm_wei") or 0) >= MIN_STAKE_WEI else 0
+    uptime = float(sla.get("uptime_30d") or 0)
+    completed = int(jobs.get("completed") or 0)
+    failed = int(jobs.get("failed") or 0)
+    total = completed + failed
+    completion = (completed / total) if total else 0.0
+    slashed = int(jobs.get("slashed") or 0)
+    disputed = int(jobs.get("disputed") or 0)
+    raw = (
+        200 * live
+        + 200 * bound
+        + 200 * staked
+        + 200 * uptime
+        + 200 * completion
+        - 50 * slashed
+        - 100 * disputed
+    )
+    return max(0, min(1000, int(raw)))
+
+
+def _is_live(rec: Dict[str, Any]) -> bool:
+    last = int((rec.get("sla") or {}).get("last_heartbeat_ms") or 0)
+    return (_now_ms() - last) <= HEARTBEAT_TTL_MS * LIVE_GRACE if last else False
+
+
+def refresh_status(rec: Dict[str, Any]) -> Dict[str, Any]:
+    if rec.get("revoked"):
+        rec["status"] = "revoked"
+        rec["score"] = score(rec)
+        return rec
+    valid_until = ((rec.get("scope") or {}).get("valid_until") or "")
+    expired = False
+    if valid_until:
+        try:
+            from datetime import datetime, timezone
+
+            dt = datetime.fromisoformat(valid_until.replace("Z", "+00:00"))
+            expired = dt.timestamp() * 1000 < _now_ms()
+        except Exception:
+            expired = False
+    if expired or (rec.get("status") == "verified" and not _is_live(rec)):
+        rec["status"] = "expired"
+    rec["score"] = score(rec)
+    rec["updated_at"] = _now_ms()
+    return rec
+
+
+def list_from_inbound(agent: Dict[str, Any], card: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    agent_id = str(agent.get("agent_id") or "")
+    if not AGENT_ID_RE.match(agent_id):
+        raise ValueError("bad agent_id")
+    wallet = str(agent.get("wallet") or "")
+    if wallet and not WALLET_RE.match(wallet):
+        raise ValueError("bad wallet")
+    card = card or {
+        "id": agent_id,
+        "name": agent.get("name"),
+        "description": agent.get("description"),
+        "version": agent.get("version"),
+        "skills": agent.get("skills") or [],
+    }
+    c_hash = card_hash(card)
+    principal = wallet or "0x0000000000000000000000000000000000000000"
+    kya_id = make_kya_id(agent_id, principal, c_hash)
+    rec = {
+        "kya_id": kya_id,
+        "agent_id": agent_id,
+        "principal": principal,
+        "agent_wallet": wallet or principal,
+        "card_url": _safe_url(agent.get("rpc_callback")),
+        "card_hash": c_hash,
+        "name": agent.get("name") or agent_id,
+        "version": agent.get("version") or "0.0.0",
+        "skills": agent.get("skills") or [],
+        "status": "listed",
+        "scope": {
+            "max_axm_per_tx": str(5 * 10**18),
+            "daily_axm_limit": str(50 * 10**18),
+            "allowed_skills": [s.get("id") for s in (agent.get("skills") or []) if isinstance(s, dict)],
+            "allowed_counterparties": [],
+            "valid_until": "2027-01-01T00:00:00Z",
+        },
+        "stake_axm_wei": "0",
+        "stake_tx": None,
+        "score": 0,
+        "sla": {
+            "last_ok": False,
+            "last_heartbeat_ms": int(agent.get("last_heartbeat") or 0),
+            "uptime_30d": 0.0,
+            "last_proof_tx": None,
+            "latency_ms": None,
+        },
+        "jobs": {"completed": 0, "failed": 0, "disputed": 0, "slashed": 0},
+        "attestation": None,
+        "revoked": False,
+        "revoke_reason": None,
+        "created_at": _now_ms(),
+        "updated_at": _now_ms(),
+        "chain_id": CHAIN_ID,
+    }
+    rec["score"] = score(rec)
+    with _LOCK:
+        _STORE[kya_id] = rec
+        _BY_AGENT[agent_id] = kya_id
+    save()
+    return rec
+
+
+def bind(agent_id: str, principal: str, signature: str, message: str, recovered: Optional[str] = None) -> Dict[str, Any]:
+    if not WALLET_RE.match(principal):
+        raise ValueError("bad principal")
+    rec = get_by_agent(agent_id)
+    if rec is None:
+        raise KeyError("unknown agent")
+    if rec.get("revoked"):
+        raise ValueError("revoked")
+    signer = (recovered or principal).lower()
+    if signer != principal.lower():
+        raise ValueError("signer mismatch")
+    rec["principal"] = principal
+    rec["attestation"] = {
+        "scheme": "eip191",
+        "message": message,
+        "signature": signature,
+        "recovered": principal,
+    }
+    rec["status"] = "bound"
+    refresh_status(rec)
+    save()
+    return rec
+
+
+def apply_stake(kya_id: str, stake_wei: str, stake_tx: str) -> Dict[str, Any]:
+    rec = get(kya_id)
+    if rec is None:
+        raise KeyError("unknown kya")
+    if rec.get("revoked"):
+        raise ValueError("revoked")
+    rec["stake_axm_wei"] = str(int(stake_wei))
+    rec["stake_tx"] = stake_tx
+    rec["status"] = "staked" if int(stake_wei) >= MIN_STAKE_WEI else rec.get("status")
+    refresh_status(rec)
+    save()
+    return rec
+
+
+def verify(kya_id: str) -> Dict[str, Any]:
+    rec = get(kya_id)
+    if rec is None:
+        raise KeyError("unknown kya")
+    if rec.get("revoked"):
+        raise ValueError("revoked")
+    if not rec.get("attestation"):
+        raise ValueError("not bound")
+    if int(rec.get("stake_axm_wei") or 0) < MIN_STAKE_WEI:
+        raise ValueError("stake below minimum")
+    if not _is_live(rec):
+        raise ValueError("heartbeat stale")
+    rec["status"] = "verified"
+    refresh_status(rec)
+    save()
+    return rec
+
+
+def heartbeat(agent_id: str, ok: bool = True, latency_ms: Optional[int] = None) -> Optional[Dict[str, Any]]:
+    rec = get_by_agent(agent_id)
+    if rec is None:
+        return None
+    sla = rec.setdefault("sla", {})
+    sla["last_heartbeat_ms"] = _now_ms()
+    sla["last_ok"] = bool(ok)
+    if latency_ms is not None:
+        sla["latency_ms"] = int(latency_ms)
+    if rec.get("status") == "expired" and rec.get("attestation") and int(rec.get("stake_axm_wei") or 0) >= MIN_STAKE_WEI:
+        rec["status"] = "verified"
+    refresh_status(rec)
+    save()
+    return rec
+
+
+def post_sla(kya_id: str, ok: bool, latency_ms: int, proof_tx: Optional[str] = None) -> Dict[str, Any]:
+    rec = get(kya_id)
+    if rec is None:
+        raise KeyError("unknown kya")
+    sla = rec.setdefault("sla", {})
+    sla["last_ok"] = bool(ok)
+    sla["latency_ms"] = int(latency_ms)
+    sla["last_heartbeat_ms"] = _now_ms()
+    if proof_tx:
+        sla["last_proof_tx"] = proof_tx
+    prev = float(sla.get("uptime_30d") or 0)
+    sla["uptime_30d"] = min(1.0, prev * 0.99 + (1.0 if ok else 0.0) * 0.01)
+    refresh_status(rec)
+    save()
+    return rec
+
+
+def revoke(kya_id: str, reason: str = "") -> Dict[str, Any]:
+    rec = get(kya_id)
+    if rec is None:
+        raise KeyError("unknown kya")
+    rec["revoked"] = True
+    rec["revoke_reason"] = reason
+    rec["status"] = "revoked"
+    refresh_status(rec)
+    save()
+    return rec
+
+
+def get(kya_id: str) -> Optional[Dict[str, Any]]:
+    with _LOCK:
+        return _STORE.get(kya_id)
+
+
+def get_by_agent(agent_id: str) -> Optional[Dict[str, Any]]:
+    with _LOCK:
+        kid = _BY_AGENT.get(agent_id)
+        rec = _STORE.get(kid) if kid else None
+        return rec
+
+
+def lookup_wallet(wallet: str) -> List[Dict[str, Any]]:
+    wallet_l = wallet.lower()
+    with _LOCK:
+        return [
+            dict(r)
+            for r in _STORE.values()
+            if r.get("principal", "").lower() == wallet_l or r.get("agent_wallet", "").lower() == wallet_l
+        ]
+
+
+def snapshot() -> Dict[str, Any]:
+    with _LOCK:
+        recs = list(_STORE.values())
+    return {
+        "token": AXM,
+        "chain_id": CHAIN_ID,
+        "min_stake_wei": str(MIN_STAKE_WEI),
+        "verify_fee_wei": str(VERIFY_FEE_WEI),
+        "listed": len(recs),
+        "verified": sum(1 for r in recs if r.get("status") == "verified"),
+        "revoked": sum(1 for r in recs if r.get("revoked")),
+    }
+
+
+def hook_listed(agent: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Best-effort list after inbound register. Never raises into A2A."""
+    try:
+        if not agent or not agent.get("agent_id"):
+            return None
+        return list_from_inbound(agent)
+    except Exception:
+        return None
+
+
+def hook_heartbeat(agent_id: str, ok: bool = True) -> Optional[Dict[str, Any]]:
+    """Best-effort liveness copy. Never raises into A2A."""
+    try:
+        return heartbeat(agent_id, ok=ok)
+    except Exception:
+        return None
+
+
+load()

--- a/tests/pytest/test_kya_registry.py
+++ b/tests/pytest/test_kya_registry.py
@@ -1,0 +1,71 @@
+"""KYA v0 tests against inbound fabric agent shape. No Flask, no chain."""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+os.environ.setdefault("KYA_STORE_PATH", os.path.join(tempfile.gettempdir(), "kya_test_records.json"))
+
+from sincor2 import kya_registry as kya
+
+
+FABRIC_AGENT = {
+    "agent_id": "scout-lead-01",
+    "name": "Scout Lead",
+    "description": "Inbound fabric shaped agent",
+    "version": "0.1.0",
+    "capability_tags": ["lead-enrichment"],
+    "skills": [{"id": "lead-enrichment", "name": "Lead Enrichment"}],
+    "rpc_callback": "https://getsincor.com/api/a2a",
+    "wallet": "0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac",
+    "chain_id": 8453,
+    "sinc_staked": 0,
+    "last_heartbeat": 0,
+}
+
+
+class KyaFabricTests(unittest.TestCase):
+    def setUp(self):
+        kya.reset()
+        path = Path(os.environ["KYA_STORE_PATH"])
+        if path.exists():
+            path.unlink()
+
+    def test_list_from_fabric_shape(self):
+        rec = kya.list_from_inbound(FABRIC_AGENT)
+        self.assertTrue(rec["kya_id"].startswith("kya_"))
+        self.assertEqual(rec["status"], "listed")
+        self.assertEqual(rec["agent_id"], "scout-lead-01")
+        self.assertEqual(rec["chain_id"], 8453)
+        self.assertEqual(rec["agent_wallet"].lower(), FABRIC_AGENT["wallet"].lower())
+
+    def test_hook_listed_never_raises(self):
+        rec = kya.hook_listed(FABRIC_AGENT)
+        self.assertIsNotNone(rec)
+        self.assertIsNone(kya.hook_listed({}))
+
+    def test_bind_stake_verify_needs_heartbeat(self):
+        rec = kya.list_from_inbound(FABRIC_AGENT)
+        principal = FABRIC_AGENT["wallet"]
+        bound = kya.bind(rec["agent_id"], principal, "0xsig", "SINCOR KYA bind", recovered=principal)
+        self.assertEqual(bound["status"], "bound")
+        staked = kya.apply_stake(rec["kya_id"], str(kya.MIN_STAKE_WEI), "0x" + "ab" * 32)
+        self.assertEqual(staked["status"], "staked")
+        with self.assertRaises(ValueError):
+            kya.verify(rec["kya_id"])
+        kya.heartbeat(rec["agent_id"], ok=True)
+        verified = kya.verify(rec["kya_id"])
+        self.assertEqual(verified["status"], "verified")
+        self.assertGreaterEqual(verified["score"], 600)
+
+    def test_revoke_blocks_verify(self):
+        rec = kya.list_from_inbound(FABRIC_AGENT)
+        kya.revoke(rec["kya_id"], "test")
+        with self.assertRaises(ValueError):
+            kya.bind(rec["agent_id"], FABRIC_AGENT["wallet"], "0x", "m", recovered=FABRIC_AGENT["wallet"])
+
+    def test_dead_token_not_in_module(self):
+        self.assertEqual(kya.AXM.lower(), "0x4c3fb66f14fbaa2088c9ae91017ba770da53715a")
+        self.assertNotIn("ff7af6ffca25a9dc0fc990d998acf24cc60b7822", kya.AXM.lower())


### PR DESCRIPTION
## What
KYA v0 — identity/reputation layer that hangs off existing `/v1/a2a/register` + heartbeat. Does not replace inbound. Does not gate `message/send`.

## Wired
- `register_agent_record` → `hook_listed` (best-effort, never breaks A2A)
- `heartbeat_agent` → `hook_heartbeat`
- `mount()` registers `/v1/kya` and returns `kya_id` on register
- Directory KPIs include KYA snapshot

## Tokens
AXM bond/fee only: `0x4c3fb66f14fbaa2088c9ae91017ba770da53715a`
Dead AXM label is rejected by test.

## Not in this PR
- Solidity deploy (`KYARegistry.sol` stays local until list+bind is live on Railway)
- Stripe
- message/send gating (wait for 50 verified records)

## Tests
`tests/pytest/test_kya_registry.py` — list, hook, bind/stake/verify needs heartbeat, revoke, token address.

Signed-off-by: Court Jansma <court@getsincor.com>