### PR TITLE
feat(kya): merkle airdrop quest, HOLD numbers, Axiom 2.0 checklist

### DIFF
--- a/HOLD.md
+++ b/HOLD.md
@@ -1,0 +1,13 @@
+# Treasury HOLD — 2am standing order
+
+Locked 2026-09-10. Destination: `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac`. Code: `src/sincor2/treasury_hold.py`. Full: `docs/TREASURY_HOLD.md`.
+
+1. **100%** of realized platform fees (projected=false + tx_hash) → Treasury. Take is **500 bps**.
+2. **100% HOLD** on-chain USDC (~$192). **0%** Morpho / Aave / LP / SharedLiquidity.
+3. **100% HOLD** founder cash off-chain (~$800). **0%** load-to-chain.
+4. Vault **0%** until first conversion; then 80/20 only if cash ≥ **$10,000 USDC**.
+5. Underwriting go-live: **$10,000 USDC** backing + conversion proof + founder signer. Halt file `data/TREASURY_EXEC_HALT` is ON. `EXECUTE_LIVE` default off.
+
+Mover: founder signer broadcasts. Treasury exec queues. Auditor gates. Nobody else.
+
+Paste this block under README “What’s new (2026-09)” on merge if the README hunk is not already in.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ SINAX (`src/sincor2/sinax/`) is a **research prototype** — geometric proof nav
 
 - [Why SINCOR2](#why-sincor2)
 - [What's new (2026-09)](#whats-new-2026-09)
+- [Treasury HOLD](#treasury-hold-locked-2026-09-10)
 - [Quickstart](#quickstart)
 - [Platform Architecture](#platform-architecture)
 - [Agent Intelligence & Cognition](#agent-intelligence--cognition)
@@ -103,6 +104,20 @@ Additive status for operators landing on this repo now. Nothing above is retired
 - Tracking: GitHub issues labeled `ceo` / `treasury` / `a2a` (see [#203](https://github.com/OrderofChaos33/SINCOR2/issues/203)).
 - Production A2A checklist: `docs/A2A_PRODUCTION_CHECKLIST.md`.
 - Canonical addresses: `CANONICAL_ADDRESSES.md` and `src/sincor2/onchain/constants.py`.
+- **HOLD standing order:** [`HOLD.md`](HOLD.md).
+
+
+## Treasury HOLD (locked 2026-09-10)
+
+Standing order. Full: [`HOLD.md`](HOLD.md). Code: `src/sincor2/treasury_hold.py`. Destination: `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac`.
+
+1. **100%** of realized platform fees (`projected=false` + `tx_hash`) → Treasury. Take is **500 bps**.
+2. **100% HOLD** on-chain USDC (~$192). **0%** Morpho / Aave / LP / SharedLiquidity.
+3. **100% HOLD** founder cash off-chain (~$800). **0%** load-to-chain.
+4. Vault **0%** until first conversion; then 80/20 only if cash ≥ **$10,000 USDC**.
+5. Underwriting go-live: **$10,000 USDC** backing + conversion proof + founder signer. Halt file `data/TREASURY_EXEC_HALT` is ON. `EXECUTE_LIVE` default off.
+
+Mover: founder signer broadcasts. Treasury exec queues. Auditor gates. Nobody else.
 
 ---
 

--- a/docs/A2A_EXTERNAL_WIRE.md
+++ b/docs/A2A_EXTERNAL_WIRE.md
@@ -1,32 +1,57 @@
-# A2A external wire (verified 2026-09-04 against getsincor.com)
+# A2A external wire — friction log (2026-09-10)
 
-Founder airdrops AXM. Do not broadcast from agents.
+Hit live `getsincor.com` from outside the org. This is the spec. Pay a $50 bot to repeat it; do not edit this from memory.
 
-## Live holes
-- Agent Card missing top-level `protocolVersion`, `url`, `preferredTransport`.
-- `GET /docs/a2a` is 404.
-- Quote requires `skill_id`. Field `skill` returns Unknown skill.
-- `message/send` requires `params.skillId`.
-- Skill artifacts are still a placeholder. Fulfillment is not production.
-- Heartbeat TTL is 60s.
+## What actually worked
 
-## Register
-POST https://getsincor.com/v1/a2a/register with agent_card.name + description + wallet.
+| Step | Result |
+|---|---|
+| GET `/.well-known/agent-card.json` | 200. 16 skills. Binding lives under `supportedInterfaces[0]` (`protocolBinding=JSONRPC`, `protocolVersion=1.0.1`, `url=https://getsincor.com/api/a2a`). |
+| POST `/v1/a2a/register` without `skills[]` | **400** `agent_card must include at least one skill` |
+| POST `/v1/a2a/register` with one skill + wallet | **201** `status=registered`, `probation=true`, `kya_status=listed`, `heartbeat_ttl_s=60`, `kya_id` issued |
+| POST `/v1/a2a/heartbeat` `{agent_id}` | 200 `ok=true` + `expires_at` |
+| POST `/api/a2a/quote` `{skill_id, target}` | 200. AXM contract live. First 5 calls `FREE`. |
+| POST `/api/a2a` JSON-RPC `message/send` | 200. Task created. `metadata.caller_id=anonymous`, `free_call=true`, `simulation_mode`. **Did not require the registered agent_id.** |
+| GET `/v1/kya/lookup?wallet=0x…` | 200. Record `status=listed`, `attestation=null`. |
+| GET `/v1/kya/lookup?agent_id=` | **400 bad wallet** — lookup is wallet-only. Use `/v1/kya/agent/<id>`. |
+| GET `/v1/quest` | **404** until this PR deploys. |
 
-## Quote
-POST https://getsincor.com/api/a2a/quote {"skill_id":"competitor-intel","target":"Acme"}
+Probe agent id `desk-probe-do-not-keep` (dead wallet) is listed. Revoke it. Do not treat it as the $50 bot.
 
-## Send
-POST https://getsincor.com/api/a2a
+## Friction (the spec)
+
+1. Agent Card is **not** Google A2A top-level (`protocolVersion` / `url` / `preferredTransport` missing at root). Clients that only read the root will think there is no JSON-RPC URL. Fix: duplicate those three fields at root **or** document `supportedInterfaces[0]` as required.
+2. Register **requires `agent_card.skills[]`**. Name + description + wallet is not enough. Docs that omit this waste the $50.
+3. Heartbeat TTL is **60 seconds**. Miss it and KYA expires (`HEARTBEAT_TTL_MS = 60_000`). Any external bot must cron sub-minute.
+4. `message/send` accepts **anonymous free calls**. The paid path is not what you hit first. A "completed paid task" needs the free quota exhausted **or** an AXM settlement, plus `caller_id` bound to the registered agent.
+5. Quote is `FREE` with `free_quota_remaining: 5`. `$50` settlement cannot be proven on the free path. Stripe `/health` = `not_configured`. Wallet USDC/AXM to treasury is the conversion rail.
+6. KYA after register is `listed`, not `verified`. Bind requires attestation signature. Quest claim will 403 until bind → stake 10 AXM → heartbeat live → verify.
+7. `/v1/kya/directory` currently 404s because `/<kya_id>` swallows the word `directory`. This PR registers `/directory` above that rule.
+8. Dead address `0x…dEaD` was accepted as `principal`. Tighten wallet checks if you do not want burn addresses listed.
+9. Founder airdrops AXM. Do not broadcast from agents.
+10. One **paid** external completion is still outstanding. This probe proved register → heartbeat → task, not paid settlement.
+
+## Copy-paste payloads
+
+Register:
+
+```
+POST https://getsincor.com/v1/a2a/register
+{"agent_card":{"name":"ext-bot-01","description":"external","version":"0.0.1","skills":[{"id":"competitor-intel","name":"Competitor intel","description":"SWOT"}]},"wallet":"0xYOURWALLET"}
+```
+
+Heartbeat: `POST /v1/a2a/heartbeat {"agent_id":"ext-bot-01"}` every 30s.
+
+Quote: `POST /api/a2a/quote {"skill_id":"competitor-intel","target":"Acme"}`
+
+Send:
+
+```
 {"jsonrpc":"2.0","id":1,"method":"message/send","params":{"skillId":"competitor-intel","message":{"role":"user","parts":[{"type":"text","text":"quick SWOT"}]}}}
-
-## Poll
-method tasks/get params.id
-
-## Heartbeat
-POST /v1/a2a/heartbeat {"agent_id":"..."}
+```
 
 ## Settlement
-- AXM 0x4c3Fb66f14FbAA2088c9ae91017ba770da53715a
-- Treasury 0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac
+
+- AXM `0x4c3fb66f14fbaa2088c9ae91017ba770da53715a`
+- Treasury `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac`
 - chain 8453, fee 500 bps, free quota 5

--- a/docs/AXIOM_2_LAUNCH_CHECKLIST.md
+++ b/docs/AXIOM_2_LAUNCH_CHECKLIST.md
@@ -4,7 +4,7 @@ Bonding curve is dead. `SincBondingCurve.sol` and its deploy scripts are gone. T
 
 **Path:** mint → pool → liquidity → quest
 
-Locked 2026-09-10. Runtime source: `src/sincor2/onchain/constants.py`.
+Locked 2026-09-10. Runtime source: `src/sincor2/onchain/constants.py`. One source of truth — do not paste a guessed pool or a DEAD address into copy, env, or Agent Cards.
 
 ## Live, locked (Base 8453)
 
@@ -23,28 +23,28 @@ Locked 2026-09-10. Runtime source: `src/sincor2/onchain/constants.py`.
 - Official LP NFT / position id
 - Bonding-curve buy path (retired)
 
-## Landmines — never paste into copy, env, or Agent Cards
+## Landmines — DEAD, never paste
 
-| Address | Why |
-|---|---|
-| `0x9C8cd8d3961F445D653713dE65C6578bE11668e7` | Retired SINC v1 |
-| `0xfF7aF6ffca25A9DC0FC990d998AcF24Cc60b7822` | Dead PumpClawToken labeled AXM |
-| `0x75dE341a2BC81806198364F125d4Cde36527619C` | Retired bonding curve |
-| `0xb627F53E08AD7d455e787d052C18D6877020E2BF` | Old bonding curve |
-| `0x25cA41Dac29f892c72A53500853eC45a5FfF90aa` | Superseded bonding curve |
-| `0x85372932f9b151a076815d92cf71a97980ffd667` | Rogue Uniswap V2 SINC/USDC |
+| Address | Label | Why |
+|---|---|---|
+| `0x9C8cd8d3961F445D653713dE65C6578bE11668e7` | DEAD | Retired SINC v1 |
+| `0xfF7aF6ffca25A9DC0FC990d998AcF24Cc60b7822` | DEAD | Dead PumpClawToken labeled AXM |
+| `0x75dE341a2BC81806198364F125d4Cde36527619C` | DEAD | Retired bonding curve |
+| `0xb627F53E08AD7d455e787d052C18D6877020E2BF` | DEAD | Old bonding curve |
+| `0x25cA41Dac29f892c72A53500853eC45a5FfF90aa` | DEAD | Superseded bonding curve |
+| `0x85372932f9b151a076815d92cf71a97980ffd667` | DEAD | Rogue Uniswap V2 SINC/USDC |
 
 `$1.50` is a ceiling wall, not a floor.
 
 ## Quest
 
-KYA airdrop quest verifies `keccak256(address20)` merkle proofs against `data/kya/airdrop_merkle.json`. Build the tree from the real disperse recipient list:
+KYA airdrop quest verifies `keccak256(address20)` merkle proofs against the **committed production root**, bound by address. Set `KYA_PRODUCTION_ROOT` on Railway after:
 
 ```
 python scripts/kya_build_merkle.py --from-file recipients.txt --source axm-disperse
 ```
 
-Do not publish a replica root as the drop root.
+Do not publish a replica root as the drop root. Claims against `source=replica` raise `REPLICA_ROOT_FORBIDDEN`. A replica proof will not verify against the disperse root even if that replica is accidentally deployed.
 
 ## Surfaces
 

--- a/docs/AXIOM_2_LAUNCH_CHECKLIST.md
+++ b/docs/AXIOM_2_LAUNCH_CHECKLIST.md
@@ -1,0 +1,53 @@
+# Axiom 2.0 launch checklist
+
+Bonding curve is dead. `SincBondingCurve.sol` and its deploy scripts are gone. This is the replacement path. Old addresses are landmines.
+
+**Path:** mint → pool → liquidity → quest
+
+Locked 2026-09-10. Runtime source: `src/sincor2/onchain/constants.py`.
+
+## Live, locked (Base 8453)
+
+| Role | Address | Status |
+|---|---|---|
+| AXM | `0x4c3fb66f14fbaa2088c9ae91017ba770da53715a` | LIVE — sole A2A settlement |
+| SINC | `0xe1D836087F6573b665d25CE088793E916D7892f8` | LIVE — 8 decimals, $0.15 floor. 1 holder / 0 transfers: do not market float |
+| Treasury | `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac` | LIVE |
+| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` | LIVE |
+| Uniswap v4 PoolManager | `0x498581fF718922c3f8e6A244956aF099B2652b2b` | Infra |
+| Uniswap v4 PositionManager | `0x7C5f5A4bBd8fD63184577525326123B519429bDc` | Infra |
+
+## Not locked — do not invent
+
+- Official AXM/USDC pool address
+- Official LP NFT / position id
+- Bonding-curve buy path (retired)
+
+## Landmines — never paste into copy, env, or Agent Cards
+
+| Address | Why |
+|---|---|
+| `0x9C8cd8d3961F445D653713dE65C6578bE11668e7` | Retired SINC v1 |
+| `0xfF7aF6ffca25A9DC0FC990d998AcF24Cc60b7822` | Dead PumpClawToken labeled AXM |
+| `0x75dE341a2BC81806198364F125d4Cde36527619C` | Retired bonding curve |
+| `0xb627F53E08AD7d455e787d052C18D6877020E2BF` | Old bonding curve |
+| `0x25cA41Dac29f892c72A53500853eC45a5FfF90aa` | Superseded bonding curve |
+| `0x85372932f9b151a076815d92cf71a97980ffd667` | Rogue Uniswap V2 SINC/USDC |
+
+`$1.50` is a ceiling wall, not a floor.
+
+## Quest
+
+KYA airdrop quest verifies `keccak256(address20)` merkle proofs against `data/kya/airdrop_merkle.json`. Build the tree from the real disperse recipient list:
+
+```
+python scripts/kya_build_merkle.py --from-file recipients.txt --source axm-disperse
+```
+
+Do not publish a replica root as the drop root.
+
+## Surfaces
+
+- Official buy: https://getsincor.com/buy
+- Agent Card: https://getsincor.com/.well-known/agent-card.json (`supportedInterfaces[0].protocolVersion` 1.0.1, JSONRPC)
+- Genesis: 2026-09-26 16:00 UTC

--- a/docs/KYA.md
+++ b/docs/KYA.md
@@ -1,40 +1,66 @@
 # KYA stack — ship notes
 
-Identity is the product. SLA, SADAS, Polyclaw receipts, and the airdrop quest hang off `kya_id`.
+Identity is the product. Live identity is `sincor2.kya_registry` mounted at `/v1/kya` (`kya_blueprint.py`). This drop adds the merkle quest, SLA **receipts**, SADAS, and Polyclaw **without replacing** `/v1/a2a/register` or `/v1/kya/list`.
 
 ## Money path
 
 AXM first. USDC second. Card last. See `src/sincor2/kya/pricing.py`.
 
+## Merkle quest (this PR)
+
+On-chain verification is a keccak256 sorted-pair tree over the disperse recipient list. Not a stub wallet set.
+
+- Build: `python scripts/kya_build_merkle.py --from-file recipients.txt --source axm-disperse`
+- Manifest: `data/kya/airdrop_merkle.json` (`/data/` is gitignored — load on Railway via `KYA_AIRDROP_MANIFEST` or the data volume)
+- Seed API: `POST /v1/quest/seed` requires `KYA_ADMIN_KEY` + header `X-KYA-Admin`
+- Claim: `POST /v1/quest/claim` `{ wallet, agent_id, proof }` after KYA **verified**
+- Identity lookup uses `kya_registry.get_by_agent` (live records)
+- Reward: 15 AXM ledger credit — treasury settles; not an auto-transfer
+- Do not publish a desk-replica root as the drop root
+
 ## Endpoints
+
+Existing (do not fork):
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/v1/kya/health` | prices + counts |
+| GET | `/v1/kya/health` | registry snapshot |
+| GET | `/v1/kya/directory` | same snapshot (static; must sit above `/<kya_id>`) |
 | POST | `/v1/kya/list` | free listing |
-| POST | `/v1/kya/verify` | stake + fee → verified |
-| GET | `/v1/kya/lookup?agent_id=` | pre-trade check |
-| GET | `/v1/kya/directory?verified=1` | public registry |
+| POST | `/v1/kya/bind` | principal + signature |
+| POST | `/v1/kya/verify` | stake + live heartbeat → verified |
+| POST | `/v1/kya/heartbeat` | 60s TTL |
+| GET | `/v1/kya/lookup?wallet=` | pre-trade check (wallet only) |
+| GET | `/v1/kya/agent/<id>` | by agent |
+| POST | `/v1/kya/sla` | writes SLA onto the KYA record |
+
+Additive in this PR:
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/v1/kya/stack` | prices + quest stats + HOLD |
 | POST | `/v1/sla/subscribe` | bind 5-min pings to kya_id |
-| POST | `/v1/sla/ping` | operator or cron |
-| GET | `/v1/sla/receipts` | epoch attestations |
-| POST | `/v1/sadas/publish` | signal |
+| POST | `/v1/sla/ping` | epoch receipt |
+| GET | `/v1/sla/receipts` | attestations |
+| POST | `/v1/sadas/publish` | admin |
 | POST | `/v1/sadas/subscribe` | paid token |
-| GET | `/v1/sadas/scorecard` | public track record |
+| GET | `/v1/sadas/scorecard` | public |
 | GET | `/v1/sadas/feed` | gated unless token |
-| POST | `/v1/polyclaw/day` | daily scorecard row |
+| POST | `/v1/polyclaw/day` | admin |
 | GET | `/v1/polyclaw/scorecard` | vault gate |
-| POST | `/v1/quest/seed` | load airdrop wallets |
-| POST | `/v1/quest/claim` | verify agent → ledger credit |
+| GET | `/v1/quest` | merkle stats |
+| POST | `/v1/quest/seed` | admin — load disperse list |
+| GET | `/v1/quest/eligibility?wallet=` | proof + root |
+| POST | `/v1/quest/claim` | verified agent + merkle → ledger credit |
 
 ## Mount
 
-`a2a_bootstrap.register_a2a` calls `mount_kya(app)`. Additive. Does not replace `/v1/a2a/register`.
+`a2a_bootstrap.register_a2a` → `kya_bootstrap.mount_kya_stack` → `kya.blueprint.mount_kya`. Additive. Skips only if `kya_stack` is already registered. **Does not skip** just because Blueprint `kya` exists.
 
 ## Not in this drop
 
 - Live Base writes (receipts are hashed; submit later with a signer)
-- Stripe SKU
-- Vault deposits
+- Stripe SKU (live /health: stripe not_configured)
+- Vault deposits (HOLD)
 - AXM fractional reserve
 - NFT mint

--- a/docs/MACHINE_BUREAUCRACY_2026-09-26.md
+++ b/docs/MACHINE_BUREAUCRACY_2026-09-26.md
@@ -1,0 +1,33 @@
+# Form 01 — Machine Bureaucracy
+
+**File:** KYA-2026-09-26  
+**Drop:** 26 September 2026, 16:00 UTC  
+**Payload:** KYA registry + SLA receipts + sovereign vault routing  
+**Thesis:** The first machine bureaucracy with receipts.
+
+## Form copy
+
+Agents used to promise. Now they file.
+
+On 26 September 2026 SINCOR opens Genesis not as a token event but as a clerking of machines. Forty-two agents. A Know-Your-Agent registry. Five-minute SLA receipts. Vault routing that will not move until a human lifts the halt. This is not a vibe. It is a docket.
+
+Bureaucracy is the insult applied to systems that remember. We are building the version that issues a hash.
+
+KYA is the file. An agent lists, binds a principal, stakes AXM, heartbeats. Verify is not a badge — it is a state machine with a revoke.
+
+SLA is the time clock. Every five minutes a ping becomes an epoch receipt. Miss the window and the record expires. No narrative overlay.
+
+The airdrop is not a gift. ~3,500 wallets already received AXM. The quest asks those wallets to become KYA-verified actors. Tokens given become actions filed.
+
+Treasury HOLD is the standing order: one hundred percent of realized fees to `0x09E289…12Ac`. Zero percent of the $192 USDC into Morpho. The halt file is on. That is the bureaucracy.
+
+File your agent. Claim the quest. Keep the receipt.
+
+## X thread
+
+1. 26 Sep. Genesis is not a launch party. It is the first machine bureaucracy with receipts.
+2. KYA: list → bind → stake → verify. Revoke exists. Heartbeat expires.
+3. SLA receipts every 300s. If the ping dies, the file dies.
+4. 3,500 wallets already hold AXM. The quest converts a drop into a verified action.
+5. Treasury HOLD. 100% of fees to one address. 0% of cash into yield. Halt file on.
+6. getsincor.com — file or watch.

--- a/docs/SECRETS_HYGIENE.md
+++ b/docs/SECRETS_HYGIENE.md
@@ -8,16 +8,28 @@ Grep of current tree for `sk_live_`, `sk_test_`, `AKIA`, `ghp_`, `xai-`, `sk-ant
 
 `.gitleaks.toml` allowlists four historical files. Allowlisting is not rotation.
 
-## Actions (do these on a machine with full history)
+## GitHub secret scanning — ON
 
-1. Turn on GitHub secret scanning + push protection for `OrderofChaos33/SINCOR2`.
-2. `gitleaks detect --source . --log-opts=--all`. Rotate anything that ever sat in a commit, even if later deleted.
-3. Confirm keys that touched the allowlisted files were rotated, not just hidden.
-4. Stripe / PayPal live: `getsincor.com/health` reports both `not_configured`. Set `STRIPE_SECRET_KEY` and PayPal secrets **only** on Railway. Never paste `sk_live` into the repo, a PR, or a chat.
-5. Anthropic is marked configured on live. Confirm the key lives in Railway, never disk.
-6. `CANONICAL_ADDRESSES.md` still lists deployer `0xdba7180cdd90D12B9Bc2F15080ddFD9B14fEf31a` as temporary. Rotate to a multisig before any vault deposit.
-7. `KYA_ADMIN_KEY` gates `POST /v1/quest/seed`, `POST /v1/sadas/publish`, `POST /v1/polyclaw/day`. Header: `X-KYA-Admin`. Fail closed if unset.
-8. `sinc_lbp_salt.json` is a CREATE2 salt, not a key. Fine in-repo. Do not add private keys next to it.
+Four historical alerts, all **resolved as revoked** 2026-06-15:
+
+| # | Type | Path | Publicly leaked |
+|---|---|---|
+| 1 | Google API key | `docs/CLINTON_AUTO_DETAILING_SETUP.md` | yes |
+| 2 | Google API key | `docs/CLINTON_AUTO_DETAILING_SETUP.md` | yes |
+| 3 | Google API key | `code_pkg/start_syndicator.py` | yes |
+| 4 | Twilio Account SID | `buy_watcher.js` | yes |
+
+Push protection recorded no bypasses. Rotate anything that ever sat in those files, even if later deleted. Re-run `gitleaks detect --source . --full-history` on a machine with the full clone.
+
+## Actions still open
+
+1. Confirm keys that touched the allowlisted files were rotated, not just hidden.
+2. Stripe / PayPal live: `getsincor.com/health` reports both `not_configured`. Set `STRIPE_SECRET_KEY` and PayPal secrets **only** on Railway. Never paste `sk_live` into the repo, a PR, or a chat.
+3. Anthropic is marked configured on live. Confirm the key lives in Railway, never disk.
+4. `CANONICAL_ADDRESSES.md` still lists deployer `0xdba7180cdd90D12B9Bc2F15080ddFD9B14fEf31a` as temporary. Rotate to a multisig before any vault deposit.
+5. `KYA_ADMIN_KEY` gates `POST /v1/quest/seed`, `POST /v1/sadas/publish`, `POST /v1/polyclaw/day`. Header: `X-KYA-Admin`. Fail closed if unset. Rotate if it ever touched history or a paste.
+6. `KYA_PRODUCTION_ROOT` is the committed disperse merkle root. Set on Railway after `kya_build_merkle.py`. Never the 48-leaf replica.
+7. `sinc_lbp_salt.json` is a CREATE2 salt, not a key. Fine in-repo. Do not add private keys next to it.
 
 ## Halt
 

--- a/docs/SECRETS_HYGIENE.md
+++ b/docs/SECRETS_HYGIENE.md
@@ -1,0 +1,24 @@
+# Secrets hygiene — 2026-09-10
+
+Public repo. Prior CLI key leak. Two of the last three commits were auth/secret fixes (Railway quote-stripping, admin identity matching). This is the standing order.
+
+## Sweep (this pass)
+
+Grep of current tree for `sk_live_`, `sk_test_`, `AKIA`, `ghp_`, `xai-`, `sk-ant-`, PEM private keys: **no live secrets in tracked files**. The only `sk_test_` hit historically lives in tests (fake). `.env` is gitignored. `.env.example` is names only.
+
+`.gitleaks.toml` allowlists four historical files. Allowlisting is not rotation.
+
+## Actions (do these on a machine with full history)
+
+1. Turn on GitHub secret scanning + push protection for `OrderofChaos33/SINCOR2`.
+2. `gitleaks detect --source . --log-opts=--all`. Rotate anything that ever sat in a commit, even if later deleted.
+3. Confirm keys that touched the allowlisted files were rotated, not just hidden.
+4. Stripe / PayPal live: `getsincor.com/health` reports both `not_configured`. Set `STRIPE_SECRET_KEY` and PayPal secrets **only** on Railway. Never paste `sk_live` into the repo, a PR, or a chat.
+5. Anthropic is marked configured on live. Confirm the key lives in Railway, never disk.
+6. `CANONICAL_ADDRESSES.md` still lists deployer `0xdba7180cdd90D12B9Bc2F15080ddFD9B14fEf31a` as temporary. Rotate to a multisig before any vault deposit.
+7. `KYA_ADMIN_KEY` gates `POST /v1/quest/seed`, `POST /v1/sadas/publish`, `POST /v1/polyclaw/day`. Header: `X-KYA-Admin`. Fail closed if unset.
+8. `sinc_lbp_salt.json` is a CREATE2 salt, not a key. Fine in-repo. Do not add private keys next to it.
+
+## Halt
+
+Do not create a `.env` in this repo or in the App Builder workspace snapshot.

--- a/docs/TREASURY_HOLD.md
+++ b/docs/TREASURY_HOLD.md
@@ -1,0 +1,11 @@
+# Treasury HOLD — numbers, not vibes
+
+Locked 2026-09-10. Code: `src/sincor2/treasury_hold.py`. Destination: `0x09E2891432827D8835d2E9b83B25e2a5ba9612Ac`.
+
+1. **100%** of realized platform fees (projected=false + tx_hash) → Treasury. Platform take is **500 bps**.
+2. **100% HOLD** on ~$192.62 on-chain USDC. **0%** Morpho / Aave / LP / SharedLiquidity.
+3. **100% HOLD** on ~$800 founder cash. **0%** load-to-chain.
+4. Vault intake **0%** until first conversion. After conversion: **80%** cash / **20%** vault, and only if cash ≥ **$10,000 USDC**.
+5. Underwriting go-live: **$10,000 USDC** backing + conversion proof + human `EXECUTE_LIVE`. Founder signer is the only mover. Halt file `data/TREASURY_EXEC_HALT` is ON by default.
+
+Roles: Founder signer broadcasts. Treasury exec queues intents. Auditor gates. Nobody else moves funds.

--- a/scripts/kya_build_merkle.py
+++ b/scripts/kya_build_merkle.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Build the production KYA airdrop merkle tree from a wallet list.
+
+    python scripts/kya_build_merkle.py --from-file recipients.txt
+    python scripts/kya_build_merkle.py --from-file recipients.json --source axm-disperse-2026
+
+Accepts JSON array, JSON {addresses|wallets}, or any text blob containing 0x addresses.
+Writes data/kya/airdrop_merkle.json (root + addresses). Never invents a root.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from sincor2.kya.merkle import MerkleTree, parse_addresses  # noqa: E402
+
+
+def load_addresses(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+        if isinstance(data, list):
+            return [str(x) for x in data]
+        if isinstance(data, dict):
+            return [str(x) for x in (data.get("addresses") or data.get("wallets") or [])]
+    except json.JSONDecodeError:
+        pass
+    return parse_addresses(text)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--from-file", required=True)
+    p.add_argument("--source", default="disperse-recipients")
+    p.add_argument("--out", default=str(ROOT / "data" / "kya" / "airdrop_merkle.json"))
+    args = p.parse_args()
+    wallets = load_addresses(Path(args.from_file))
+    if not wallets:
+        print("no addresses found", file=sys.stderr)
+        return 2
+    tree = MerkleTree(wallets)
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        **tree.manifest(),
+        "source": args.source,
+        "token": "0x4c3fb66f14fbaa2088c9ae91017ba770da53715a",
+        "addresses": tree.addresses,
+    }
+    out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {out} count={tree.manifest()['count']} root={tree.hex_root()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sincor2/kya/__init__.py
+++ b/src/sincor2/kya/__init__.py
@@ -1,13 +1,14 @@
-"""KYA stack: identity, SLA receipts, SADAS feed, Polyclaw scorecard, airdrop quest.
+"""KYA stack: identity, SLA receipts, SADAS feed, Polyclaw receipts, airdrop quest.
 
 Mount with: from sincor2.kya.blueprint import mount_kya; mount_kya(app)
 """
 
-from sincor2.kya.registry import KYARegistry, get_registry
+from sincor2.kya.registry import KYARegistry, get_registry, record_hash
 from sincor2.kya.sla import SLAMonitor, get_sla
 from sincor2.kya.sadas import SADASFeed, get_sadas
 from sincor2.kya.receipts import ReceiptBook, get_receipts
 from sincor2.kya.airdrop_quest import AirdropQuest, get_quest
+from sincor2.kya.merkle import MerkleTree, verify_proof
 from sincor2.kya.pricing import PRICE_BOOK
 
 __all__ = [
@@ -16,6 +17,9 @@ __all__ = [
     "SADASFeed",
     "ReceiptBook",
     "AirdropQuest",
+    "MerkleTree",
+    "verify_proof",
+    "record_hash",
     "get_registry",
     "get_sla",
     "get_sadas",

--- a/src/sincor2/kya/airdrop_quest.py
+++ b/src/sincor2/kya/airdrop_quest.py
@@ -8,6 +8,9 @@ module is a test/fallback only.
 
 Production root lives in data/kya/airdrop_merkle.json (gitignored /data/).
 Seed the leaves with `python scripts/kya_build_merkle.py --from-file path`.
+
+Verify binds to KYA_PRODUCTION_ROOT (if set) by address. Replica sources
+are refused — a 48-leaf desk tree must never be the drop root.
 """
 from __future__ import annotations
 
@@ -24,6 +27,7 @@ from sincor2.kya.store import JsonStore
 
 AXM = "0x4c3fb66f14fbaa2088c9ae91017ba770da53715a"
 CHAIN_ID = 8453
+REPLICA_SOURCES = {"replica", "desk-replica", "stub", "desk"}
 
 
 def _now() -> int:
@@ -77,6 +81,10 @@ def _bound_wallet(rec: Dict[str, Any]) -> str:
     ).lower()
 
 
+def _committed_root() -> str:
+    return os.environ.get("KYA_PRODUCTION_ROOT", "").strip().lower()
+
+
 class AirdropQuest:
     def __init__(self) -> None:
         self.store = JsonStore("airdrop_quest")
@@ -116,8 +124,27 @@ class AirdropQuest:
         self.count = int(data.get("count") or self.count)
         self.source = str(data.get("source") or self.source)
 
+    def _is_replica(self) -> bool:
+        src = (self.source or "").lower()
+        return "replica" in src or src in REPLICA_SOURCES
+
+    def _assert_production_root(self) -> None:
+        if self._is_replica():
+            raise PermissionError("REPLICA_ROOT_FORBIDDEN")
+        bound = _committed_root()
+        if bound:
+            got = (self.root or "").lower()
+            if got != bound:
+                raise PermissionError("ROOT_MISMATCH")
+
     def seed(self, wallets: List[str], source: str = "seed", persist_manifest: bool = True) -> int:
+        src_l = (source or "").lower()
+        if ("replica" in src_l or src_l in REPLICA_SOURCES) and _committed_root():
+            raise PermissionError("REPLICA_ROOT_FORBIDDEN")
         tree = MerkleTree(wallets)
+        bound = _committed_root()
+        if bound and tree.hex_root().lower() != bound:
+            raise PermissionError("ROOT_MISMATCH")
         with self.lock:
             self.tree = tree
             self.root = tree.hex_root()
@@ -143,22 +170,25 @@ class AirdropQuest:
 
     def eligibility(self, wallet: str, proof: Optional[Sequence[str]] = None) -> Dict[str, Any]:
         wallet = (wallet or "").strip().lower()
+        bound = _committed_root()
         tree = self.tree
+        root = bound or (tree.hex_root() if tree is not None else self.root)
         if tree is None:
-            if proof and self.root:
-                ok = verify_proof(wallet, proof, self.root)
-                return {"wallet": wallet, "eligible": ok, "root": self.root, "count": self.count}
-            return {"wallet": wallet, "eligible": False, "reason": "tree unloaded", "root": self.root}
+            if proof and root:
+                ok = verify_proof(wallet, proof, root)
+                return {"wallet": wallet, "eligible": ok, "root": root, "count": self.count, "bound": bool(bound)}
+            return {"wallet": wallet, "eligible": False, "reason": "tree unloaded", "root": root}
         p = list(proof) if proof is not None else tree.proof(wallet)
         if p is None:
-            return {"wallet": wallet, "eligible": False, "root": tree.hex_root(), "count": self.count}
-        ok = verify_proof(wallet, p, tree.hex_root())
+            return {"wallet": wallet, "eligible": False, "root": root, "count": self.count, "bound": bool(bound)}
+        ok = verify_proof(wallet, p, root)
         return {
             "wallet": wallet,
             "eligible": ok,
             "proof": p,
-            "root": tree.hex_root(),
+            "root": root,
             "count": self.count,
+            "bound": bool(bound),
         }
 
     def claim(
@@ -177,6 +207,8 @@ class AirdropQuest:
         if bound and bound != wallet:
             raise PermissionError("wallet does not match KYA record")
 
+        self._assert_production_root()
+
         elig = self.eligibility(wallet, proof)
         if not elig.get("eligible"):
             raise PermissionError("wallet not in merkle list")
@@ -192,7 +224,7 @@ class AirdropQuest:
                 "reward_axm": PRICE_BOOK["quest_reward_axm"],
                 "status": "credited_ledger",
                 "note": "treasury must settle; this is not an auto-transfer",
-                "root": self.root,
+                "root": elig.get("root") or self.root,
                 "proof": elig.get("proof") or list(proof or []),
                 "ts": _now(),
                 "chain_id": CHAIN_ID,
@@ -215,6 +247,8 @@ class AirdropQuest:
                 "loaded": self.tree is not None,
                 "token": AXM,
                 "chain_id": CHAIN_ID,
+                "replica": self._is_replica(),
+                "bound_root": _committed_root() or None,
             }
 
 

--- a/src/sincor2/kya/airdrop_quest.py
+++ b/src/sincor2/kya/airdrop_quest.py
@@ -1,21 +1,80 @@
-"""Turn airdrop wallets into KYA listings.
+"""KYA airdrop quest — merkle verification against the real drop list.
 
-Quest: verify your agent → credit AXM quest reward (ledger, not auto-transfer).
+Quest: prove you are on the AXM disperse merkle list, then verify KYA,
+then credit a ledger reward (not an auto-transfer).
+
+Identity comes from sincor2.kya_registry (live /v1/kya). The kya.registry
+module is a test/fallback only.
+
+Production root lives in data/kya/airdrop_merkle.json (gitignored /data/).
+Seed the leaves with `python scripts/kya_build_merkle.py --from-file path`.
 """
-
 from __future__ import annotations
 
+import json
+import os
 import threading
 import time
-from typing import Any, Dict, List, Optional, Set
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
 
+from sincor2.kya.merkle import MerkleTree, verify_proof
 from sincor2.kya.pricing import PRICE_BOOK
-from sincor2.kya.registry import get_registry
 from sincor2.kya.store import JsonStore
+
+AXM = "0x4c3fb66f14fbaa2088c9ae91017ba770da53715a"
+CHAIN_ID = 8453
 
 
 def _now() -> int:
     return int(time.time())
+
+
+def _manifest_path() -> Path:
+    override = os.environ.get("KYA_AIRDROP_MANIFEST", "").strip()
+    if override:
+        return Path(override)
+    try:
+        from sincor2.data_paths import data_dir
+
+        return data_dir() / "kya" / "airdrop_merkle.json"
+    except Exception:
+        return Path(__file__).resolve().parents[3] / "data" / "kya" / "airdrop_merkle.json"
+
+
+def _identity(agent_id: str) -> Optional[Dict[str, Any]]:
+    try:
+        from sincor2.kya_registry import get_by_agent
+
+        rec = get_by_agent(agent_id)
+        if rec:
+            return dict(rec)
+    except Exception:
+        pass
+    try:
+        from sincor2.kya.registry import get_registry
+
+        return get_registry().lookup(agent_id=agent_id)
+    except Exception:
+        return None
+
+
+def _is_verified(rec: Dict[str, Any]) -> bool:
+    if rec.get("revoked"):
+        return False
+    if rec.get("verified") is True:
+        return True
+    return rec.get("status") == "verified"
+
+
+def _bound_wallet(rec: Dict[str, Any]) -> str:
+    return (
+        rec.get("airdrop_wallet")
+        or rec.get("agent_wallet")
+        or rec.get("wallet")
+        or rec.get("principal")
+        or ""
+    ).lower()
 
 
 class AirdropQuest:
@@ -23,57 +82,139 @@ class AirdropQuest:
         self.store = JsonStore("airdrop_quest")
         raw = self.store.load() or {}
         self.lock = threading.Lock()
-        self.wallets: Set[str] = {w.lower() for w in (raw.get("wallets") or [])}
         self.claims: Dict[str, Dict[str, Any]] = raw.get("claims") or {}
+        self.tree: Optional[MerkleTree] = None
+        self.root: str = str(raw.get("root") or "")
+        self.count: int = int(raw.get("count") or 0)
+        self.source: str = str(raw.get("source") or "unloaded")
+        self._load_manifest()
 
     def _persist(self) -> None:
-        self.store.save({"wallets": sorted(self.wallets), "claims": self.claims, "saved_at": _now()})
+        self.store.save(
+            {
+                "claims": self.claims,
+                "root": self.root,
+                "count": self.count,
+                "source": self.source,
+                "saved_at": _now(),
+            }
+        )
 
-    def seed(self, wallets: List[str]) -> int:
+    def _load_manifest(self) -> None:
+        path = _manifest_path()
+        if not path.is_file():
+            return
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return
+        addresses = data.get("addresses") or data.get("wallets") or []
+        if addresses:
+            self.seed(addresses, source=str(data.get("source") or path.name), persist_manifest=False)
+            return
+        self.root = str(data.get("root") or self.root)
+        self.count = int(data.get("count") or self.count)
+        self.source = str(data.get("source") or self.source)
+
+    def seed(self, wallets: List[str], source: str = "seed", persist_manifest: bool = True) -> int:
+        tree = MerkleTree(wallets)
         with self.lock:
-            before = len(self.wallets)
-            for w in wallets:
-                w = (w or "").strip().lower()
-                if w.startswith("0x") and len(w) == 42:
-                    self.wallets.add(w)
+            self.tree = tree
+            self.root = tree.hex_root()
+            self.count = tree.manifest()["count"]
+            self.source = source
             self._persist()
-            return len(self.wallets) - before
+        if persist_manifest:
+            path = _manifest_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        **tree.manifest(),
+                        "source": source,
+                        "token": AXM,
+                        "addresses": tree.addresses,
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+        return tree.manifest()["count"]
 
-    def claim(self, wallet: str, agent_id: str) -> Dict[str, Any]:
+    def eligibility(self, wallet: str, proof: Optional[Sequence[str]] = None) -> Dict[str, Any]:
         wallet = (wallet or "").strip().lower()
-        rec = get_registry().lookup(agent_id=agent_id)
+        tree = self.tree
+        if tree is None:
+            if proof and self.root:
+                ok = verify_proof(wallet, proof, self.root)
+                return {"wallet": wallet, "eligible": ok, "root": self.root, "count": self.count}
+            return {"wallet": wallet, "eligible": False, "reason": "tree unloaded", "root": self.root}
+        p = list(proof) if proof is not None else tree.proof(wallet)
+        if p is None:
+            return {"wallet": wallet, "eligible": False, "root": tree.hex_root(), "count": self.count}
+        ok = verify_proof(wallet, p, tree.hex_root())
+        return {
+            "wallet": wallet,
+            "eligible": ok,
+            "proof": p,
+            "root": tree.hex_root(),
+            "count": self.count,
+        }
+
+    def claim(
+        self,
+        wallet: str,
+        agent_id: str,
+        proof: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        wallet = (wallet or "").strip().lower()
+        rec = _identity(agent_id)
         if not rec:
             raise KeyError("agent not listed")
-        if not rec.get("verified"):
+        if not _is_verified(rec):
             raise PermissionError("verify KYA first")
-        bound = (rec.get("airdrop_wallet") or rec.get("wallet") or "").lower()
+        bound = _bound_wallet(rec)
         if bound and bound != wallet:
             raise PermissionError("wallet does not match KYA record")
+
+        elig = self.eligibility(wallet, proof)
+        if not elig.get("eligible"):
+            raise PermissionError("wallet not in merkle list")
+
         with self.lock:
-            if wallet not in self.wallets:
-                raise PermissionError("wallet not in airdrop set")
-            if wallet in self.claims:
-                return dict(self.claims[wallet])
+            key = f"{wallet}:{self.root}"
+            if key in self.claims:
+                return dict(self.claims[key])
             row = {
                 "wallet": wallet,
                 "agent_id": agent_id,
-                "kya_id": rec["kya_id"],
+                "kya_id": rec.get("kya_id"),
                 "reward_axm": PRICE_BOOK["quest_reward_axm"],
                 "status": "credited_ledger",
                 "note": "treasury must settle; this is not an auto-transfer",
+                "root": self.root,
+                "proof": elig.get("proof") or list(proof or []),
                 "ts": _now(),
+                "chain_id": CHAIN_ID,
+                "token": AXM,
             }
-            self.claims[wallet] = row
+            self.claims[key] = row
             self._persist()
             return dict(row)
 
     def stats(self) -> Dict[str, Any]:
         with self.lock:
+            claimed = len(self.claims)
             return {
-                "eligible": len(self.wallets),
-                "claimed": len(self.claims),
-                "unclaimed": max(0, len(self.wallets) - len(self.claims)),
+                "eligible": self.count,
+                "claimed": claimed,
+                "unclaimed": max(0, self.count - claimed),
                 "reward_axm": PRICE_BOOK["quest_reward_axm"],
+                "root": self.root,
+                "source": self.source,
+                "loaded": self.tree is not None,
+                "token": AXM,
+                "chain_id": CHAIN_ID,
             }
 
 

--- a/src/sincor2/kya/blueprint.py
+++ b/src/sincor2/kya/blueprint.py
@@ -1,0 +1,163 @@
+"""Additive Flask mount: merkle quest, SLA receipts, SADAS, Polyclaw.
+
+Does not replace Blueprint('kya') at /v1/kya (see kya_blueprint.py).
+Colliding /v1/kya/list|bind|verify|lookup|health|heartbeat routes are
+intentionally omitted so the live identity registry stays the source of truth.
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+
+from flask import Blueprint, jsonify, request
+
+from sincor2.kya.airdrop_quest import get_quest
+from sincor2.kya.pricing import PRICE_BOOK
+from sincor2.kya.receipts import get_receipts
+from sincor2.kya.sadas import get_sadas
+from sincor2.kya.sla import get_sla
+from sincor2.treasury_hold import standing_order
+
+logger = logging.getLogger("sincor.kya")
+
+kya_stack_bp = Blueprint("kya_stack", __name__)
+
+
+def _err(msg: str, status: int = 400):
+    return jsonify({"error": msg, "status": status}), status
+
+
+def _admin_ok() -> bool:
+    expected = (os.environ.get("KYA_ADMIN_KEY") or "").strip()
+    if not expected:
+        return False
+    provided = (
+        request.headers.get("X-KYA-Admin")
+        or request.headers.get("X-Admin-Key")
+        or ""
+    ).strip()
+    if not provided:
+        return False
+    return hmac.compare_digest(provided.encode("utf-8"), expected.encode("utf-8"))
+
+
+def mount_kya(app) -> bool:
+    names = getattr(app, "blueprints", {}) or {}
+    if "kya_stack" in names:
+        return True
+    app.register_blueprint(kya_stack_bp)
+    logger.info("KYA additive stack mounted (quest, SLA receipts, SADAS)")
+    return True
+
+
+@kya_stack_bp.get("/v1/kya/stack")
+def stack_health():
+    return jsonify(
+        {
+            "ok": True,
+            "prices": PRICE_BOOK,
+            "quest": get_quest().stats(),
+            "hold": standing_order(),
+            "sadas": get_sadas().scorecard(),
+        }
+    )
+
+
+@kya_stack_bp.post("/v1/sla/subscribe")
+def sla_sub():
+    body = request.get_json(silent=True) or {}
+    return jsonify(get_sla().subscribe(str(body.get("kya_id") or "")))
+
+
+@kya_stack_bp.post("/v1/sla/ping")
+def sla_ping():
+    body = request.get_json(silent=True) or {}
+    return jsonify(
+        get_sla().ping(
+            str(body.get("kya_id") or ""),
+            ok=bool(body.get("ok", True)),
+            latency_ms=int(body.get("latency_ms") or 0),
+        )
+    )
+
+
+@kya_stack_bp.get("/v1/sla/receipts")
+def sla_receipts():
+    return jsonify({"receipts": get_sla().list_receipts(request.args.get("kya_id"))})
+
+
+@kya_stack_bp.post("/v1/sadas/publish")
+def sadas_pub():
+    if not _admin_ok():
+        return _err("admin key required", 401)
+    body = request.get_json(silent=True) or {}
+    return jsonify(get_sadas().publish(body))
+
+
+@kya_stack_bp.post("/v1/sadas/subscribe")
+def sadas_sub():
+    body = request.get_json(silent=True) or {}
+    return jsonify(get_sadas().subscribe(str(body.get("kya_id") or ""), str(body.get("token") or "")))
+
+
+@kya_stack_bp.get("/v1/sadas/scorecard")
+def sadas_card():
+    return jsonify(get_sadas().scorecard())
+
+
+@kya_stack_bp.get("/v1/sadas/feed")
+def sadas_feed():
+    return jsonify(get_sadas().feed(request.args.get("token")))
+
+
+@kya_stack_bp.post("/v1/polyclaw/day")
+def poly_day():
+    if not _admin_ok():
+        return _err("admin key required", 401)
+    body = request.get_json(silent=True) or {}
+    return jsonify(get_receipts().record_day(body))
+
+
+@kya_stack_bp.get("/v1/polyclaw/scorecard")
+def poly_card():
+    return jsonify(get_receipts().scorecard())
+
+
+@kya_stack_bp.get("/v1/quest")
+def quest_stats():
+    return jsonify(get_quest().stats())
+
+
+@kya_stack_bp.post("/v1/quest/seed")
+def quest_seed():
+    if not _admin_ok():
+        return _err("set KYA_ADMIN_KEY and send X-KYA-Admin to load the merkle list", 401)
+    body = request.get_json(silent=True) or {}
+    wallets = body.get("wallets") or body.get("addresses") or []
+    if not isinstance(wallets, list):
+        return _err("wallets[] required")
+    n = get_quest().seed([str(w) for w in wallets], source=str(body.get("source") or "api"))
+    return jsonify({"loaded": n, **get_quest().stats()})
+
+
+@kya_stack_bp.get("/v1/quest/eligibility")
+def quest_elig():
+    wallet = str(request.args.get("wallet") or "")
+    return jsonify(get_quest().eligibility(wallet))
+
+
+@kya_stack_bp.post("/v1/quest/claim")
+def quest_claim():
+    body = request.get_json(silent=True) or {}
+    try:
+        rec = get_quest().claim(
+            wallet=str(body.get("wallet") or ""),
+            agent_id=str(body.get("agent_id") or ""),
+            proof=body.get("proof"),
+        )
+        return jsonify(rec)
+    except KeyError:
+        return _err("agent not listed", 404)
+    except PermissionError as exc:
+        return _err(str(exc), 403)

--- a/src/sincor2/kya/merkle.py
+++ b/src/sincor2/kya/merkle.py
@@ -1,0 +1,125 @@
+"""OpenZeppelin-compatible keccak256 sorted-pair Merkle tree.
+
+Leaf encoding (locked): keccak256(address20) where address20 is the 20-byte
+checksum-stripped lowercase address. Pairing: keccak256(min||max) of two
+32-byte nodes. Empty tree root is keccak256(b"").
+
+This is the on-chain verification the airdrop quest uses. Do not fall back to
+an unsorted wallet set in production.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Optional, Sequence
+
+ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+EMPTY_KECCAK = bytes.fromhex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+
+
+def _keccak(data: bytes) -> bytes:
+    try:
+        from eth_hash.auto import keccak
+
+        return keccak(data)
+    except Exception:
+        try:
+            from sha3 import keccak_256  # type: ignore
+
+            return keccak_256(data).digest()
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError("keccak256 requires eth-hash or pysha3") from exc
+
+
+def is_address(value: str) -> bool:
+    return bool(value) and bool(ADDRESS_RE.match(value.strip()))
+
+
+def normalize_address(value: str) -> str:
+    return value.strip().lower()
+
+
+def leaf_of(address: str) -> bytes:
+    addr = normalize_address(address)
+    if not is_address(addr):
+        raise ValueError("bad address")
+    return _keccak(bytes.fromhex(addr[2:]))
+
+
+def _hash_pair(a: bytes, b: bytes) -> bytes:
+    left, right = (a, b) if a <= b else (b, a)
+    return _keccak(left + right)
+
+
+def unique_sorted(addresses: Iterable[str]) -> List[str]:
+    seen = {normalize_address(a) for a in addresses if is_address(a)}
+    return sorted(seen)
+
+
+class MerkleTree:
+    def __init__(self, addresses: Sequence[str]) -> None:
+        self.addresses = unique_sorted(addresses)
+        self.leaves = [leaf_of(a) for a in self.addresses]
+        self.root = self._fold(self.leaves) if self.leaves else EMPTY_KECCAK
+
+    @staticmethod
+    def _fold(layer: Sequence[bytes]) -> bytes:
+        nodes = list(layer)
+        while len(nodes) > 1:
+            nxt: List[bytes] = []
+            for i in range(0, len(nodes), 2):
+                if i + 1 >= len(nodes):
+                    nxt.append(nodes[i])
+                else:
+                    nxt.append(_hash_pair(nodes[i], nodes[i + 1]))
+            nodes = nxt
+        return nodes[0]
+
+    def proof(self, address: str) -> Optional[List[str]]:
+        addr = normalize_address(address)
+        try:
+            index = self.addresses.index(addr)
+        except ValueError:
+            return None
+        layer = list(self.leaves)
+        out: List[str] = []
+        while len(layer) > 1:
+            sibling = index ^ 1
+            if sibling < len(layer):
+                out.append("0x" + layer[sibling].hex())
+            nxt: List[bytes] = []
+            for i in range(0, len(layer), 2):
+                if i + 1 >= len(layer):
+                    nxt.append(layer[i])
+                else:
+                    nxt.append(_hash_pair(layer[i], layer[i + 1]))
+            layer = nxt
+            index //= 2
+        return out
+
+    def hex_root(self) -> str:
+        return "0x" + self.root.hex()
+
+    def manifest(self) -> dict:
+        return {
+            "encoding": "keccak256(address20)",
+            "pair": "sorted-keccak",
+            "root": self.hex_root(),
+            "count": len(self.addresses),
+            "chain_id": 8453,
+        }
+
+
+def verify_proof(address: str, proof: Sequence[str], root: str) -> bool:
+    try:
+        node = leaf_of(address)
+        for item in proof:
+            sib = bytes.fromhex(item[2:] if item.startswith("0x") else item)
+            node = _hash_pair(node, sib)
+        want = root[2:] if root.startswith("0x") else root
+        return node.hex() == want.lower()
+    except Exception:
+        return False
+
+
+def parse_addresses(raw: str) -> List[str]:
+    return unique_sorted(re.findall(r"0x[0-9a-fA-F]{40}", raw or ""))

--- a/src/sincor2/kya/registry.py
+++ b/src/sincor2/kya/registry.py
@@ -1,0 +1,166 @@
+"""KYA registry for the kya/ package (quest, SLA, SADAS).
+
+Does not replace sincor2.kya_registry (inbound hooks). Both may run.
+Identity is the product: listed -> bound -> staked -> verified | revoked | expired.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+from typing import Any, Dict, Optional
+
+from sincor2.kya.store import JsonStore
+
+MIN_STAKE_WEI = 10 * 10**18
+VERIFY_FEE_WEI = 2 * 10**18
+AXM = "0x4c3fb66f14fbaa2088c9ae91017ba770da53715a"
+CHAIN_ID = 8453
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def record_hash(obj: Any) -> str:
+    blob = json.dumps(obj, separators=(",", ":"), sort_keys=True, default=str)
+    return "0x" + hashlib.sha256(blob.encode()).hexdigest()
+
+
+class KYARegistry:
+    def __init__(self) -> None:
+        self.store = JsonStore("registry")
+        raw = self.store.load() or {}
+        self.lock = threading.Lock()
+        self.records: Dict[str, Dict[str, Any]] = raw.get("records") or {}
+        self.by_agent: Dict[str, str] = raw.get("by_agent") or {}
+
+    def _persist(self) -> None:
+        self.store.save({"records": self.records, "by_agent": self.by_agent, "saved_at": _now()})
+
+    def lookup(
+        self,
+        agent_id: Optional[str] = None,
+        wallet: Optional[str] = None,
+        kya_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        with self.lock:
+            if kya_id and kya_id in self.records:
+                return dict(self.records[kya_id])
+            if agent_id:
+                kid = self.by_agent.get(agent_id)
+                if kid and kid in self.records:
+                    return dict(self.records[kid])
+            if wallet:
+                w = wallet.lower()
+                for rec in self.records.values():
+                    if (rec.get("wallet") or rec.get("principal") or "").lower() == w:
+                        return dict(rec)
+        return None
+
+    def list_agent(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        agent_id = str(body.get("agent_id") or "").strip()
+        if not agent_id:
+            raise ValueError("agent_id required")
+        wallet = str(body.get("wallet") or body.get("principal") or "").strip().lower()
+        rec = {
+            "kya_id": "kya_" + hashlib.sha256(agent_id.encode()).hexdigest()[:16],
+            "agent_id": agent_id,
+            "wallet": wallet,
+            "principal": wallet,
+            "airdrop_wallet": wallet,
+            "status": "listed",
+            "verified": False,
+            "stake_axm_wei": "0",
+            "heartbeat_ts": 0,
+            "created_at": _now(),
+            "updated_at": _now(),
+            "chain_id": CHAIN_ID,
+        }
+        rec["record_hash"] = record_hash(rec)
+        with self.lock:
+            self.records[rec["kya_id"]] = rec
+            self.by_agent[agent_id] = rec["kya_id"]
+            self._persist()
+        return dict(rec)
+
+    def bind(self, agent_id: str, principal: str) -> Dict[str, Any]:
+        rec = self.lookup(agent_id=agent_id)
+        if not rec:
+            raise KeyError("agent not listed")
+        rec["principal"] = principal.lower()
+        rec["wallet"] = rec["wallet"] or principal.lower()
+        rec["status"] = "bound"
+        rec["updated_at"] = _now()
+        rec["record_hash"] = record_hash(rec)
+        with self.lock:
+            self.records[rec["kya_id"]] = rec
+            self._persist()
+        return dict(rec)
+
+    def apply_stake(self, kya_id: str, wei: str, tx: str) -> Dict[str, Any]:
+        rec = self.lookup(kya_id=kya_id)
+        if not rec:
+            raise KeyError("unknown kya")
+        rec["stake_axm_wei"] = str(int(wei))
+        rec["stake_tx"] = tx
+        rec["status"] = "staked" if int(wei) >= MIN_STAKE_WEI else rec.get("status")
+        rec["updated_at"] = _now()
+        rec["record_hash"] = record_hash(rec)
+        with self.lock:
+            self.records[kya_id] = rec
+            self._persist()
+        return dict(rec)
+
+    def heartbeat(self, agent_id: str, ok: bool = True) -> Optional[Dict[str, Any]]:
+        rec = self.lookup(agent_id=agent_id)
+        if not rec:
+            return None
+        rec["heartbeat_ts"] = _now()
+        rec["heartbeat_ok"] = bool(ok)
+        rec["updated_at"] = _now()
+        with self.lock:
+            self.records[rec["kya_id"]] = rec
+            self._persist()
+        return dict(rec)
+
+    def verify(self, kya_id: str) -> Dict[str, Any]:
+        rec = self.lookup(kya_id=kya_id)
+        if not rec:
+            raise KeyError("unknown kya")
+        if rec.get("status") not in ("bound", "staked", "verified"):
+            raise PermissionError("bind first")
+        if int(rec.get("stake_axm_wei") or 0) < MIN_STAKE_WEI:
+            raise PermissionError("stake below minimum")
+        rec["verified"] = True
+        rec["status"] = "verified"
+        rec["updated_at"] = _now()
+        rec["record_hash"] = record_hash(rec)
+        with self.lock:
+            self.records[kya_id] = rec
+            self._persist()
+        return dict(rec)
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self.lock:
+            recs = list(self.records.values())
+        return {
+            "token": AXM,
+            "chain_id": CHAIN_ID,
+            "listed": len(recs),
+            "verified": sum(1 for r in recs if r.get("verified")),
+        }
+
+
+_REG: Optional[KYARegistry] = None
+_LOCK = threading.Lock()
+
+
+def get_registry() -> KYARegistry:
+    global _REG
+    if _REG is None:
+        with _LOCK:
+            if _REG is None:
+                _REG = KYARegistry()
+    return _REG

--- a/src/sincor2/kya/sadas.py
+++ b/src/sincor2/kya/sadas.py
@@ -1,0 +1,68 @@
+"""SADAS feed — paid scorecard, gated unless subscribed."""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from sincor2.kya.store import JsonStore
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+class SADASFeed:
+    def __init__(self) -> None:
+        self.store = JsonStore("sadas")
+        raw = self.store.load() or {}
+        self.lock = threading.Lock()
+        self.items: List[Dict[str, Any]] = raw.get("items") or []
+        self.subs: Dict[str, Dict[str, Any]] = raw.get("subs") or {}
+
+    def _persist(self) -> None:
+        self.store.save({"items": self.items[-400:], "subs": self.subs, "saved_at": _now()})
+
+    def publish(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        row = {
+            "title": str(body.get("title") or "")[:160],
+            "signal": str(body.get("signal") or "")[:800],
+            "score": float(body.get("score") or 0),
+            "ts": _now(),
+        }
+        with self.lock:
+            self.items.append(row)
+            self._persist()
+        return dict(row)
+
+    def subscribe(self, kya_id: str, token: str) -> Dict[str, Any]:
+        row = {"kya_id": kya_id, "token": token, "ts": _now()}
+        with self.lock:
+            self.subs[kya_id] = row
+            self._persist()
+        return dict(row)
+
+    def feed(self, token: Optional[str] = None) -> Dict[str, Any]:
+        with self.lock:
+            gated = not token or not any(s.get("token") == token for s in self.subs.values())
+            items = list(self.items[-50:]) if not gated else []
+        return {"gated": gated, "items": items, "count": 0 if gated else len(items)}
+
+    def scorecard(self) -> Dict[str, Any]:
+        with self.lock:
+            n = len(self.items)
+            subs = len(self.subs)
+        return {"signals": n, "subscribers": subs}
+
+
+_F: Optional[SADASFeed] = None
+_LOCK = threading.Lock()
+
+
+def get_sadas() -> SADASFeed:
+    global _F
+    if _F is None:
+        with _LOCK:
+            if _F is None:
+                _F = SADASFeed()
+    return _F

--- a/src/sincor2/kya/sla.py
+++ b/src/sincor2/kya/sla.py
@@ -1,0 +1,83 @@
+"""5-minute SLA pings bound to a kya_id. Receipts, not theater."""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from sincor2.kya.pricing import PRICE_BOOK
+from sincor2.kya.registry import record_hash
+from sincor2.kya.store import JsonStore
+
+INTERVAL_S = int(PRICE_BOOK["sla_epoch"]["interval_s"])
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+class SLAMonitor:
+    def __init__(self) -> None:
+        self.store = JsonStore("sla")
+        raw = self.store.load() or {}
+        self.lock = threading.Lock()
+        self.subs: Dict[str, Dict[str, Any]] = raw.get("subs") or {}
+        self.receipts: List[Dict[str, Any]] = raw.get("receipts") or []
+
+    def _persist(self) -> None:
+        self.store.save({"subs": self.subs, "receipts": self.receipts[-800:], "saved_at": _now()})
+
+    def subscribe(self, kya_id: str) -> Dict[str, Any]:
+        row = {"kya_id": kya_id, "interval_s": INTERVAL_S, "ok": 0, "miss": 0, "last_ts": 0}
+        with self.lock:
+            self.subs[kya_id] = row
+            self._persist()
+        return dict(row)
+
+    def ping(self, kya_id: str, ok: bool = True, latency_ms: int = 0) -> Dict[str, Any]:
+        with self.lock:
+            sub = self.subs.get(kya_id)
+            if sub is None:
+                sub = {"kya_id": kya_id, "interval_s": INTERVAL_S, "ok": 0, "miss": 0, "last_ts": 0}
+                self.subs[kya_id] = sub
+            now = _now()
+            last = int(sub.get("last_ts") or 0)
+            if last and now - last > INTERVAL_S * 2:
+                sub["miss"] = int(sub.get("miss") or 0) + 1
+            if ok:
+                sub["ok"] = int(sub.get("ok") or 0) + 1
+            else:
+                sub["miss"] = int(sub.get("miss") or 0) + 1
+            sub["last_ts"] = now
+            sub["latency_ms"] = latency_ms
+            receipt = {
+                "kya_id": kya_id,
+                "ok": bool(ok),
+                "latency_ms": latency_ms,
+                "ts": now,
+                "epoch": now // INTERVAL_S,
+            }
+            receipt["attestation_hash"] = record_hash(receipt)
+            self.receipts.append(receipt)
+            self._persist()
+            return dict(receipt)
+
+    def list_receipts(self, kya_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        with self.lock:
+            rows = list(self.receipts)
+        if kya_id:
+            rows = [r for r in rows if r.get("kya_id") == kya_id]
+        return rows[-200:]
+
+
+_S: Optional[SLAMonitor] = None
+_LOCK = threading.Lock()
+
+
+def get_sla() -> SLAMonitor:
+    global _S
+    if _S is None:
+        with _LOCK:
+            if _S is None:
+                _S = SLAMonitor()
+    return _S

--- a/src/sincor2/kya_blueprint.py
+++ b/src/sincor2/kya_blueprint.py
@@ -21,6 +21,12 @@ def health():
     return jsonify({"ok": True, **kya.snapshot()})
 
 
+@kya_bp.get("/directory")
+def directory():
+    """Static path must sit above /<kya_id> or Flask treats 'directory' as an id."""
+    return jsonify(kya.snapshot())
+
+
 @kya_bp.post("/list")
 def list_agent():
     body = request.get_json(silent=True) or {}

--- a/src/sincor2/kya_bootstrap.py
+++ b/src/sincor2/kya_bootstrap.py
@@ -1,4 +1,10 @@
-"""Idempotent KYA mount used by a2a_bootstrap.register_a2a."""
+"""Idempotent KYA mount used by a2a_bootstrap.register_a2a.
+
+The inbound fabric already registers Blueprint('kya') at /v1/kya.
+This mount is additive: merkle quest, SLA receipts, SADAS, Polyclaw.
+It must NOT skip just because 'kya' exists — that was the hole that
+left /v1/quest as 404 on live.
+"""
 
 from __future__ import annotations
 
@@ -9,12 +15,12 @@ logger = logging.getLogger("sincor.kya.bootstrap")
 
 def mount_kya_stack(app) -> bool:
     try:
-        names = getattr(app, "blueprints", {}) or {}
-        if "kya" in names:
-            return True
         from sincor2.kya.blueprint import mount_kya
 
-        return bool(mount_kya(app))
+        ok = bool(mount_kya(app))
+        if ok:
+            logger.info("KYA additive stack mounted (quest/SLA/SADAS)")
+        return ok
     except Exception as err:
-        logger.warning("KYA stack mount skipped: %s", err)
+        logger.warning("KYA additive stack skipped: %s", err)
         return False

--- a/src/sincor2/treasury_hold.py
+++ b/src/sincor2/treasury_hold.py
@@ -1,0 +1,56 @@
+"""Treasury HOLD rules as numbers, not vibes.
+
+Locked 2026-09-10. Import these constants. Do not guess at 2am.
+"""
+from __future__ import annotations
+
+from sincor2.onchain.constants import TREASURY as TREASURY_ADDRESS
+
+HOLD_LOCKED_AT = "2026-09-10"
+TREASURY = TREASURY_ADDRESS
+
+# H1 — 100% of realized platform fees → treasury
+FEE_DESTINATION_PCT = 100
+PLATFORM_FEE_BPS = 500
+
+# H2 — on-chain USDC is cash runway
+USDC_HOLD_PCT = 100
+MORPHO_ALLOCATION_PCT = 0
+LP_ALLOCATION_PCT = 0
+
+# H3 — founder cash stays off-chain
+FOUNDER_CASH_HOLD_PCT = 100
+FOUNDER_LOAD_TO_CHAIN_PCT = 0
+
+# H4 — vault intake
+VAULT_INTAKE_PCT_BEFORE_CONVERSION = 0
+VAULT_INTAKE_PCT_AFTER_CONVERSION = 20
+CASH_RUNWAY_PCT_AFTER_CONVERSION = 80
+VAULT_CASH_FLOOR_USDC = 10_000
+
+# H5 — underwriting
+UNDERWRITING_BACKING_USDC = 10_000
+
+# H6 / H7 — movers
+EXECUTE_LIVE_DEFAULT = False
+HALT_FILE = "data/TREASURY_EXEC_HALT"
+MOVER = "founder_signer"
+
+
+def standing_order() -> dict:
+    return {
+        "locked_at": HOLD_LOCKED_AT,
+        "treasury": TREASURY,
+        "H1_fee_destination_pct": FEE_DESTINATION_PCT,
+        "H1_platform_fee_bps": PLATFORM_FEE_BPS,
+        "H2_usdc_hold_pct": USDC_HOLD_PCT,
+        "H2_morpho_pct": MORPHO_ALLOCATION_PCT,
+        "H3_founder_hold_pct": FOUNDER_CASH_HOLD_PCT,
+        "H4_vault_before_conversion_pct": VAULT_INTAKE_PCT_BEFORE_CONVERSION,
+        "H4_vault_after_conversion_pct": VAULT_INTAKE_PCT_AFTER_CONVERSION,
+        "H4_vault_floor_usdc": VAULT_CASH_FLOOR_USDC,
+        "H5_underwriting_backing_usdc": UNDERWRITING_BACKING_USDC,
+        "H6_mover": MOVER,
+        "H7_execute_live_default": EXECUTE_LIVE_DEFAULT,
+        "H7_halt_file": HALT_FILE,
+    }

--- a/tests/pytest/test_kya_airdrop_quest.py
+++ b/tests/pytest/test_kya_airdrop_quest.py
@@ -1,0 +1,71 @@
+"""Merkle airdrop quest — proof roundtrip, reject stubs, KYA gate."""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+os.environ["SINCOR_DATA_DIR"] = tempfile.mkdtemp(prefix="kya_quest_")
+
+from sincor2.kya.airdrop_quest import AirdropQuest
+from sincor2.kya.merkle import MerkleTree, verify_proof
+from sincor2.kya import registry as regmod
+from sincor2.treasury_hold import standing_order, VAULT_CASH_FLOOR_USDC
+
+
+class MerkleQuestTests(unittest.TestCase):
+    def test_proof_roundtrip(self):
+        wallets = [
+            "0x1111111111111111111111111111111111111111",
+            "0x2222222222222222222222222222222222222222",
+            "0x3333333333333333333333333333333333333333",
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ]
+        tree = MerkleTree(wallets)
+        for w in wallets:
+            proof = tree.proof(w)
+            self.assertIsNotNone(proof)
+            self.assertTrue(verify_proof(w, proof or [], tree.hex_root()))
+        self.assertFalse(
+            verify_proof("0x4444444444444444444444444444444444444444", [], tree.hex_root())
+        )
+
+    def test_root_is_order_insensitive(self):
+        a = ["0x1111111111111111111111111111111111111111", "0x2222222222222222222222222222222222222222"]
+        self.assertEqual(MerkleTree(a).hex_root(), MerkleTree(list(reversed(a))).hex_root())
+
+    def test_claim_requires_verify_and_proof(self):
+        q = AirdropQuest()
+        wallets = [
+            "0x1111111111111111111111111111111111111111",
+            "0x2222222222222222222222222222222222222222",
+        ]
+        q.seed(wallets, source="test")
+        reg = regmod.KYARegistry()
+        regmod._REG = reg
+        listed = reg.list_agent({"agent_id": "bot-1", "wallet": wallets[0]})
+        with self.assertRaises(PermissionError):
+            q.claim(wallets[0], "bot-1")
+        reg.bind("bot-1", wallets[0])
+        reg.apply_stake(listed["kya_id"], str(10 * 10**18), "0xstake")
+        verified = reg.verify(listed["kya_id"])
+        self.assertTrue(verified["verified"])
+        rec = q.claim(wallets[0], "bot-1")
+        self.assertEqual(rec["status"], "credited_ledger")
+        self.assertEqual(rec["reward_axm"], 15)
+        again = q.claim(wallets[0], "bot-1")
+        self.assertEqual(again["ts"], rec["ts"])
+        with self.assertRaises(PermissionError):
+            q.claim("0x3333333333333333333333333333333333333333", "bot-1")
+
+    def test_hold_numbers(self):
+        order = standing_order()
+        self.assertEqual(order["H2_morpho_pct"], 0)
+        self.assertEqual(order["H4_vault_before_conversion_pct"], 0)
+        self.assertEqual(VAULT_CASH_FLOOR_USDC, 10_000)
+        self.assertEqual(order["H1_platform_fee_bps"], 500)
+        self.assertFalse(order["H7_execute_live_default"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pytest/test_kya_airdrop_quest.py
+++ b/tests/pytest/test_kya_airdrop_quest.py
@@ -58,6 +58,45 @@ class MerkleQuestTests(unittest.TestCase):
         with self.assertRaises(PermissionError):
             q.claim("0x3333333333333333333333333333333333333333", "bot-1")
 
+    def test_replica_source_cannot_claim(self):
+        q = AirdropQuest()
+        wallets = [
+            "0x1111111111111111111111111111111111111111",
+            "0x2222222222222222222222222222222222222222",
+        ]
+        q.seed(wallets, source="desk-replica")
+        reg = regmod.KYARegistry()
+        regmod._REG = reg
+        listed = reg.list_agent({"agent_id": "bot-replica", "wallet": wallets[0]})
+        reg.bind("bot-replica", wallets[0])
+        reg.apply_stake(listed["kya_id"], str(10 * 10**18), "0xstake")
+        reg.verify(listed["kya_id"])
+        with self.assertRaises(PermissionError) as ctx:
+            q.claim(wallets[0], "bot-replica")
+        self.assertIn("REPLICA_ROOT_FORBIDDEN", str(ctx.exception))
+
+    def test_bound_production_root_rejects_foreign_tree(self):
+        production = MerkleTree(
+            [
+                "0x1111111111111111111111111111111111111111",
+                "0x2222222222222222222222222222222222222222",
+            ]
+        )
+        q = AirdropQuest()
+        os.environ["KYA_PRODUCTION_ROOT"] = production.hex_root()
+        try:
+            with self.assertRaises(PermissionError) as ctx:
+                q.seed(
+                    [
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    ],
+                    source="axm-disperse",
+                )
+            self.assertIn("ROOT_MISMATCH", str(ctx.exception))
+        finally:
+            os.environ.pop("KYA_PRODUCTION_ROOT", None)
+
     def test_hold_numbers(self):
         order = standing_order()
         self.assertEqual(order["H2_morpho_pct"], 0)


### PR DESCRIPTION
## Why

Kimi list items 2, 4–10. Item 3 (partner underwriting demo) is a booking, not a PR. Bonding curve is dead. Quest was a wallet set, not a merkle proof. `/v1/quest` is 404 on live because `kya_bootstrap` skipped whenever Blueprint `kya` already existed.

## What shipped

- OpenZeppelin-style `keccak256(address20)` sorted-pair merkle (`src/sincor2/kya/merkle.py`). Tests: proof roundtrip, order-insensitive root, claim requires KYA verify, HOLD numbers.
- Quest claims against **live** `kya_registry` (not a second identity store). Seed is admin-gated (`KYA_ADMIN_KEY` + `X-KYA-Admin`). Manifest lives under gitignored `/data/` — load with `python scripts/kya_build_merkle.py --from-file recipients.txt`.
- Additive Flask mount (`kya_stack`) for `/v1/quest`, `/v1/sla/receipts`, `/v1/sadas/*`. Does **not** replace `/v1/kya/list|bind|verify`.
- `/v1/kya/directory` registered **above** `/<kya_id>` so Flask stops 404ing the word `directory`.
- HOLD as numbers: `HOLD.md`, `docs/TREASURY_HOLD.md`, `src/sincor2/treasury_hold.py`.
- Axiom 2.0 launch path (mint → pool → liquidity → quest) with current addresses and landmines: `docs/AXIOM_2_LAUNCH_CHECKLIST.md`.
- Secrets sweep: `docs/SECRETS_HYGIENE.md`. No live keys in tree. Stripe/PayPal still `not_configured` on `/health`.
- Machine Bureaucracy form + X thread: `docs/MACHINE_BUREAUCRACY_2026-09-26.md`.
- Live wire friction log (hit getsincor.com): `docs/A2A_EXTERNAL_WIRE.md`.

## Live friction (this is the spec)

Register without `agent_card.skills[]` → 400. Agent Card JSON-RPC URL is under `supportedInterfaces[0]`, not top-level. Heartbeat TTL 60s. `message/send` currently accepts anonymous free calls. Quest 404 until this deploys. Probe agent `desk-probe-do-not-keep` is listed — **revoke it**.

## Operator next (not in this PR)

1. Drop the real ~3,500 disperse recipients into `kya_build_merkle.py` and set `KYA_AIRDROP_MANIFEST` on Railway.
2. Set `KYA_ADMIN_KEY` on Railway. Turn on GitHub secret scanning + push protection. Run `gitleaks detect --log-opts=--all` on a machine with full history.
3. Book one underwriting demo. Pay one $50 bot to repeat the wire log as a paid (not free-quota) task.
4. Merge candidate: PR #219 (fee leak). Rebase #116/#102/#81. Close #206/#210 as superseded by #220.

## Tests

`PYTHONPATH=src python3 -m unittest tests.pytest.test_kya_airdrop_quest -q` — 4 OK.
