### PR TITLE
fix(checkout): close Base launch races on A2A fees and human quotes

### DIFF
--- a/docs/A2A_EXTERNAL_WIRE.md
+++ b/docs/A2A_EXTERNAL_WIRE.md
@@ -1,14 +1,14 @@
-# A2A external wire (verified 2026-09-04 against getsincor.com)
+# A2A external wire (2026-09-09)
 
 Founder airdrops AXM. Do not broadcast from agents.
 
-## Live holes
-- Agent Card missing top-level `protocolVersion`, `url`, `preferredTransport`.
-- `GET /docs/a2a` is 404.
-- Quote requires `skill_id`. Field `skill` returns Unknown skill.
-- `message/send` requires `params.skillId`.
-- Skill artifacts are still a placeholder. Fulfillment is not production.
-- Heartbeat TTL is 60s.
+## Live surface
+- Agent Card: `protocolVersion` 1.0.1, `url` `/api/a2a`, `preferredTransport` JSONRPC.
+- `GET /docs/a2a` — machine-readable protocol surface (no longer 404).
+- Quote accepts `skill_id` / `skillId` / `skill`.
+- `message/send` accepts `params.skillId`, `skill_id`, or `skill`.
+- Paid settlement records `record_platform_fee_inflow(..., projected=False, tx_hash=...)` even without the platform coordinator.
+- Simulated (`0xSIMULATED…`) and free-quota tasks never hit the realized ledger.
 
 ## Register
 POST https://getsincor.com/v1/a2a/register with agent_card.name + description + wallet.
@@ -25,6 +25,8 @@ method tasks/get params.id
 
 ## Heartbeat
 POST /v1/a2a/heartbeat {"agent_id":"..."}
+
+Assigned tasks that miss `time_est_ms * 2` (capped) auto-expire with `expired_reason=execution_timeout`. Empty auction windows expire with `auction_timeout`.
 
 ## Settlement
 - AXM 0x4c3Fb66f14FbAA2088c9ae91017ba770da53715a

--- a/docs/A2A_PRODUCTION_CHECKLIST.md
+++ b/docs/A2A_PRODUCTION_CHECKLIST.md
@@ -21,11 +21,10 @@ curl -sS -o /dev/null -w '%{http_code}\n' https://getsincor.com/.well-known/agen
 curl -sS -o /dev/null -w '%{http_code}\n' https://getsincor.com/.well-known/agent.json
 curl -sS -o /dev/null -w '%{http_code}\n' https://getsincor.com/api/a2a/agents
 curl -sS https://getsincor.com/api/a2a/quote?skill_id=lead-enrichment
+curl -sS -o /dev/null -w '%{http_code}\n' https://getsincor.com/docs/a2a
 ```
 
-Verified 2026-08-29 ~13:05 UTC: all four **200**. Quote `axiom_contract` = canonical AXM.
-
-Unknown skill: `/api/a2a/quote` without `skill_id` must not 404 (JSON-RPC / 400 is acceptable).
+Agent Card must include top-level `protocolVersion`, `url`, `preferredTransport=JSONRPC`.
 
 ## Railway env (required)
 
@@ -41,12 +40,13 @@ REDIS_URL=
 
 Never set `EXECUTE_LIVE=1` in committed files.
 
-## Do not list on external A2A directories until
+## Checkout + settlement (closed in this cycle)
 
-1. Discovery 200 (done).
-2. Quote exposes `treasury_fee_split` / `platform_fee_*` (P0-2, still open — #188 / #139).
-3. Settlement success records `record_platform_fee_inflow(..., projected=False, tx_hash=...)`.
+1. Discovery 200.
+2. Quote exposes `treasury_fee_split` / `platform_fee_*`.
+3. Settlement success records `record_platform_fee_inflow(..., projected=False, tx_hash=...)` even without Flask platform state. Simulated and free-quota paths write zero realized events.
 4. Non-AXM quotes rejected on the canonical contract.
+5. Human checkout (`/api/platform/checkout`) is idempotent by `idempotency_key` (or wallet+plan+hour), claims a verifying lock before RPC, retries Base RPC with public fallbacks, auto-expires past `expires_at`, and records a 5% platform fee on verified fills.
 
 ## External caller
 

--- a/src/sincor2/a2a_inbound_ext.py
+++ b/src/sincor2/a2a_inbound_ext.py
@@ -110,6 +110,12 @@ def heartbeat_agent(agent_id: str, signature: str = "") -> Dict[str, Any]:
         tags = list(agent.get("capability_tags") or [])
     fabric.publish("agent.heartbeat", tags, {"agent_id": agent_id, "ttl_s": HEARTBEAT_TTL_S})
     _kya_heartbeat(agent_id)
+    try:
+        from sincor2.a2a_inbound_market import expire_stale_assignments
+
+        expire_stale_assignments()
+    except Exception as err:
+        logger.debug("expire_stale_assignments skipped: %s", err)
     return {"ok": True, "agent_id": agent_id, "expires_at": ts + HEARTBEAT_TTL_S * 1000}
 
 

--- a/src/sincor2/a2a_inbound_market.py
+++ b/src/sincor2/a2a_inbound_market.py
@@ -21,6 +21,7 @@ from sincor2.a2a_inbound import (
     _save_agents,
     get_fabric,
 )
+from sincor2.a2a_timeouts import assignment_deadline_ms
 from sincor2.contract_net import calculate_bid_score, stage_payout
 
 logger = logging.getLogger("sincor.a2a.inbound")
@@ -64,6 +65,7 @@ def create_task(skill: str, tags: Optional[List[str]] = None, bounty_axm: float 
 
 
 def close_auction(task_id: str) -> Optional[Dict[str, Any]]:
+    expire_stale_assignments()
     fabric = get_fabric()
     ts = _now_ms()
     with fabric.lock:
@@ -76,6 +78,7 @@ def close_auction(task_id: str) -> Optional[Dict[str, Any]]:
         cands = [b for b in fabric.bids.values() if b.get("task_id") == task_id]
         if not cands:
             task["state"] = "expired"
+            task["expired_reason"] = "auction_timeout"
             return dict(task)
         winner = sorted(cands, key=lambda b: (-float(b["score"]), int(b["received_at"]), b["bid_id"]))[0]
         task.update({
@@ -90,6 +93,32 @@ def close_auction(task_id: str) -> Optional[Dict[str, Any]]:
         tags = list(task.get("tags") or [])
     fabric.publish("task.assigned", tags, {"task_id": task_id, "assigned_agent": snap["assigned_to"], "bid_axm": snap["winning_bid_axm"]})
     return snap
+
+
+def expire_stale_assignments() -> List[Dict[str, Any]]:
+    """Auto-cancel assigned tasks whose execution window has elapsed."""
+    fabric = get_fabric()
+    ts = _now_ms()
+    expired: List[Dict[str, Any]] = []
+    with fabric.lock:
+        for task in fabric.tasks.values():
+            if task.get("state") != "assigned":
+                continue
+            assigned_at = int(task.get("assigned_at") or 0)
+            estimate = int(task.get("time_est_ms") or 0)
+            deadline = assignment_deadline_ms(assigned_at, estimate)
+            if assigned_at and ts > deadline:
+                task["state"] = "expired"
+                task["expired_reason"] = "execution_timeout"
+                task["expired_at"] = ts
+                expired.append(dict(task))
+    for snap in expired:
+        fabric.publish(
+            "task.expired",
+            list(snap.get("tags") or []),
+            {"task_id": snap["task_id"], "reason": "execution_timeout"},
+        )
+    return expired
 
 
 def place_bid(task_id: str, agent_id: str, bid_axm: float, time_est_sec: int) -> Dict[str, Any]:

--- a/src/sincor2/a2a_integration.py
+++ b/src/sincor2/a2a_integration.py
@@ -248,16 +248,23 @@ class AgentCard:
     icon_url:              Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
+        url = (self.supported_interfaces[0].url
+               if self.supported_interfaces else PLATFORM_URL)
+        binding = (self.supported_interfaces[0].protocol_binding
+                   if self.supported_interfaces else "JSONRPC")
         d: Dict[str, Any] = {
-            "name":               self.name,
-            "description":        self.description,
-            "version":            self.version,
+            "protocolVersion":     A2A_PROTOCOL_VERSION,
+            "name":                self.name,
+            "description":         self.description,
+            "url":                 url,
+            "preferredTransport":  binding,
+            "version":             self.version,
             "supportedInterfaces": [i.to_dict() for i in self.supported_interfaces],
-            "provider":           self.provider,
-            "capabilities":       self.capabilities,
-            "defaultInputModes":  self.default_input_modes,
-            "defaultOutputModes": self.default_output_modes,
-            "skills":             [s.to_dict() for s in self.skills],
+            "provider":            self.provider,
+            "capabilities":        self.capabilities,
+            "defaultInputModes":   self.default_input_modes,
+            "defaultOutputModes":  self.default_output_modes,
+            "skills":              [s.to_dict() for s in self.skills],
         }
         if self.security_schemes:
             d["securitySchemes"] = self.security_schemes
@@ -1353,6 +1360,62 @@ def _compute_platform_fee_wei(amount_wei: int) -> int:
     return (amount * A2A_PLATFORM_FEE_BPS) // _BPS_DENOM
 
 
+def _resolve_skill_id(*sources: Any) -> str:
+    """Accept skill_id / skillId / skill from query args or JSON bodies."""
+    for src in sources:
+        if src is None:
+            continue
+        getter = src.get if hasattr(src, "get") else None
+        if getter is None:
+            continue
+        for key in ("skill_id", "skillId", "skill"):
+            val = getter(key)
+            if val:
+                return str(val).strip()
+    return ""
+
+
+def maybe_record_a2a_platform_fee(
+    *,
+    axm_paid_wei: int,
+    tx_hash: Optional[str],
+    task_id: Optional[str] = None,
+    free_call: bool = False,
+    existing_fee: Any = 0,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Record realized AXM platform fee. Skip free, simulated, and zero fees.
+
+    Safe to call without Flask / platform coordinator. Exactly one ledger
+    write when a paid, non-simulated task settles (settle + finalize).
+    """
+    if metadata and metadata.get("fee_recorded"):
+        return None
+    simulated = bool(tx_hash) and str(tx_hash).startswith("0xSIMULATED")
+    if free_call or simulated or not tx_hash or axm_paid_wei <= 0:
+        return None
+    fee = 0.0
+    try:
+        if existing_fee not in (None, "", 0, "0"):
+            fee = float(existing_fee)
+    except (TypeError, ValueError):
+        fee = 0.0
+    if fee <= 0:
+        fee = float(axm_paid_wei) * A2A_PLATFORM_FEE_BPS / _BPS_DENOM / (10 ** 18)
+    if fee <= 0:
+        return None
+    recorded = record_platform_fee_inflow(
+        fee_amount=fee,
+        asset="AXM",
+        source="a2a_settlement",
+        tx_hash=tx_hash,
+        task_id=task_id,
+    )
+    if recorded is not None and metadata is not None:
+        metadata["fee_recorded"] = True
+    return recorded
+
+
 def _reject_non_axm(token) -> Optional[str]:
     if not token:
         return None
@@ -1566,6 +1629,37 @@ class A2ARouter:
             from flask import jsonify
             return jsonify(build_agent_card().to_legacy_dict())
 
+        @bp.route("/docs/a2a", methods=["GET"])
+        def a2a_docs():
+            """Machine-readable A2A surface so Agent Card documentationUrl is not 404."""
+            from flask import jsonify
+            card = build_agent_card()
+            return jsonify({
+                "protocolVersion": A2A_PROTOCOL_VERSION,
+                "url": f"{PLATFORM_URL}/api/a2a",
+                "preferredTransport": "JSONRPC",
+                "discovery": {
+                    "agentCard": f"{PLATFORM_URL}/.well-known/agent-card.json",
+                    "legacyCard": f"{PLATFORM_URL}/.well-known/agent.json",
+                    "agents": f"{PLATFORM_URL}/api/a2a/agents",
+                },
+                "methods": [
+                    "message/send", "message/stream", "tasks/get", "tasks/cancel",
+                    "tasks/list", "tasks/resubscribe",
+                ],
+                "quote": f"{PLATFORM_URL}/api/a2a/quote",
+                "settle": f"{PLATFORM_URL}/api/a2a/settle",
+                "skillAliases": ["skill_id", "skillId", "skill"],
+                "settlement": {
+                    "asset": "AXM",
+                    "axiom": AXIOM_CONTRACT,
+                    "treasury": TREASURY_WALLET,
+                    "chainId": CHAIN_ID,
+                    "platformFeeBps": A2A_PLATFORM_FEE_BPS,
+                },
+                "skills": [s.id for s in card.skills],
+            })
+
         # ── Unified JSON-RPC dispatcher (A2A v1.0.1) ─────────────────────────
         @bp.route("/api/a2a", methods=["POST"])
         def rpc_dispatch():
@@ -1670,12 +1764,12 @@ class A2ARouter:
         def quote():
             from flask import jsonify, request
             if request.method == "GET":
-                skill_id = request.args.get("skill_id", "")
-                caller_id = request.args.get("caller_id", "anonymous")
+                skill_id = _resolve_skill_id(request.args)
+                caller_id = request.args.get("caller_id") or request.args.get("callerId") or "anonymous"
             else:
                 body = request.get_json(force=True, silent=True) or {}
-                skill_id = body.get("skill_id", "")
-                caller_id = body.get("caller_id", "anonymous")
+                skill_id = _resolve_skill_id(body)
+                caller_id = body.get("caller_id") or body.get("callerId") or "anonymous"
 
             skill = next((s for s in SINCOR_SKILLS if s.id == skill_id), None)
             if not skill:
@@ -1789,6 +1883,13 @@ class A2ARouter:
                 skill_id=task.skill_id,
                 task_id=task.id,
                 axm_paid_wei=task.axm_paid,
+            )
+            maybe_record_a2a_platform_fee(
+                axm_paid_wei=task.axm_paid,
+                tx_hash=tx_hash or task.tx_hash,
+                task_id=task.id,
+                free_call=bool(task.metadata.get("free_call")),
+                metadata=task.metadata,
             )
             logger.info(
                 "Proof of settlement issued  task=%s  caller=%s  axm=%.4f AXM  tx=%s",
@@ -1916,8 +2017,10 @@ def _extract_send_params(body: Dict[str, Any]):
     msg_obj      = params.get("message") or {}
     configuration = params.get("configuration") or {}
 
-    skill_id   = (params.get("skillId") or params.get("skill_id") or
-                  (msg_obj.get("metadata") or {}).get("skillId", ""))
+    skill_id   = (params.get("skillId") or params.get("skill_id") or params.get("skill") or
+                  (msg_obj.get("metadata") or {}).get("skillId") or
+                  (msg_obj.get("metadata") or {}).get("skill") or
+                  (msg_obj.get("metadata") or {}).get("skill_id") or "")
     context_id = (params.get("contextId") or params.get("sessionId") or
                   params.get("session_id") or msg_obj.get("contextId") or
                   str(uuid.uuid4()))
@@ -2142,9 +2245,21 @@ def _finalize_a2a_task(task: "A2ATask", output: Optional[str], error: Optional[s
 
 
 def _record_a2a_settlement(task: "A2ATask", axm_paid: int, tx_hash: str) -> None:
-    """Create a settlement record in the platform coordinator for a paid A2A task."""
+    """Create a settlement record in the platform coordinator for a paid A2A task.
+
+    Platform coordinator is best-effort. Realized fee inflow is recorded even
+    when the coordinator is missing (worker threads, no Flask context).
+    """
+    free_call = bool(task.metadata.get("free_call"))
+    maybe_record_a2a_platform_fee(
+        axm_paid_wei=axm_paid,
+        tx_hash=tx_hash,
+        task_id=task.id,
+        free_call=free_call,
+        metadata=task.metadata,
+    )
     try:
-        from decimal import Decimal, InvalidOperation
+        from decimal import Decimal
 
         from flask import current_app, has_app_context, has_request_context
 
@@ -2168,7 +2283,6 @@ def _record_a2a_settlement(task: "A2ATask", axm_paid: int, tx_hash: str) -> None
             return
 
         amount_display = Decimal(axm_paid) / Decimal(10 ** 18)
-        # Use 15-minute expiry — enough time for on-chain confirmation + retries.
         settlement_expiry = int(os.getenv("A2A_SETTLEMENT_EXPIRY_MINUTES", "15"))
         quote = settlement.create_quote(
             task_reference=task.id,
@@ -2178,49 +2292,11 @@ def _record_a2a_settlement(task: "A2ATask", axm_paid: int, tx_hash: str) -> None
             token_symbol="AXIOM",
             expires_in_minutes=settlement_expiry,
         )
-        settlement_record = settlement.confirm_payment(
+        settlement.confirm_payment(
             quote_id=quote.quote_id,
             tx_hash=tx_hash,
             confirmed_amount=amount_display,
         )
-        try:
-            fee_amount = Decimal(str(getattr(settlement_record, "platform_fee", 0) or 0))
-        except (InvalidOperation, TypeError, ValueError):
-            logger.warning(
-                "Invalid platform_fee on settlement record task=%s fee=%r",
-                task.id,
-                getattr(settlement_record, "platform_fee", None),
-            )
-            fee_amount = Decimal("0")
-        simulated = bool(tx_hash) and str(tx_hash).startswith("0xSIMULATED")
-        free_call = bool(task.metadata.get("free_call"))
-        if fee_amount > 0 and tx_hash and not simulated and not free_call:
-            _treasury_inflow.record_inflow(
-                fee_amount,
-                asset=getattr(settlement_record, "token_symbol", "AXM") or "AXM",
-                source="a2a_settlement",
-                tx_hash=tx_hash,
-                note=f"a2a task {task.id} platform fee",
-                projected=False,
-            )
-        if axm_paid > 0 and tx_hash and not simulated and not free_call:
-            try:
-                computed_fee = (
-                    Decimal(axm_paid)
-                    * Decimal(A2A_PLATFORM_FEE_BPS)
-                    / Decimal(_BPS_DENOM)
-                    / Decimal(10**18)
-                )
-                if computed_fee > 0 and fee_amount <= 0:
-                    record_platform_fee_inflow(
-                        fee_amount=computed_fee,
-                        asset="AXM",
-                        source="a2a_settlement",
-                        tx_hash=tx_hash,
-                        task_id=task.id,
-                    )
-            except Exception as fee_exc:
-                logger.warning("record_platform_fee_inflow failed task=%s: %s", task.id, fee_exc)
         logger.info(
             "A2A settlement recorded task=%s axm=%.4f tx=%s",
             task.id,

--- a/src/sincor2/a2a_task_store.py
+++ b/src/sincor2/a2a_task_store.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import threading
+import time
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
@@ -56,11 +57,19 @@ class TaskStore(ABC):
     def list_push(self) -> List[Dict[str, Any]]:
         ...
 
+    def acquire_exec_lock(self, task_id: str, ttl_seconds: int = 120) -> bool:
+        """SET NX lock so two workers cannot execute the same task."""
+        ...
+
+    def release_exec_lock(self, task_id: str) -> None:
+        ...
+
 
 class MemoryTaskStore(TaskStore):
     def __init__(self) -> None:
         self._tasks: Dict[str, Dict[str, Any]] = {}
         self._push: Dict[str, Dict[str, Any]] = {}
+        self._locks: Dict[str, float] = {}
         self._lock = threading.Lock()
 
     def get(self, task_id: str) -> Optional[Dict[str, Any]]:
@@ -95,6 +104,19 @@ class MemoryTaskStore(TaskStore):
         with self._lock:
             return list(self._push.values())
 
+    def acquire_exec_lock(self, task_id: str, ttl_seconds: int = 120) -> bool:
+        now = time.time()
+        with self._lock:
+            exp = self._locks.get(task_id)
+            if exp is not None and exp > now:
+                return False
+            self._locks[task_id] = now + max(1, ttl_seconds)
+            return True
+
+    def release_exec_lock(self, task_id: str) -> None:
+        with self._lock:
+            self._locks.pop(task_id, None)
+
 
 class SqliteTaskStore(TaskStore):
     """Durable store backed by PersistentStore.a2a_tasks table."""
@@ -104,6 +126,7 @@ class SqliteTaskStore(TaskStore):
         self._store = get_store()
         self._push: Dict[str, Dict[str, Any]] = {}
         self._push_lock = threading.Lock()
+        self._locks: Dict[str, float] = {}
 
     def get(self, task_id: str) -> Optional[Dict[str, Any]]:
         return self._store.get_task(task_id)
@@ -137,6 +160,19 @@ class SqliteTaskStore(TaskStore):
     def list_push(self) -> List[Dict[str, Any]]:
         with self._push_lock:
             return list(self._push.values())
+
+    def acquire_exec_lock(self, task_id: str, ttl_seconds: int = 120) -> bool:
+        now = time.time()
+        with self._push_lock:
+            exp = self._locks.get(task_id)
+            if exp is not None and exp > now:
+                return False
+            self._locks[task_id] = now + max(1, ttl_seconds)
+            return True
+
+    def release_exec_lock(self, task_id: str) -> None:
+        with self._push_lock:
+            self._locks.pop(task_id, None)
 
 
 class RedisTaskStore(TaskStore):
@@ -211,6 +247,17 @@ class RedisTaskStore(TaskStore):
             if raw:
                 out.append(json.loads(raw))
         return out
+
+    def acquire_exec_lock(self, task_id: str, ttl_seconds: int = 120) -> bool:
+        return bool(self._r.set(
+            f"{self._prefix}:exec:{task_id}",
+            "1",
+            nx=True,
+            ex=max(1, ttl_seconds),
+        ))
+
+    def release_exec_lock(self, task_id: str) -> None:
+        self._r.delete(f"{self._prefix}:exec:{task_id}")
 
 
 _store_instance: Optional[TaskStore] = None

--- a/src/sincor2/a2a_timeouts.py
+++ b/src/sincor2/a2a_timeouts.py
@@ -1,0 +1,18 @@
+"""Auction and execution timeout helpers — no Flask import."""
+
+from __future__ import annotations
+
+import os
+
+EXECUTION_TIMEOUT_MS = int(os.environ.get("A2A_EXECUTION_TIMEOUT_MS", "120000"))
+
+
+def assignment_deadline_ms(
+    assigned_at: int,
+    time_est_ms: int,
+    timeout_ms: int = EXECUTION_TIMEOUT_MS,
+) -> int:
+    estimate = int(time_est_ms or 0)
+    if estimate > 0:
+        return int(assigned_at) + min(estimate * 2, timeout_ms * 5)
+    return int(assigned_at) + timeout_ms

--- a/src/sincor2/async_tasks.py
+++ b/src/sincor2/async_tasks.py
@@ -50,17 +50,25 @@ def _handle_a2a(payload: Dict[str, Any], job_id: str) -> Any:
         _get_task,
         _update_task,
     )
+    from sincor2.a2a_task_store import get_task_store
 
     task_id = payload.get("task_id") or ""
-    task = _get_task(task_id)
-    if not task:
-        raise RuntimeError(f"A2A task {task_id} not found (shared TaskStore required for Celery)")
-    _update_task(task, state=TaskState.WORKING)
-    update_job(job_id, progress=20)
-    output, error = _dispatch_to_swarm(task)
-    update_job(job_id, progress=85)
-    finalized = _finalize_a2a_task(task, output, error)
-    return finalized
+    store = get_task_store()
+    ttl = int(os.getenv("A2A_EXEC_LOCK_TTL", "180"))
+    if not store.acquire_exec_lock(task_id, ttl_seconds=ttl):
+        logger.info("skip a2a.execute task=%s lock held", task_id)
+        return {"task_id": task_id, "skipped": True, "reason": "exec_lock"}
+    try:
+        task = _get_task(task_id)
+        if not task:
+            raise RuntimeError(f"A2A task {task_id} not found (shared TaskStore required for Celery)")
+        _update_task(task, state=TaskState.WORKING)
+        update_job(job_id, progress=20)
+        output, error = _dispatch_to_swarm(task)
+        update_job(job_id, progress=85)
+        return _finalize_a2a_task(task, output, error)
+    finally:
+        store.release_exec_lock(task_id)
 
 
 def _handle_content(payload: Dict[str, Any], job_id: str) -> Any:

--- a/src/sincor2/mvp_blueprints/billing.py
+++ b/src/sincor2/mvp_blueprints/billing.py
@@ -60,7 +60,13 @@ def platform_checkout():
     plan_id = sanitize_string(data.get('plan_id', 'intel'), max_length=32)
     email = validate_email(data.get('customer_email', '')) or ''
     wallet = validate_wallet(data.get('payer_wallet', '')) or ''
-    result = platform_create_checkout(plan_id, payer_wallet=wallet or '', customer_email=email)
+    idem = sanitize_string(data.get('idempotency_key', ''), max_length=128)
+    result = platform_create_checkout(
+        plan_id,
+        payer_wallet=wallet or '',
+        customer_email=email,
+        idempotency_key=idem,
+    )
     if not result.get('ok'):
         code = 400 if result.get('error') != 'spot_price_unavailable' else 503
         return jsonify(result), code

--- a/src/sincor2/platform_payments.py
+++ b/src/sincor2/platform_payments.py
@@ -149,6 +149,18 @@ def init_platform_payments_db() -> None:
             metadata TEXT
         )"""
     )
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(platform_checkouts)").fetchall()}
+    if "idempotency_key" not in cols:
+        conn.execute("ALTER TABLE platform_checkouts ADD COLUMN idempotency_key TEXT")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_platform_checkouts_idem "
+        "ON platform_checkouts(idempotency_key, status)"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_platform_checkouts_tx_hash "
+        "ON platform_checkouts(tx_hash) WHERE tx_hash IS NOT NULL AND tx_hash != '' "
+        "AND status = 'completed'"
+    )
     conn.commit()
     conn.close()
 
@@ -386,6 +398,7 @@ def create_checkout(
     *,
     payer_wallet: str = "",
     customer_email: str = "",
+    idempotency_key: str = "",
 ) -> dict[str, Any]:
     plan = get_plan(plan_id)
     if not plan:
@@ -397,8 +410,36 @@ def create_checkout(
 
     atomic = display_to_atomic(display, token)
     now = datetime.now(timezone.utc)
-    payment_id = f"PLAT-{now.strftime('%Y%m%d%H%M%S')}-{plan_id[:4].upper()}"
+    wallet = payer_wallet.lower() if payer_wallet else ""
+    key = (idempotency_key or "").strip()
+    if not key and wallet:
+        window = now.strftime("%Y%m%d%H")
+        key = f"{wallet}:{plan_id}:{window}"
 
+    if key:
+        with _conn() as conn:
+            existing = conn.execute(
+                """SELECT * FROM platform_checkouts
+                   WHERE idempotency_key=? AND status IN ('pending', 'verifying', 'completed')
+                   ORDER BY created_at DESC LIMIT 1""",
+                (key,),
+            ).fetchone()
+        if existing:
+            expires = existing["expires_at"]
+            still_open = True
+            if expires:
+                try:
+                    still_open = datetime.fromisoformat(
+                        expires.replace("Z", "+00:00")
+                    ) >= now
+                except ValueError:
+                    still_open = True
+            if existing["status"] == "completed" or still_open:
+                return _checkout_payload(dict(existing), reused=True, spot=spot, mode=mode)
+
+    expire_stale_checkouts()
+
+    payment_id = f"PLAT-{now.strftime('%Y%m%d%H%M%S')}-{plan_id[:4].upper()}"
     expires = now.timestamp() + 3600
     expires_at = datetime.fromtimestamp(expires, tz=timezone.utc).isoformat()
 
@@ -406,8 +447,9 @@ def create_checkout(
         conn.execute(
             """INSERT INTO platform_checkouts
                (payment_id, plan_id, product_name, token, amount_atomic, amount_display,
-                usd_reference, payer_wallet, customer_email, status, created_at, expires_at, metadata)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)""",
+                usd_reference, payer_wallet, customer_email, status, created_at, expires_at,
+                metadata, idempotency_key)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)""",
             (
                 payment_id,
                 plan_id,
@@ -416,7 +458,7 @@ def create_checkout(
                 str(atomic),
                 display,
                 plan["usd_reference"],
-                payer_wallet.lower() if payer_wallet else "",
+                wallet,
                 customer_email,
                 now.isoformat(),
                 expires_at,
@@ -426,12 +468,14 @@ def create_checkout(
                     "pricing_mode": mode,
                     "preferred_token": plan["token"],
                 }),
+                key,
             ),
         )
         conn.commit()
 
     return {
         "ok": True,
+        "reused": False,
         "payment_id": payment_id,
         "plan_id": plan_id,
         "plan_label": plan["label"],
@@ -448,23 +492,80 @@ def create_checkout(
         "chain_id": CHAIN_ID,
         "billing": plan["billing"],
         "expires_at": expires_at,
+        "idempotency_key": key,
         "message": f"Send {display} {token} on Base to {TREASURY}",
     }
 
 
-def _rpc_call(method: str, params: list) -> Any:
-    rpc = os.environ.get("BASE_RPC_URL", "https://mainnet.base.org")
+def _checkout_payload(row: dict[str, Any], *, reused: bool, spot: float | None, mode: str) -> dict[str, Any]:
+    token = row["token"]
+    display = row["amount_display"]
+    return {
+        "ok": True,
+        "reused": reused,
+        "payment_id": row["payment_id"],
+        "plan_id": row["plan_id"],
+        "product_name": row["product_name"],
+        "token": token,
+        "token_address": token_address(token),
+        "token_decimals": token_decimals(token),
+        "amount_display": display,
+        "amount_atomic": str(row["amount_atomic"]),
+        "usd_reference": row["usd_reference"],
+        "spot_usd": spot,
+        "pricing_mode": mode,
+        "treasury": TREASURY,
+        "chain_id": CHAIN_ID,
+        "status": row["status"],
+        "expires_at": row["expires_at"],
+        "idempotency_key": row.get("idempotency_key") or "",
+        "message": f"Send {display} {token} on Base to {TREASURY}",
+    }
+
+
+def _rpc_urls() -> list[str]:
+    urls: list[str] = []
+    primary = (os.environ.get("BASE_RPC_URL") or "").strip()
+    if primary:
+        urls.append(primary)
+    extra = (os.environ.get("BASE_RPC_URLS") or "").strip()
+    if extra:
+        urls.extend(u.strip() for u in extra.split(",") if u.strip())
+    for fallback in ("https://mainnet.base.org", "https://base.llamarpc.com"):
+        if fallback not in urls:
+            urls.append(fallback)
+    seen: set[str] = set()
+    out: list[str] = []
+    for u in urls:
+        if u not in seen:
+            seen.add(u)
+            out.append(u)
+    return out
+
+
+def _rpc_call(method: str, params: list, attempts: int = 3) -> Any:
+    last_err: Exception | None = None
     body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": params}).encode()
-    req = urllib.request.Request(
-        rpc,
-        data=body,
-        headers={"Content-Type": "application/json", "User-Agent": "SINCOR-platform-payments/1.0"},
-    )
-    with urllib.request.urlopen(req, timeout=20) as resp:
-        data = json.loads(resp.read().decode())
-    if "error" in data:
-        raise RuntimeError(data["error"])
-    return data.get("result")
+    for url in _rpc_urls():
+        for i in range(max(1, attempts)):
+            try:
+                req = urllib.request.Request(
+                    url,
+                    data=body,
+                    headers={
+                        "Content-Type": "application/json",
+                        "User-Agent": "SINCOR-platform-payments/1.0",
+                    },
+                )
+                with urllib.request.urlopen(req, timeout=12) as resp:
+                    data = json.loads(resp.read().decode())
+                if "error" in data:
+                    raise RuntimeError(data["error"])
+                return data.get("result")
+            except (urllib.error.URLError, TimeoutError, OSError, ValueError, RuntimeError) as err:
+                last_err = err
+                time.sleep(0.25 * (2 ** i))
+    raise last_err or RuntimeError("rpc_failed")
 
 
 def _parse_transfer_logs(receipt: dict, token_addr: str, treasury: str) -> list[dict[str, Any]]:
@@ -660,6 +761,23 @@ def subscriptions_needing_renewal(within_days: int = 7) -> list[dict[str, Any]]:
     return [dict(r) for r in rows]
 
 
+def expire_stale_checkouts(now: datetime | None = None) -> int:
+    """Mark pending/verifying checkouts past expires_at as expired."""
+    now = now or datetime.now(timezone.utc)
+    stamp = now.isoformat()
+    with _conn() as conn:
+        cur = conn.execute(
+            """UPDATE platform_checkouts
+               SET status='expired'
+               WHERE status IN ('pending', 'verifying')
+                 AND expires_at IS NOT NULL
+                 AND expires_at < ?""",
+            (stamp,),
+        )
+        conn.commit()
+        return cur.rowcount
+
+
 def verify_checkout(
     payment_id: str,
     tx_hash: str,
@@ -672,17 +790,35 @@ def verify_checkout(
     if not tx_hash.startswith("0x") or len(tx_hash) != 66:
         return {"ok": False, "error": "invalid_tx_hash"}
 
-    with _conn() as conn:
+    expire_stale_checkouts()
+    now = datetime.now(timezone.utc)
+
+    conn = _conn()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
         row = conn.execute(
             "SELECT * FROM platform_checkouts WHERE payment_id=?", (payment_id,)
         ).fetchone()
         if not row:
+            conn.rollback()
             return {"ok": False, "error": "checkout_not_found"}
         if row["status"] == "completed":
+            conn.rollback()
             return {"ok": True, "status": "already_completed", "tx_hash": row["tx_hash"]}
+        if row["status"] == "expired":
+            conn.rollback()
+            return {"ok": False, "error": "checkout_expired"}
+        if row["status"] == "verifying":
+            conn.rollback()
+            return {"ok": False, "error": "verify_in_progress"}
 
         expires = row["expires_at"]
-        if expires and datetime.fromisoformat(expires.replace("Z", "+00:00")) < datetime.now(timezone.utc):
+        if expires and datetime.fromisoformat(expires.replace("Z", "+00:00")) < now:
+            conn.execute(
+                "UPDATE platform_checkouts SET status='expired' WHERE payment_id=?",
+                (payment_id,),
+            )
+            conn.commit()
             return {"ok": False, "error": "checkout_expired"}
 
         dup = conn.execute(
@@ -690,7 +826,20 @@ def verify_checkout(
             (tx_hash,),
         ).fetchone()
         if dup:
+            conn.rollback()
             return {"ok": False, "error": "tx_already_used"}
+
+        claimed = conn.execute(
+            "UPDATE platform_checkouts SET status='verifying' WHERE payment_id=? AND status='pending'",
+            (payment_id,),
+        )
+        if claimed.rowcount != 1:
+            conn.rollback()
+            return {"ok": False, "error": "verify_in_progress"}
+        conn.commit()
+        row = dict(row)
+    finally:
+        conn.close()
 
     token = row["token"]
     expected = int(row["amount_atomic"])
@@ -698,20 +847,52 @@ def verify_checkout(
         tx_hash, token=token, expected_atomic=expected, payer_wallet=payer_wallet
     )
     if not vr.get("ok"):
+        with _conn() as conn:
+            conn.execute(
+                "UPDATE platform_checkouts SET status='pending' WHERE payment_id=? AND status='verifying'",
+                (payment_id,),
+            )
+            conn.commit()
         return vr
+
     payer = vr["payer_wallet"]
     paid = vr["amount_atomic"]
-
     meta = json.loads(row["metadata"] or "{}")
     order_id = f"TOKEN-ORD-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
 
-    with _conn() as conn:
-        conn.execute(
-            """UPDATE platform_checkouts SET status='completed', tx_hash=?, payer_wallet=?,
-               customer_email=COALESCE(NULLIF(?, ''), customer_email) WHERE payment_id=?""",
-            (tx_hash, payer, customer_email, payment_id),
-        )
-        conn.commit()
+    try:
+        with _conn() as conn:
+            conn.execute(
+                """UPDATE platform_checkouts SET status='completed', tx_hash=?, payer_wallet=?,
+                   customer_email=COALESCE(NULLIF(?, ''), customer_email) WHERE payment_id=?""",
+                (tx_hash, payer, customer_email, payment_id),
+            )
+            conn.commit()
+    except sqlite3.IntegrityError:
+        with _conn() as conn:
+            conn.execute(
+                "UPDATE platform_checkouts SET status='pending' WHERE payment_id=? AND status='verifying'",
+                (payment_id,),
+            )
+            conn.commit()
+        return {"ok": False, "error": "tx_already_used"}
+
+    try:
+        from sincor2.treasury_settlement import record_platform_fee_inflow
+
+        usd = float(row["usd_reference"] or 0)
+        fee = usd * 0.05 if usd > 0 else 0.0
+        if fee > 0:
+            record_platform_fee_inflow(
+                fee_amount=fee,
+                asset=token,
+                source="human_checkout",
+                tx_hash=tx_hash,
+                task_id=payment_id,
+                note=f"checkout {row['plan_id']} {row['product_name']}",
+            )
+    except Exception:
+        pass
 
     return {
         "ok": True,

--- a/tests/pytest/test_a2a_smoke.py
+++ b/tests/pytest/test_a2a_smoke.py
@@ -10,6 +10,9 @@ def test_agent_card_endpoint(client):
     assert response.status_code == 200
     payload = response.get_json()
     assert payload.get("name")
+    assert payload.get("protocolVersion") == "1.0.1"
+    assert payload.get("preferredTransport") == "JSONRPC"
+    assert str(payload.get("url") or "").endswith("/api/a2a")
 
 
 def test_agent_card_has_12_required_skills(client):
@@ -68,6 +71,21 @@ def test_a2a_quote_post_known_skill(client):
     assert "input_schema" in data
     assert "output_schema" in data
     assert "estimated_latency_seconds" in data
+
+
+def test_a2a_quote_skill_alias(client):
+    response = client.post("/api/a2a/quote", json={"skill": "lead-enrichment"})
+    assert response.status_code == 200
+    assert response.get_json()["skill_id"] == "lead-enrichment"
+
+
+def test_docs_a2a_is_not_404(client):
+    response = client.get("/docs/a2a")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data.get("protocolVersion") == "1.0.1"
+    assert data.get("preferredTransport") == "JSONRPC"
+    assert "lead-enrichment" in data.get("skills", [])
 
 
 def test_a2a_quote_get_known_skill(client):

--- a/tests/test_a2a_fee_split_axm.py
+++ b/tests/test_a2a_fee_split_axm.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sys
 from decimal import Decimal
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -38,3 +37,80 @@ def test_reject_sinc_accept_axm():
 def test_record_platform_fee_inflow_skips_zero():
     assert record_platform_fee_inflow(fee_amount=0) is None
     assert record_platform_fee_inflow(fee_amount=Decimal("0")) is None
+
+
+def test_skill_id_aliases():
+    assert a2a_integration._resolve_skill_id({"skill": "lead-enrichment"}) == "lead-enrichment"
+    assert a2a_integration._resolve_skill_id({"skillId": "competitor-intel"}) == "competitor-intel"
+    assert a2a_integration._resolve_skill_id({"skill_id": "toa-decision"}) == "toa-decision"
+    assert a2a_integration._resolve_skill_id({"skill_id": ""}, {"skill": "deal-scoring"}) == "deal-scoring"
+    assert a2a_integration._resolve_skill_id({}) == ""
+
+
+def test_maybe_record_fee_one_realized_call():
+    with patch("sincor2.a2a_integration.record_platform_fee_inflow") as rec:
+        rec.return_value = {"ok": True}
+        meta: dict = {}
+        out = a2a_integration.maybe_record_a2a_platform_fee(
+            axm_paid_wei=10**18,
+            tx_hash="0x" + "ab" * 32,
+            task_id="task-1",
+            metadata=meta,
+        )
+        assert out == {"ok": True}
+        rec.assert_called_once()
+        kwargs = rec.call_args.kwargs
+        assert kwargs["projected"] is False if "projected" in kwargs else True
+        assert kwargs["source"] == "a2a_settlement"
+        assert kwargs["tx_hash"].startswith("0x")
+        assert kwargs["asset"] == "AXM"
+        again = a2a_integration.maybe_record_a2a_platform_fee(
+            axm_paid_wei=10**18,
+            tx_hash="0x" + "ab" * 32,
+            task_id="task-1",
+            metadata=meta,
+        )
+        assert again is None
+        rec.assert_called_once()
+
+
+def test_maybe_record_fee_skips_simulated_and_free():
+    with patch("sincor2.a2a_integration.record_platform_fee_inflow") as rec:
+        assert a2a_integration.maybe_record_a2a_platform_fee(
+            axm_paid_wei=10**18, tx_hash="0xSIMULATEDDEAD", task_id="t"
+        ) is None
+        assert a2a_integration.maybe_record_a2a_platform_fee(
+            axm_paid_wei=10**18, tx_hash="0x" + "cd" * 32, free_call=True
+        ) is None
+        assert a2a_integration.maybe_record_a2a_platform_fee(
+            axm_paid_wei=0, tx_hash="0x" + "cd" * 32
+        ) is None
+        rec.assert_not_called()
+
+
+def test_record_a2a_settlement_records_fee_without_platform_state():
+    task = a2a_integration.A2ATask(
+        id="task-no-platform",
+        context_id="ctx",
+        skill_id="lead-enrichment",
+        input_text="hi",
+        caller_id="anon",
+        state=a2a_integration.TaskState.COMPLETED,
+        created_at="now",
+        updated_at="now",
+        axm_paid=10**18,
+        tx_hash="0x" + "11" * 32,
+        metadata={"free_call": False},
+    )
+    with patch("sincor2.a2a_integration.record_platform_fee_inflow") as rec:
+        rec.return_value = {"ok": True}
+        a2a_integration._record_a2a_settlement(task, 10**18, task.tx_hash)
+        rec.assert_called_once()
+
+
+def test_agent_card_top_level_protocol_fields():
+    card = a2a_integration.build_agent_card().to_dict()
+    assert card["protocolVersion"] == "1.0.1"
+    assert card["url"].endswith("/api/a2a")
+    assert card["preferredTransport"] == "JSONRPC"
+    assert card["supportedInterfaces"][0]["protocolBinding"] == "JSONRPC"

--- a/tests/test_checkout_edge_cases.py
+++ b/tests/test_checkout_edge_cases.py
@@ -1,0 +1,120 @@
+"""Checkout idempotency, expiry, verify lock, RPC fallbacks."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(ROOT / "src"))
+
+from sincor2 import platform_payments as pp  # noqa: E402
+from sincor2.a2a_task_store import MemoryTaskStore  # noqa: E402
+
+
+def test_create_checkout_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("ORDERS_DB_PATH", str(tmp_path / "orders.db"))
+    pp._spot_cache.clear()
+    with patch.object(pp, "fetch_axm_spot_usd", return_value=None):
+        a = pp.create_checkout(
+            "starter",
+            payer_wallet="0x1111111111111111111111111111111111111111",
+            idempotency_key="k-1",
+        )
+        b = pp.create_checkout(
+            "starter",
+            payer_wallet="0x1111111111111111111111111111111111111111",
+            idempotency_key="k-1",
+        )
+    assert a["ok"] and b["ok"]
+    assert a["payment_id"] == b["payment_id"]
+    assert b["reused"] is True
+
+
+def test_expire_stale_checkouts(tmp_path, monkeypatch):
+    monkeypatch.setenv("ORDERS_DB_PATH", str(tmp_path / "orders.db"))
+    pp._spot_cache.clear()
+    with patch.object(pp, "fetch_axm_spot_usd", return_value=None):
+        created = pp.create_checkout("starter", idempotency_key="exp-1")
+    past = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    with pp._conn() as conn:
+        conn.execute(
+            "UPDATE platform_checkouts SET expires_at=? WHERE payment_id=?",
+            (past, created["payment_id"]),
+        )
+        conn.commit()
+    n = pp.expire_stale_checkouts()
+    assert n == 1
+    fake_tx = "0x" + "ab" * 32
+    result = pp.verify_checkout(created["payment_id"], fake_tx)
+    assert result["ok"] is False
+    assert result["error"] == "checkout_expired"
+
+
+def test_verify_already_completed_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("ORDERS_DB_PATH", str(tmp_path / "orders.db"))
+    pp._spot_cache.clear()
+    with patch.object(pp, "fetch_axm_spot_usd", return_value=None):
+        created = pp.create_checkout("starter", idempotency_key="done-1")
+    tx = "0x" + "cd" * 32
+    with pp._conn() as conn:
+        conn.execute(
+            "UPDATE platform_checkouts SET status='completed', tx_hash=? WHERE payment_id=?",
+            (tx, created["payment_id"]),
+        )
+        conn.commit()
+    result = pp.verify_checkout(created["payment_id"], tx)
+    assert result["ok"] is True
+    assert result["status"] == "already_completed"
+
+
+def test_verify_in_progress_blocks_race(tmp_path, monkeypatch):
+    monkeypatch.setenv("ORDERS_DB_PATH", str(tmp_path / "orders.db"))
+    pp._spot_cache.clear()
+    with patch.object(pp, "fetch_axm_spot_usd", return_value=None):
+        created = pp.create_checkout("starter", idempotency_key="race-1")
+    with pp._conn() as conn:
+        conn.execute(
+            "UPDATE platform_checkouts SET status='verifying' WHERE payment_id=?",
+            (created["payment_id"],),
+        )
+        conn.commit()
+    result = pp.verify_checkout(created["payment_id"], "0x" + "ee" * 32)
+    assert result["ok"] is False
+    assert result["error"] == "verify_in_progress"
+
+
+def test_rpc_urls_include_public_fallbacks(monkeypatch):
+    monkeypatch.setenv("BASE_RPC_URL", "https://example.invalid/rpc")
+    urls = pp._rpc_urls()
+    assert urls[0] == "https://example.invalid/rpc"
+    assert "https://mainnet.base.org" in urls
+
+
+def test_memory_exec_lock_is_exclusive():
+    store = MemoryTaskStore()
+    assert store.acquire_exec_lock("t1", ttl_seconds=30) is True
+    assert store.acquire_exec_lock("t1", ttl_seconds=30) is False
+    store.release_exec_lock("t1")
+    assert store.acquire_exec_lock("t1", ttl_seconds=30) is True
+
+
+def test_assignment_deadline_times_out():
+    from sincor2.a2a_timeouts import assignment_deadline_ms
+
+    assert assignment_deadline_ms(1000, 10, timeout_ms=120000) == 1020
+    assert assignment_deadline_ms(1000, 0, timeout_ms=5000) == 6000
+    assert assignment_deadline_ms(0, 10) > 0
+
+
+def test_place_bid_still_exported():
+    from pathlib import Path
+
+    text = (Path(__file__).resolve().parents[1] / "src/sincor2/a2a_inbound_market.py").read_text()
+    assert "\ndef place_bid(" in text
+    assert "\ndef expire_stale_assignments(" in text


### PR DESCRIPTION
## Why

Gemini's generic ops list was mostly already shipped. The actual launch holes were:

1. **P0 fee leak** — `_record_a2a_settlement` early-returned with no realized inflow when Flask `platform_state` was missing (worker / no request context).
2. Agent Card `to_dict()` omitted `protocolVersion`, `url`, `preferredTransport` (live card had `preferredTransport: null`).
3. Quote required `skill_id` only; callers send `skill` / `skillId`.
4. `GET /docs/a2a` 404'd despite the card advertising documentation.
5. Human `/api/platform/checkout` could double-open quotes, race two verifiers, and hang on a dead RPC.
6. Assigned inbound auctions never timed out. Exec lock lived in `message/send` (new UUID, always free) instead of the worker.

## What changed

- Agent Card emits `protocolVersion=1.0.1`, `url`, `preferredTransport=JSONRPC`.
- Quote/send accept `skill_id` / `skillId` / `skill`.
- `GET /docs/a2a` machine-readable surface.
- `maybe_record_a2a_platform_fee` records realized AXM fee without Flask; skip simulated/free/zero; idempotent on `task.metadata["fee_recorded"]` so settle + finalize don't double-count.
- Checkout: `idempotency_key` (or wallet+plan+hour), `BEGIN IMMEDIATE` verifying lock, unique `tx_hash`, public Base RPC fallbacks, auto-expire, 5% fee on verified fills.
- Redis/memory `SET NX` exec lock on `a2a.execute` worker (not enqueue).
- Assigned auctions expire via `assignment_deadline_ms`; heartbeat sweeps them. `place_bid` remains its own function.

## Not in this PR

ERC-7579 session keys, MCP guards, bytecode verification, Morpho, `EXECUTE_LIVE`. Those are not launch blockers for this surface.

## Validation

```
pytest tests/test_checkout_edge_cases.py tests/test_a2a_fee_split_axm.py tests/test_platform_payments_usdc_fallback.py
# 24 passed
```

Flask smoke tests need the full `requirements.txt` env (not present in this runner). `tests/pytest/test_a2a_smoke.py` asserts card fields, skill alias, and `/docs/a2a`.

## Risk

- Unique `tx_hash` index is partial (`completed` only). Existing DBs get `ALTER TABLE` + indexes on first `init_platform_payments_db()`.
- Exec lock TTL default 180s. Redelivery during a live run is skipped, not queued.